### PR TITLE
fix: security patches and PageSession architecture refactor (review fixes)

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,6 +1,6 @@
 # browserctl — Vision & Roadmap
 
-> _Navigate the web. Stay in command._
+> _Navigate the web. Stay in session._
 
 ---
 
@@ -32,6 +32,7 @@ It is the difference between a browser **you restart** and a browser **you steer
 3. **Unix composability** — every command is one-line, pipeable, scriptable
 4. **Protocol over implementation** — the JSON-RPC wire format is stable and language-agnostic
 5. **Zero magic, full control** — no auto-waiting policies you can't see; every operation is explicit
+6. **Human presence is a resumable event** — when the human needs to act, the session pauses and waits; when they're done, automation resumes exactly where it stopped
 
 ---
 
@@ -65,6 +66,8 @@ It is the difference between a browser **you restart** and a browser **you steer
 ### v0.3 — Developer Experience
 **Goal:** The gem that developers actually recommend to each other.
 
+- [ ] `browserctl pause` / `browserctl resume` — human-in-the-loop pause/resume primitive
+- [ ] Cloudflare challenge detection in `snapshot` and `goto` responses (`challenge: true` field)
 - [ ] `browserctl init` — scaffold `.browserctl/` in a project
 - [ ] Workflow composition: `include`, `extend`, shared step libraries
 - [ ] Plugin system: `Browserctl.register_command(:my_cmd) { }` in workflow files
@@ -83,8 +86,9 @@ It is the difference between a browser **you restart** and a browser **you steer
 - [ ] Compatibility matrix: Ruby 3.2–3.x, Chrome 120+
 
 ### v1.x and Beyond — Platform
-**Goal:** browserctl becomes the standard browser interface for agents.
+**Goal:** browserctl becomes the runtime layer where human oversight produces better agents.
 
+- [ ] **Annotated session traces**: export pause/resume sessions as fine-tuning data for browser agents
 - [ ] **Cloud daemon**: remote `browserd` instances accessible over mTLS
 - [ ] **Session recording + replay**: deterministic browser regression testing
 - [ ] **Visual regression**: `shot --compare baseline.png` with pixel diff

--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -39,6 +39,8 @@ module Browserctl
       # ref-based interactions have no replayable selector — skip them
       return if %w[click fill].include?(cmd.to_s) && attrs[:selector].nil?
 
+      attrs = attrs.except(:value) if cmd.to_s == "fill"
+
       File.open(log_path(name), "a") do |f|
         f.puts JSON.generate({ cmd: cmd.to_s }.merge(attrs.transform_keys(&:to_s)))
       end
@@ -90,7 +92,7 @@ module Browserctl
           ["goto #{page}", "page(:#{page}).goto(#{cmd[:url].inspect})"]
         when "fill"
           ["fill #{cmd[:selector]} on #{page}",
-           "page(:#{page}).fill(#{cmd[:selector].inspect}, #{cmd[:value].inspect})"]
+           "page(:#{page}).fill(#{cmd[:selector].inspect}, params[:fill_value])"]
         when "click"
           ["click #{cmd[:selector]} on #{page}",
            "page(:#{page}).click(#{cmd[:selector].inspect})"]

--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -27,9 +27,9 @@ module Browserctl
       { name: defn.name, desc: defn.description, params: format_params(defn), steps: defn.steps.map(&:label) }
     end
 
-    private
+    SAFE_WORKFLOW_NAME = /\A[a-zA-Z0-9_-]+\z/
 
-    SAFE_WORKFLOW_NAME = /\A[a-zA-Z0-9_-]+\z/.freeze
+    private
 
     def validate_name!(name)
       return if SAFE_WORKFLOW_NAME.match?(name.to_s)

--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -29,7 +29,16 @@ module Browserctl
 
     private
 
+    SAFE_WORKFLOW_NAME = /\A[a-zA-Z0-9_-]+\z/.freeze
+
+    def validate_name!(name)
+      return if SAFE_WORKFLOW_NAME.match?(name.to_s)
+
+      raise Browserctl::WorkflowError, "invalid workflow name: #{name.inspect} — use letters, digits, _ and - only"
+    end
+
     def fetch_workflow(name)
+      validate_name!(name)
       load_workflow_file(name)
       REGISTRY[name.to_s] || raise("workflow '#{name}' not found")
     end

--- a/lib/browserctl/server.rb
+++ b/lib/browserctl/server.rb
@@ -85,7 +85,6 @@ module Browserctl
     def dispatch(socket, line)
       return unless line
 
-      @mutex.synchronize { @last_used = Time.now }
       socket.puts JSON.generate(process(line))
     end
 
@@ -109,7 +108,7 @@ module Browserctl
 
     def quietly
       yield
-    rescue StandardError
+    rescue Exception # rubocop:disable Lint/RescueException
       nil
     end
   end

--- a/lib/browserctl/server.rb
+++ b/lib/browserctl/server.rb
@@ -9,6 +9,7 @@ require_relative "constants"
 require_relative "logger"
 require_relative "server/command_dispatcher"
 require_relative "server/idle_watcher"
+require_relative "server/page_session"
 
 module Browserctl
   class Server
@@ -16,7 +17,7 @@ module Browserctl
       @socket_path = socket_path
       @pid_path    = pid_path
       prepare_runtime(headless)
-      @dispatcher = CommandDispatcher.new(@pages, @browser, mutex: @mutex)
+      @dispatcher = CommandDispatcher.new(@pages, @browser, global_mutex: @mutex)
     end
 
     def run

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -4,6 +4,9 @@ require_relative "snapshot_builder"
 
 module Browserctl
   class CommandDispatcher
+    SCREENSHOT_DIR  = File.expand_path("~/.browserctl/screenshots").freeze
+    SCREENSHOT_EXTS = %w[.png .jpg .jpeg].freeze
+
     COMMAND_MAP = {
       "open_page" => :cmd_open_page,
       "close_page" => :cmd_close_page,
@@ -127,9 +130,27 @@ module Browserctl
 
     def cmd_screenshot(req)
       with_page(req[:name]) do |p|
-        path = req[:path] || "/tmp/browserctl_shot_#{req[:name]}_#{Time.now.to_i}.png"
+        path = safe_screenshot_path(req[:path], req[:name])
+        return path if path.is_a?(Hash)
+
+        FileUtils.mkdir_p(File.dirname(path))
         p.screenshot(path: path, full: req.fetch(:full, false))
         { ok: true, path: path }
+      end
+    end
+
+    def safe_screenshot_path(requested, page_name)
+      if requested
+        expanded = File.expand_path(requested)
+        return { error: "path outside allowed directory (#{SCREENSHOT_DIR})" } \
+          unless expanded.start_with?(SCREENSHOT_DIR)
+        return { error: "invalid extension — use .png, .jpg, or .jpeg" } \
+          unless SCREENSHOT_EXTS.include?(File.extname(expanded).downcase)
+
+        expanded
+      else
+        name_safe = page_name.to_s.gsub(/[^a-zA-Z0-9_-]/, "_")
+        File.join(SCREENSHOT_DIR, "browserctl_shot_#{name_safe}_#{Time.now.to_i}.png")
       end
     end
 

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -1,36 +1,35 @@
 # frozen_string_literal: true
 
 require_relative "snapshot_builder"
+require_relative "page_session"
 
 module Browserctl
   class CommandDispatcher
+    COMMAND_MAP = {
+      "open_page"  => :cmd_open_page,
+      "close_page" => :cmd_close_page,
+      "list_pages" => :cmd_list_pages,
+      "goto"       => :cmd_goto,
+      "snapshot"   => :cmd_snapshot,
+      "evaluate"   => :cmd_evaluate,
+      "fill"       => :cmd_fill,
+      "click"      => :cmd_click,
+      "screenshot" => :cmd_screenshot,
+      "wait_for"   => :cmd_wait_for,
+      "watch"      => :cmd_watch,
+      "url"        => :cmd_url,
+      "ping"       => :cmd_ping,
+      "shutdown"   => :cmd_shutdown
+    }.freeze
+
     SCREENSHOT_DIR  = File.expand_path("~/.browserctl/screenshots").freeze
     SCREENSHOT_EXTS = %w[.png .jpg .jpeg].freeze
 
-    COMMAND_MAP = {
-      "open_page" => :cmd_open_page,
-      "close_page" => :cmd_close_page,
-      "list_pages" => :cmd_list_pages,
-      "goto" => :cmd_goto,
-      "snapshot" => :cmd_snapshot,
-      "evaluate" => :cmd_evaluate,
-      "fill" => :cmd_fill,
-      "click" => :cmd_click,
-      "screenshot" => :cmd_screenshot,
-      "wait_for" => :cmd_wait_for,
-      "watch" => :cmd_watch,
-      "url" => :cmd_url,
-      "ping" => :cmd_ping,
-      "shutdown" => :cmd_shutdown
-    }.freeze
-
-    def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, mutex: Mutex.new)
-      @pages          = pages
-      @browser        = browser
-      @snapshot       = snapshot_builder
-      @mutex          = mutex
-      @ref_registries = {}
-      @prev_snapshots = {}
+    def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
+      @pages            = pages
+      @browser          = browser
+      @snapshot_builder = snapshot_builder
+      @global_mutex     = global_mutex
     end
 
     def dispatch(req)
@@ -44,43 +43,44 @@ module Browserctl
     private
 
     def cmd_open_page(req)
-      page = @mutex.synchronize { @pages[req[:name]] ||= @browser.create_page }
-      page.go_to(req[:url]) if req[:url]
+      session = @global_mutex.synchronize do
+        @pages[req[:name]] ||= PageSession.new(@browser.create_page)
+      end
+      session.page.go_to(req[:url]) if req[:url]
       { ok: true, name: req[:name] }
     end
 
     def cmd_close_page(req)
-      @mutex.synchronize { @pages.delete(req[:name]) }&.close
+      session = @global_mutex.synchronize { @pages.delete(req[:name]) }
+      session&.page&.close
       { ok: true }
     end
 
     def cmd_list_pages(_req)
-      { pages: @mutex.synchronize { @pages.keys } }
+      { pages: @global_mutex.synchronize { @pages.keys } }
     end
 
     def cmd_goto(req)
-      with_page(req[:name]) do |p|
-        p.go_to(req[:url])
-        { ok: true, url: p.current_url }
+      with_page(req[:name]) do |session|
+        session.page.go_to(req[:url])
+        { ok: true, url: session.page.current_url }
       end
     end
 
     def cmd_snapshot(req)
-      with_page(req[:name]) { |p| take_snapshot(req[:name], p, req[:format], req[:diff]) }
+      with_page(req[:name]) { |session| take_snapshot(session, req[:format], req[:diff]) }
     end
 
-    def take_snapshot(name, page, format, diff)
-      return { ok: true, html: page.body } unless format == "ai"
+    def take_snapshot(session, format, diff)
+      return { ok: true, html: session.page.body } unless format == "ai"
 
-      snapshot = @snapshot.call(page)
+      snapshot = @snapshot_builder.call(session.page)
       registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }
 
-      result = @mutex.synchronize do
-        prev = @prev_snapshots[name]
-        @ref_registries[name] = registry
-        @prev_snapshots[name] = snapshot
-        diff && prev ? compute_diff(prev, snapshot) : snapshot
-      end
+      prev = session.prev_snapshot
+      session.ref_registry  = registry
+      session.prev_snapshot = snapshot
+      result = diff && prev ? compute_diff(prev, snapshot) : snapshot
 
       { ok: true, snapshot: result }
     end
@@ -94,14 +94,16 @@ module Browserctl
     end
 
     def cmd_evaluate(req)
-      with_page(req[:name]) { |p| { ok: true, result: p.evaluate(req[:expression]) } }
+      with_page(req[:name]) { |session| { ok: true, result: session.page.evaluate(req[:expression]) } }
     end
 
     def cmd_fill(req)
-      sel = resolve_selector(req[:name], req)
-      return sel if sel.is_a?(Hash)
+      with_page(req[:name]) do |session|
+        sel = resolve_selector_from(session, req)
+        return sel if sel.is_a?(Hash)
 
-      with_page(req[:name]) { |p| type_into(p, sel, req[:value]) }
+        type_into(session.page, sel, req[:value])
+      end
     end
 
     def type_into(page, selector, value)
@@ -114,10 +116,12 @@ module Browserctl
     end
 
     def cmd_click(req)
-      sel = resolve_selector(req[:name], req)
-      return sel if sel.is_a?(Hash)
+      with_page(req[:name]) do |session|
+        sel = resolve_selector_from(session, req)
+        return sel if sel.is_a?(Hash)
 
-      with_page(req[:name]) { |p| click_element(p, sel) }
+        click_element(session.page, sel)
+      end
     end
 
     def click_element(page, selector)
@@ -129,12 +133,12 @@ module Browserctl
     end
 
     def cmd_screenshot(req)
-      with_page(req[:name]) do |p|
+      with_page(req[:name]) do |session|
         path = safe_screenshot_path(req[:path], req[:name])
         return path if path.is_a?(Hash)
 
         FileUtils.mkdir_p(File.dirname(path))
-        p.screenshot(path: path, full: req.fetch(:full, false))
+        session.page.screenshot(path: path, full: req.fetch(:full, false))
         { ok: true, path: path }
       end
     end
@@ -155,29 +159,32 @@ module Browserctl
     end
 
     def cmd_wait_for(req)
-      with_page(req[:name]) { |p| wait_for_selector(p, req[:selector], req.fetch(:timeout, 10).to_f) }
+      with_page(req[:name]) { |session| wait_for_selector(session.page, req[:selector], req.fetch(:timeout, 10).to_f) }
     end
 
     def cmd_watch(req)
-      with_page(req[:name]) do |p|
-        result = wait_for_selector(p, req[:selector], req.fetch(:timeout, 30).to_f)
+      with_page(req[:name]) do |session|
+        result = wait_for_selector(session.page, req[:selector], req.fetch(:timeout, 30).to_f)
         result[:error] ? result : { ok: true, selector: req[:selector] }
       end
     end
 
     def wait_for_selector(page, selector, timeout)
       deadline = Time.now + timeout
-      sleep 0.2 until (found = page.at_css(selector)) || Time.now > deadline
-      found ? { ok: true } : { error: "wait_for timeout: selector '#{selector}' not found after #{timeout}s" }
+      loop do
+        found = page.at_css(selector)
+        break { ok: true } if found
+        break { error: "wait_for timeout: selector '#{selector}' not found after #{timeout}s" } if Time.now >= deadline
+
+        sleep 0.2
+      end
     end
 
     def cmd_url(req)
-      with_page(req[:name]) { |p| { ok: true, url: p.current_url } }
+      with_page(req[:name]) { |session| { ok: true, url: session.page.current_url } }
     end
 
-    def cmd_ping(_req)
-      { ok: true, pid: Process.pid }
-    end
+    def cmd_ping(_req) = { ok: true, pid: Process.pid }
 
     def cmd_shutdown(_req)
       Process.kill("INT", Process.pid)
@@ -185,18 +192,17 @@ module Browserctl
     end
 
     def with_page(name)
-      page = @mutex.synchronize { @pages[name] }
-      return { error: "no page named '#{name}'" } unless page
+      session = @global_mutex.synchronize { @pages[name] }
+      return { error: "no page named '#{name}'" } unless session
 
-      yield page
+      session.mutex.synchronize { yield session }
     end
 
-    def resolve_selector(name, req)
+    def resolve_selector_from(session, req)
       return req[:selector] if req[:selector]
       return { error: "selector or ref required" } unless req[:ref]
 
-      sel = @mutex.synchronize { @ref_registries.dig(name, req[:ref]) }
-      sel || { error: "ref '#{req[:ref]}' not found — run snap first" }
+      session.ref_registry[req[:ref]] || { error: "ref '#{req[:ref]}' not found — run snap first" }
     end
   end
 end

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -6,20 +6,20 @@ require_relative "page_session"
 module Browserctl
   class CommandDispatcher
     COMMAND_MAP = {
-      "open_page"  => :cmd_open_page,
+      "open_page" => :cmd_open_page,
       "close_page" => :cmd_close_page,
       "list_pages" => :cmd_list_pages,
-      "goto"       => :cmd_goto,
-      "snapshot"   => :cmd_snapshot,
-      "evaluate"   => :cmd_evaluate,
-      "fill"       => :cmd_fill,
-      "click"      => :cmd_click,
+      "goto" => :cmd_goto,
+      "snapshot" => :cmd_snapshot,
+      "evaluate" => :cmd_evaluate,
+      "fill" => :cmd_fill,
+      "click" => :cmd_click,
       "screenshot" => :cmd_screenshot,
-      "wait_for"   => :cmd_wait_for,
-      "watch"      => :cmd_watch,
-      "url"        => :cmd_url,
-      "ping"       => :cmd_ping,
-      "shutdown"   => :cmd_shutdown
+      "wait_for" => :cmd_wait_for,
+      "watch" => :cmd_watch,
+      "url" => :cmd_url,
+      "ping" => :cmd_ping,
+      "shutdown" => :cmd_shutdown
     }.freeze
 
     SCREENSHOT_DIR  = File.expand_path("~/.browserctl/screenshots").freeze

--- a/lib/browserctl/server/page_session.rb
+++ b/lib/browserctl/server/page_session.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class PageSession
+    attr_reader :page, :mutex
+    attr_accessor :ref_registry, :prev_snapshot
+
+    def initialize(page)
+      @page          = page
+      @mutex         = Mutex.new
+      @ref_registry  = {}
+      @prev_snapshot = nil
+    end
+  end
+end

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "browserctl/server/command_dispatcher"
 require "browserctl/server/snapshot_builder"
+require "browserctl/server/page_session"
 
 RSpec.describe Browserctl::CommandDispatcher do
   let(:browser)    { double("browser") }
@@ -22,7 +23,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
 
     it "responds to list_pages" do
-      pages["main"] = double("page")
+      pages["main"] = Browserctl::PageSession.new(double("page"))
       expect(dispatcher.dispatch({ cmd: "list_pages" })).to eq({ pages: ["main"] })
     end
 
@@ -36,7 +37,8 @@ RSpec.describe Browserctl::CommandDispatcher do
       allow(browser).to receive(:create_page).and_return(page)
       result = dispatcher.dispatch({ cmd: "open_page", name: "home" })
       expect(result).to eq({ ok: true, name: "home" })
-      expect(pages["home"]).to eq(page)
+      expect(pages["home"]).to be_a(Browserctl::PageSession)
+      expect(pages["home"].page).to eq(page)
     end
 
     it "open_page navigates to url when given" do
@@ -48,7 +50,7 @@ RSpec.describe Browserctl::CommandDispatcher do
 
     it "open_page re-navigates an existing page when url is given" do
       page = double("page")
-      pages["home"] = page
+      pages["home"] = Browserctl::PageSession.new(page)
       expect(page).to receive(:go_to).with("http://example.com/new")
       result = dispatcher.dispatch({ cmd: "open_page", name: "home", url: "http://example.com/new" })
       expect(result).to eq({ ok: true, name: "home" })
@@ -57,7 +59,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     it "close_page removes page and closes it" do
       page = double("page")
       allow(page).to receive(:close)
-      pages["home"] = page
+      pages["home"] = Browserctl::PageSession.new(page)
       result = dispatcher.dispatch({ cmd: "close_page", name: "home" })
       expect(result).to eq({ ok: true })
       expect(pages.key?("home")).to be false
@@ -73,7 +75,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   describe "ref-based interaction" do
     let(:html) { '<html><body><input name="email"><button>Go</button></body></html>' }
     let(:page) { instance_double("Ferrum::Page", body: html) }
-    let(:pages) { { "main" => page } }
+    let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("browser")) }
 
     before do
@@ -108,7 +110,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     let(:html_v1) { '<html><body><button id="a">A</button></body></html>' }
     let(:html_v2) { '<html><body><button id="a">A</button><button id="b">B</button></body></html>' }
     let(:page)    { instance_double("Ferrum::Page") }
-    let(:pages)   { { "main" => page } }
+    let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("browser")) }
 
     it "returns full snapshot on first call with diff: true (no previous)" do
@@ -137,7 +139,7 @@ RSpec.describe Browserctl::CommandDispatcher do
 
   describe "#cmd_screenshot" do
     let(:page)  { instance_double("Ferrum::Page") }
-    let(:pages) { { "main" => page } }
+    let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("browser")) }
 
     it "rejects paths outside the allowed screenshot directory" do
@@ -164,7 +166,7 @@ RSpec.describe Browserctl::CommandDispatcher do
 
   describe "#cmd_watch" do
     let(:page)  { instance_double("Ferrum::Page") }
-    let(:pages) { { "main" => page } }
+    let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("browser")) }
 
     it "returns ok with selector when element appears" do
@@ -187,27 +189,36 @@ RSpec.describe Browserctl::CommandDispatcher do
 
   describe "#cmd_snapshot (state storage)" do
     let(:page)    { instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>") }
-    let(:pages)   { { "main" => page } }
+    let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
     let(:builder) { Browserctl::SnapshotBuilder.new }
     subject(:dispatcher) { described_class.new(pages, double("browser"), builder) }
 
     it "stores ref registry after ai snapshot" do
       dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
-      reg = dispatcher.instance_variable_get(:@ref_registries)
-      expect(reg["main"]).to be_a(Hash)
-      expect(reg["main"]).not_to be_empty
+      expect(pages["main"].ref_registry).to be_a(Hash)
+      expect(pages["main"].ref_registry).not_to be_empty
     end
 
     it "stores previous snapshot after ai snapshot" do
       dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
-      prev = dispatcher.instance_variable_get(:@prev_snapshots)
-      expect(prev["main"]).to be_an(Array)
+      expect(pages["main"].prev_snapshot).to be_an(Array)
     end
 
     it "does not store state for html format" do
       allow(page).to receive(:body).and_return("<html></html>")
       dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
-      expect(dispatcher.instance_variable_get(:@ref_registries)["main"]).to be_nil
+      expect(pages["main"].ref_registry).to be_empty
+    end
+
+    it "evicts ref_registry and prev_snapshot when page is closed" do
+      page2 = instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>")
+      allow(page2).to receive(:close)
+      pages["temp"] = Browserctl::PageSession.new(page2)
+      dispatcher.dispatch({ cmd: "snapshot", name: "temp", format: "ai" })
+      expect(pages["temp"].ref_registry).not_to be_empty
+
+      dispatcher.dispatch({ cmd: "close_page", name: "temp" })
+      expect(pages.key?("temp")).to be false
     end
   end
 end

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -135,6 +135,33 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
   end
 
+  describe "#cmd_screenshot" do
+    let(:page)  { instance_double("Ferrum::Page") }
+    let(:pages) { { "main" => page } }
+    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+
+    it "rejects paths outside the allowed screenshot directory" do
+      res = dispatcher.dispatch({ cmd: "screenshot", name: "main",
+                                  path: "/tmp/../Users/nqhuy25/.ssh/authorized_keys" })
+      expect(res[:error]).to match(/outside allowed directory/)
+    end
+
+    it "rejects paths without .png or .jpg extension" do
+      res = dispatcher.dispatch({ cmd: "screenshot", name: "main",
+                                  path: File.expand_path("~/.browserctl/screenshots/evil.rb") })
+      expect(res[:error]).to match(/invalid extension/)
+    end
+
+    it "accepts a valid path inside the allowed directory" do
+      allowed = File.expand_path("~/.browserctl/screenshots/test.png")
+      FileUtils.mkdir_p(File.dirname(allowed))
+      allow(page).to receive(:screenshot)
+      res = dispatcher.dispatch({ cmd: "screenshot", name: "main", path: allowed })
+      expect(res[:ok]).to be true
+      expect(res[:path]).to eq(allowed)
+    end
+  end
+
   describe "#cmd_watch" do
     let(:page)  { instance_double("Ferrum::Page") }
     let(:pages) { { "main" => page } }

--- a/spec/unit/page_session_spec.rb
+++ b/spec/unit/page_session_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/server/page_session"
+
+RSpec.describe Browserctl::PageSession do
+  let(:page) { double("Ferrum::Page") }
+  subject(:session) { described_class.new(page) }
+
+  it "holds the page" do
+    expect(session.page).to eq(page)
+  end
+
+  it "starts with an empty ref_registry" do
+    expect(session.ref_registry).to eq({})
+  end
+
+  it "starts with nil prev_snapshot" do
+    expect(session.prev_snapshot).to be_nil
+  end
+
+  it "has its own Mutex" do
+    expect(session.mutex).to be_a(Mutex)
+  end
+
+  it "allows ref_registry to be updated" do
+    session.ref_registry = { "e1" => "input#email" }
+    expect(session.ref_registry["e1"]).to eq("input#email")
+  end
+
+  it "allows prev_snapshot to be updated" do
+    snapshot = [{ ref: "e1", tag: "input" }]
+    session.prev_snapshot = snapshot
+    expect(session.prev_snapshot).to eq(snapshot)
+  end
+
+  it "has a separate mutex per instance" do
+    other = described_class.new(double("page2"))
+    expect(session.mutex).not_to equal(other.mutex)
+  end
+end

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Browserctl::Recording do
       described_class.start("test")
       described_class.append("fill", name: "login", selector: "input", value: "hi")
       ruby = described_class.generate_workflow("test")
-      expect(ruby).to include('page(:login).fill("input", "hi")')
+      expect(ruby).to include('page(:login).fill("input", params[:fill_value])')
     end
 
     it "ignores non-recordable commands" do
@@ -54,6 +54,25 @@ RSpec.describe Browserctl::Recording do
     it "does nothing when no active recording" do
       described_class.append("click", name: "p", selector: "a")
       # no error, no file created
+    end
+  end
+
+  describe ".append for fill commands" do
+    before do
+      File.write(Browserctl::Recording::STATE_FILE, "test")
+    end
+
+    it "does not record the value field for fill commands" do
+      Browserctl::Recording.append(:fill, name: "main", selector: "input[name=email]", value: "secret@example.com")
+      log = File.read(File.join(Browserctl::Recording::RECORDINGS_DIR, "test.jsonl"))
+      expect(log).not_to include("secret@example.com")
+    end
+
+    it "still records the selector for fill commands" do
+      Browserctl::Recording.append(:fill, name: "main", selector: "input[name=email]", value: "secret@example.com")
+      log = File.read(File.join(Browserctl::Recording::RECORDINGS_DIR, "test.jsonl"))
+      parsed = JSON.parse(log.strip)
+      expect(parsed["selector"]).to eq("input[name=email]")
     end
   end
 

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/runner"
+
+RSpec.describe Browserctl::Runner do
+  subject(:runner) { described_class.new }
+
+  describe "#run_workflow with unsafe name" do
+    it "raises for path-traversal names" do
+      expect { runner.run_workflow("../../etc/passwd") }
+        .to raise_error(Browserctl::WorkflowError, /invalid workflow name/)
+    end
+
+    it "raises for names with slashes" do
+      expect { runner.run_workflow("foo/bar") }
+        .to raise_error(Browserctl::WorkflowError, /invalid workflow name/)
+    end
+
+    it "raises for names with null bytes" do
+      expect { runner.run_workflow("foo\x00bar") }
+        .to raise_error(Browserctl::WorkflowError, /invalid workflow name/)
+    end
+
+    it "accepts safe names" do
+      # workflow does not exist — error should be "not found" not "invalid name"
+      expect { runner.run_workflow("my-workflow_01") }
+        .to raise_error(RuntimeError, /not found/)
+    end
+  end
+end

--- a/spec/unit/server_spec.rb
+++ b/spec/unit/server_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "timeout"
+require "browserctl/server"
+
+RSpec.describe Browserctl::Server do
+  describe "#quietly (private)" do
+    subject(:server) { described_class.allocate }
+
+    it "swallows StandardError" do
+      expect { server.send(:quietly) { raise "boom" } }.not_to raise_error
+    end
+
+    it "swallows Timeout::Error" do
+      expect { server.send(:quietly) { raise Timeout::Error } }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?

Addresses all Blocker and critical Suggestion findings from the 2026-04-20 deep review. Six self-contained commits, each independently testable.

## Type of change

- [x] Bug fix
- [x] Refactor / internal improvement
- [x] Documentation

## Changes

| Commit | Fix |
|--------|-----|
| `a0ea9a1` | Strip plaintext `fill` values from JSONL recordings — passwords no longer baked into generated workflows |
| `0a1303f` | Guard `screenshot` path against directory traversal — writes restricted to `~/.browserctl/screenshots/` |
| `1d0f221` | Validate workflow names before path construction — blocks `../../etc/passwd`-style inputs |
| `d0b1430` | Rescue `Timeout::Error` in `quietly`; remove duplicate `@last_used` update in `dispatch` |
| `f75e982` | Introduce `PageSession` — per-page state + mutex, fixing CDP race conditions and memory leak on page close |
| `58b156b` | Update VISION.md — HITL as first-class principle, revised tagline, v0.3 + v1.x roadmap items |

## How to test

```bash
bundle exec rspec --format documentation
```

All 84 examples pass.

## Checklist

- [x] Tests added or updated
- [x] `bundle exec rspec` passes
- [ ] `bundle exec rubocop` reports no offenses
- [ ] CHANGELOG.md updated (for user-visible changes)