### PR TITLE
feat: browserctl v0.3 — HITL, Cloudflare detection, init, compose, plugins, inspect, RBS, YARD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp/
 .claude/settings.local.json
 .worktrees/
 doc/
+.yardoc/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp/
 .envrc
 .DS_Store
 .claude/settings.local.json
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp/
 .DS_Store
 .claude/settings.local.json
 .worktrees/
+doc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/MethodLength:
   Max: 30
 
 Metrics/ClassLength:
-  Max: 200
+  Max: 220
 
 Metrics/AbcSize:
   Max: 30

--- a/bin/browserctl
+++ b/bin/browserctl
@@ -23,6 +23,7 @@ require "browserctl/commands/watch"
 require "browserctl/commands/record"
 require "browserctl/commands/pause_resume"
 require "browserctl/commands/init"
+require "browserctl/commands/inspect"
 
 def print_result(res)
   if res.is_a?(Hash) && res[:error]
@@ -54,8 +55,9 @@ def usage
       url    <page>                                Print current URL
       eval   <page> <expression>                   Evaluate JS expression
       watch  <page> <selector> [--timeout N]       Wait for a selector to appear
-      pause  <page>                                Pause automation — browser stays live
-      resume <page>                                Resume automation after manual action
+      pause   <page>                               Pause automation — browser stays live
+      resume  <page>                               Resume automation after manual action
+      inspect <page>                               Open Chrome DevTools for a named page
 
     Recording commands:
       record start <name>            Start recording browser commands
@@ -136,6 +138,7 @@ else
   when "watch"    then Browserctl::Commands::Watch.run(client, args)
   when "pause"    then Browserctl::Commands::PauseResume.pause(client, args)
   when "resume"   then Browserctl::Commands::PauseResume.resume(client, args)
+  when "inspect"  then Browserctl::Commands::Inspect.run(client, args)
   when "ping"     then print_result(client.ping)
   when "shutdown" then print_result(client.shutdown)
   else

--- a/bin/browserctl
+++ b/bin/browserctl
@@ -21,6 +21,7 @@ require "browserctl/commands/snapshot"
 require "browserctl/commands/screenshot"
 require "browserctl/commands/watch"
 require "browserctl/commands/record"
+require "browserctl/commands/pause_resume"
 
 def print_result(res)
   if res.is_a?(Hash) && res[:error]
@@ -49,6 +50,8 @@ def usage
       url    <page>                                Print current URL
       eval   <page> <expression>                   Evaluate JS expression
       watch  <page> <selector> [--timeout N]       Wait for a selector to appear
+      pause  <page>                                Pause automation — browser stays live
+      resume <page>                                Resume automation after manual action
 
     Recording commands:
       record start <name>            Start recording browser commands
@@ -126,6 +129,8 @@ else
   when "url"      then print_result(client.url(args[0]))
   when "eval"     then print_result(client.evaluate(args[0], args[1]))
   when "watch"    then Browserctl::Commands::Watch.run(client, args)
+  when "pause"    then Browserctl::Commands::PauseResume.pause(client, args)
+  when "resume"   then Browserctl::Commands::PauseResume.resume(client, args)
   when "ping"     then print_result(client.ping)
   when "shutdown" then print_result(client.shutdown)
   else

--- a/bin/browserctl
+++ b/bin/browserctl
@@ -22,6 +22,7 @@ require "browserctl/commands/screenshot"
 require "browserctl/commands/watch"
 require "browserctl/commands/record"
 require "browserctl/commands/pause_resume"
+require "browserctl/commands/init"
 
 def print_result(res)
   if res.is_a?(Hash) && res[:error]
@@ -35,6 +36,9 @@ end
 def usage
   puts <<~USAGE
     Usage: browserctl <command> [args]
+
+    Setup:
+      init                                         Scaffold .browserctl/ in this project
 
     Browser commands (require browserd running):
       open   <page> [--url URL]                   Open or focus a named page
@@ -113,6 +117,7 @@ when "describe"
   puts JSON.pretty_generate(runner.describe_workflow(name))
 
 when "record" then Browserctl::Commands::Record.run(args)
+when "init"   then Browserctl::Commands::Init.run(args)
 
 else
   client = Browserctl::Client.new(Browserctl.socket_path(daemon_name))

--- a/browserctl.gemspec
+++ b/browserctl.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 
   s.add_development_dependency "rspec",   "~> 3.13"
   s.add_development_dependency "rubocop", "~> 1.65"
+  s.add_development_dependency "yard",    "~> 0.9"
 end

--- a/examples/cloudflare_hitl.rb
+++ b/examples/cloudflare_hitl.rb
@@ -9,6 +9,9 @@
 # Run:
 #   browserctl run examples/cloudflare_hitl.rb --url https://example.com
 #
+# Note: modern Cloudflare often passes a real headed Chrome without challenge.
+# The pause/resume branch fires only when the challenge page is actually served
+# (typically against headless or CDP-fingerprinted browsers, or stricter zones).
 # When paused, the terminal prints instructions. Solve the challenge in the open
 # browser window, then run: browserctl resume main
 

--- a/examples/cloudflare_hitl.rb
+++ b/examples/cloudflare_hitl.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Demonstrates the Cloudflare HITL (Human-in-the-Loop) pattern.
+#
+# When an agent navigates to a Cloudflare-protected page and hits a bot challenge,
+# it cannot interact with the real page content. This workflow detects the challenge,
+# pauses automation so a human can solve it in the live browser, then resumes.
+#
+# Run:
+#   browserctl run examples/cloudflare_hitl.rb --url https://example.com
+#
+# When paused, the terminal prints instructions. Solve the challenge in the open
+# browser window, then run: browserctl resume main
+
+Browserctl.workflow "cloudflare_hitl" do
+  desc "Navigate a Cloudflare-protected URL with human-assisted challenge bypass"
+
+  param :url,      required: true
+  param :selector, default: "body"
+
+  step "open page" do
+    client.open_page("main")
+  end
+
+  step "navigate to target URL" do
+    res = client.goto("main", url)
+
+    if res[:challenge]
+      $stdout.puts ""
+      $stdout.puts "  ⚠  Cloudflare challenge detected on #{url}"
+      $stdout.puts "  → Pausing automation. Solve the challenge in the browser, then run:"
+      $stdout.puts "       browserctl resume main"
+      $stdout.puts ""
+
+      client.pause("main")
+
+      # Block here until the human calls `browserctl resume main`.
+      # The pause command marks the page; resume unblocks and signals the CV.
+      # In a workflow context, we poll the server until the page is unpaused
+      # by attempting a lightweight snapshot — once it succeeds, we're through.
+      loop do
+        snap = client.snapshot("main", format: "html")
+        break unless snap[:challenge]
+
+        $stdout.puts "  … still on challenge page, waiting 3s"
+        sleep 3
+      end
+
+      $stdout.puts "  ✓ Challenge cleared — resuming automation"
+    end
+  end
+
+  step "wait for content and snapshot" do
+    page(:main).wait_for(selector, timeout: 15)
+    result = page(:main).snapshot(format: "ai")
+    $stdout.puts "  Snapshot: #{result[:snapshot]&.length || 0} elements captured"
+  end
+
+  step "close page" do
+    client.close_page("main")
+  end
+end

--- a/lib/browserctl.rb
+++ b/lib/browserctl.rb
@@ -5,3 +5,11 @@ require_relative "browserctl/constants"
 require_relative "browserctl/workflow"
 require_relative "browserctl/runner"
 require_relative "browserctl/client"
+
+module Browserctl
+  PLUGIN_COMMANDS = {} # rubocop:disable Style/MutableConstant
+
+  def self.register_command(name, &block)
+    PLUGIN_COMMANDS[name.to_s] = block
+  end
+end

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -54,8 +54,9 @@ module Browserctl
     def evaluate(name, expression) = call("evaluate",    name: name, expression: expression)
     def ping                       = call("ping")
     def shutdown                   = call("shutdown")
-    def pause(name)                = call("pause",  name: name)
-    def resume(name)               = call("resume", name: name)
+    def pause(name)                = call("pause",   name: name)
+    def resume(name)               = call("resume",  name: name)
+    def inspect_page(name)         = call("inspect", name: name)
 
     private
 

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -54,6 +54,8 @@ module Browserctl
     def evaluate(name, expression) = call("evaluate",    name: name, expression: expression)
     def ping                       = call("ping")
     def shutdown                   = call("shutdown")
+    def pause(name)                = call("pause",  name: name)
+    def resume(name)               = call("resume", name: name)
 
     private
 

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -6,6 +6,7 @@ require_relative "constants"
 require_relative "recording"
 
 module Browserctl
+  # Thin IPC client that wraps each browserd command as a Ruby method call.
   class Client
     def initialize(socket_path = Browserctl.socket_path)
       @socket_path = socket_path
@@ -19,43 +20,114 @@ module Browserctl
       raise "browserd is not running — start it with: browserd"
     end
 
-    # Convenience wrappers matching CLI command vocabulary
-
+    # Opens or focuses a named browser page.
+    # @param name [String] logical page name
+    # @param url [String, nil] optional URL to navigate to after opening
+    # @return [Hash] `{ ok: true, name: }` or `{ error: }`
     def open_page(name, url: nil)  = call("open_page",  name: name, url: url)
+
+    # Closes a named page and removes it from the session.
+    # @param name [String] logical page name
+    # @return [Hash] `{ ok: true }` or `{ error: }`
     def close_page(name)           = call("close_page", name: name)
+
+    # Lists all open page names.
+    # @return [Hash] `{ pages: [String] }`
     def list_pages                 = call("list_pages")
+
+    # Navigates a page to a URL. Returns `challenge: true` when Cloudflare is detected.
+    # @param name [String] logical page name
+    # @param url [String] destination URL
+    # @return [Hash] `{ ok: true, url:, challenge: }` or `{ error: }`
     def goto(name, url)            = call("goto", name: name, url: url)
 
+    # Clicks an element identified by CSS selector or snapshot ref.
+    # @param name [String] logical page name
+    # @param selector [String, nil] CSS selector
+    # @param ref [String, nil] snapshot ref (e.g. "e3")
+    # @return [Hash] `{ ok: true }` or `{ error: }`
     def click(name, selector = nil, ref: nil)
       raise ArgumentError, "click: provide selector or ref:" unless selector || ref
 
       call("click", name: name, selector: selector, ref: ref)
     end
 
+    # Fills an input element with a value.
+    # @param name [String] logical page name
+    # @param selector [String, nil] CSS selector
+    # @param value [String, nil] text to type
+    # @param ref [String, nil] snapshot ref
+    # @return [Hash] `{ ok: true }` or `{ error: }`
     def fill(name, selector = nil, value = nil, ref: nil)
       raise ArgumentError, "fill: provide selector or ref:" unless selector || ref
 
       call("fill", name: name, selector: selector, ref: ref, value: value)
     end
 
+    # Takes a screenshot of a named page.
+    # @param name [String] logical page name
+    # @param path [String, nil] output path (default: ~/.browserctl/screenshots/)
+    # @param full [Boolean] capture full page (default: false)
+    # @return [Hash] `{ ok: true, path: }` or `{ error: }`
     def screenshot(name, path: nil, full: false) = call("screenshot", name: name, path: path, full: full)
 
+    # Takes a DOM snapshot. Returns `challenge: true` when Cloudflare is detected.
+    # @param name [String] logical page name
+    # @param format [String] "ai" (token-efficient JSON) or "html" (raw HTML)
+    # @param diff [Boolean] return only elements changed since last snapshot
+    # @return [Hash] `{ ok: true, snapshot:, challenge: }` or `{ ok: true, html:, challenge: }` or `{ error: }`
     def snapshot(name, format: "ai", diff: false)
       call("snapshot", name: name, format: format, diff: diff)
     end
 
+    # Waits for a CSS selector to appear (short timeout).
+    # @param name [String] logical page name
+    # @param selector [String] CSS selector to wait for
+    # @param timeout [Numeric] seconds before giving up (default: 10)
+    # @return [Hash] `{ ok: true }` or `{ error: }`
     def wait_for(name, selector, timeout: 10) = call("wait_for", name: name, selector: selector, timeout: timeout)
 
+    # Polls for a CSS selector with a longer timeout (suitable for async operations).
+    # @param name [String] logical page name
+    # @param selector [String] CSS selector to poll for
+    # @param timeout [Numeric] seconds before giving up (default: 30)
+    # @return [Hash] `{ ok: true, selector: }` or `{ error: }`
     def watch(name, selector, timeout: 30)
       call("watch", name: name, selector: selector, timeout: timeout)
     end
 
+    # Returns the current URL of a named page.
+    # @param name [String] logical page name
+    # @return [Hash] `{ ok: true, url: }` or `{ error: }`
     def url(name)                  = call("url",         name: name)
+
+    # Evaluates a JavaScript expression and returns the result.
+    # @param name [String] logical page name
+    # @param expression [String] JavaScript expression
+    # @return [Hash] `{ ok: true, result: }` or `{ error: }`
     def evaluate(name, expression) = call("evaluate",    name: name, expression: expression)
+
+    # Checks if browserd is alive.
+    # @return [Hash] `{ ok: true, pid: }` or raises if daemon is not running
     def ping                       = call("ping")
+
+    # Shuts down browserd gracefully.
+    # @return [Hash] `{ ok: true }`
     def shutdown                   = call("shutdown")
+
+    # Pauses automation on a page so a human can interact directly.
+    # @param name [String] logical page name
+    # @return [Hash] `{ ok: true, paused: true }` or `{ error: }`
     def pause(name)                = call("pause",   name: name)
+
+    # Resumes automation on a paused page.
+    # @param name [String] logical page name
+    # @return [Hash] `{ ok: true, paused: false }` or `{ error: }`
     def resume(name)               = call("resume",  name: name)
+
+    # Returns the Chrome DevTools URL for a named page.
+    # @param name [String] logical page name
+    # @return [Hash] `{ ok: true, devtools_url: }` or `{ error: }`
     def inspect_page(name)         = call("inspect", name: name)
 
     private

--- a/lib/browserctl/commands/init.rb
+++ b/lib/browserctl/commands/init.rb
@@ -18,9 +18,7 @@ module Browserctl
         FileUtils.touch(".browserctl/workflows/.keep")
 
         config_path = ".browserctl/config.yml"
-        unless File.exist?(config_path)
-          File.write(config_path, CONFIG_TEMPLATE)
-        end
+        File.write(config_path, CONFIG_TEMPLATE) unless File.exist?(config_path)
 
         puts "Initialised browserctl project:"
         puts "  .browserctl/workflows/   (place workflow .rb files here)"

--- a/lib/browserctl/commands/init.rb
+++ b/lib/browserctl/commands/init.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module Browserctl
+  module Commands
+    class Init
+      CONFIG_TEMPLATE = <<~YAML
+        # browserctl project configuration
+        # Uncomment and edit to customise.
+
+        # daemon: default          # named daemon instance (see browserd --name)
+        # workflows_dir: .browserctl/workflows
+      YAML
+
+      def self.run(_args)
+        FileUtils.mkdir_p(".browserctl/workflows")
+        FileUtils.touch(".browserctl/workflows/.keep")
+
+        config_path = ".browserctl/config.yml"
+        unless File.exist?(config_path)
+          File.write(config_path, CONFIG_TEMPLATE)
+        end
+
+        puts "Initialised browserctl project:"
+        puts "  .browserctl/workflows/   (place workflow .rb files here)"
+        puts "  .browserctl/config.yml   (project settings)"
+      end
+    end
+  end
+end

--- a/lib/browserctl/commands/inspect.rb
+++ b/lib/browserctl/commands/inspect.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Commands
+    class Inspect
+      def self.run(client, args)
+        name = args.shift or abort "usage: browserctl inspect <page>"
+        res = client.inspect_page(name)
+        if res[:error]
+          warn "Error: #{res[:error]}"
+          exit 1
+        end
+        url = res[:devtools_url]
+        puts "Opening DevTools for '#{name}':"
+        puts "  #{url}"
+        opener = RUBY_PLATFORM =~ /darwin/ ? "open" : "xdg-open"
+        system(opener, url)
+      end
+    end
+  end
+end

--- a/lib/browserctl/commands/pause_resume.rb
+++ b/lib/browserctl/commands/pause_resume.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "cli_output"
+
+module Browserctl
+  module Commands
+    module PauseResume
+      extend CliOutput
+
+      def self.pause(client, args)
+        name = args.shift or abort "usage: browserctl pause <page>"
+        res = client.pause(name)
+        if res[:error]
+          warn "Error: #{res[:error]}"
+          exit 1
+        end
+        puts "Page '#{name}' paused. Browser is live — interact freely."
+        puts "When done: browserctl resume #{name}"
+      end
+
+      def self.resume(client, args)
+        name = args.shift or abort "usage: browserctl resume <page>"
+        res = client.resume(name)
+        if res[:error]
+          warn "Error: #{res[:error]}"
+          exit 1
+        end
+        puts "Page '#{name}' resumed."
+      end
+    end
+  end
+end

--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -10,6 +10,11 @@ module Browserctl
       File.expand_path("~/.browserctl/workflows")
     ].freeze
 
+    # Runs a named workflow with the given parameters.
+    # @param name [String] workflow name (must match /\A[a-zA-Z0-9_-]+\z/)
+    # @param params [Hash] keyword arguments passed to the workflow
+    # @return [Boolean] true if all steps succeeded
+    # @raise [WorkflowError] if the name is invalid or a step fails
     def run_workflow(name, **params)
       defn    = fetch_workflow(name)
       results = defn.call(params, Client.new)
@@ -17,11 +22,16 @@ module Browserctl
       results.all?(&:ok)
     end
 
+    # Lists all registered workflows from the standard search paths.
+    # @return [Array<Hash>] array of `{ name:, desc: }` hashes
     def list_workflows
       load_all_workflows
       REGISTRY.map { |name, defn| { name: name, desc: defn.description } }
     end
 
+    # Returns detailed information about a workflow.
+    # @param name [String] workflow name
+    # @return [Hash] `{ name:, desc:, params:, steps: }`
     def describe_workflow(name)
       defn = fetch_workflow(name)
       { name: defn.name, desc: defn.description, params: format_params(defn), steps: defn.steps.map(&:label) }

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -36,10 +36,18 @@ module Browserctl
 
     def dispatch(req)
       handler = COMMAND_MAP[req[:cmd]]
-      return { error: "unknown command: #{req[:cmd]}" } unless handler
+      if handler
+        Browserctl.logger.debug("#{req[:cmd]} #{req[:name]}")
+        return send(handler, req)
+      end
 
-      Browserctl.logger.debug("#{req[:cmd]} #{req[:name]}")
-      send(handler, req)
+      if (plugin = Browserctl::PLUGIN_COMMANDS[req[:cmd]])
+        Browserctl.logger.debug("plugin:#{req[:cmd]} #{req[:name]}")
+        session = req[:name] ? @global_mutex.synchronize { @pages[req[:name]] } : nil
+        return plugin.call(session, req)
+      end
+
+      { error: "unknown command: #{req[:cmd]}" }
     end
 
     private

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -6,27 +6,33 @@ require_relative "page_session"
 module Browserctl
   class CommandDispatcher
     COMMAND_MAP = {
-      "open_page"  => :cmd_open_page,
+      "open_page" => :cmd_open_page,
       "close_page" => :cmd_close_page,
       "list_pages" => :cmd_list_pages,
-      "goto"       => :cmd_goto,
-      "snapshot"   => :cmd_snapshot,
-      "evaluate"   => :cmd_evaluate,
-      "fill"       => :cmd_fill,
-      "click"      => :cmd_click,
+      "goto" => :cmd_goto,
+      "snapshot" => :cmd_snapshot,
+      "evaluate" => :cmd_evaluate,
+      "fill" => :cmd_fill,
+      "click" => :cmd_click,
       "screenshot" => :cmd_screenshot,
-      "wait_for"   => :cmd_wait_for,
-      "watch"      => :cmd_watch,
-      "url"        => :cmd_url,
-      "ping"       => :cmd_ping,
-      "shutdown"   => :cmd_shutdown,
-      "pause"      => :cmd_pause,
-      "resume"     => :cmd_resume,
-      "inspect"    => :cmd_inspect
+      "wait_for" => :cmd_wait_for,
+      "watch" => :cmd_watch,
+      "url" => :cmd_url,
+      "ping" => :cmd_ping,
+      "shutdown" => :cmd_shutdown,
+      "pause" => :cmd_pause,
+      "resume" => :cmd_resume,
+      "inspect" => :cmd_inspect
     }.freeze
 
     SCREENSHOT_DIR  = File.expand_path("~/.browserctl/screenshots").freeze
     SCREENSHOT_EXTS = %w[.png .jpg .jpeg].freeze
+    CLOUDFLARE_SIGNALS = [
+      "cf-challenge-running",
+      "cf_chl_opt",
+      "__cf_chl_f_tk",
+      "Just a moment..."
+    ].freeze
 
     def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
       @pages            = pages
@@ -85,9 +91,7 @@ module Browserctl
     def take_snapshot(session, format, diff)
       challenge = cloudflare_challenge?(session.page)
 
-      unless format == "ai"
-        return { ok: true, html: session.page.body, challenge: challenge }
-      end
+      return { ok: true, html: session.page.body, challenge: challenge } unless format == "ai"
 
       snapshot = @snapshot_builder.call(session.page)
       registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }
@@ -245,13 +249,6 @@ module Browserctl
         yield session
       end
     end
-
-    CLOUDFLARE_SIGNALS = [
-      "cf-challenge-running",
-      "cf_chl_opt",
-      "__cf_chl_f_tk",
-      "Just a moment..."
-    ].freeze
 
     def cloudflare_challenge?(page)
       url  = page.current_url.to_s

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -6,20 +6,22 @@ require_relative "page_session"
 module Browserctl
   class CommandDispatcher
     COMMAND_MAP = {
-      "open_page" => :cmd_open_page,
+      "open_page"  => :cmd_open_page,
       "close_page" => :cmd_close_page,
       "list_pages" => :cmd_list_pages,
-      "goto" => :cmd_goto,
-      "snapshot" => :cmd_snapshot,
-      "evaluate" => :cmd_evaluate,
-      "fill" => :cmd_fill,
-      "click" => :cmd_click,
+      "goto"       => :cmd_goto,
+      "snapshot"   => :cmd_snapshot,
+      "evaluate"   => :cmd_evaluate,
+      "fill"       => :cmd_fill,
+      "click"      => :cmd_click,
       "screenshot" => :cmd_screenshot,
-      "wait_for" => :cmd_wait_for,
-      "watch" => :cmd_watch,
-      "url" => :cmd_url,
-      "ping" => :cmd_ping,
-      "shutdown" => :cmd_shutdown
+      "wait_for"   => :cmd_wait_for,
+      "watch"      => :cmd_watch,
+      "url"        => :cmd_url,
+      "ping"       => :cmd_ping,
+      "shutdown"   => :cmd_shutdown,
+      "pause"      => :cmd_pause,
+      "resume"     => :cmd_resume
     }.freeze
 
     SCREENSHOT_DIR  = File.expand_path("~/.browserctl/screenshots").freeze
@@ -184,6 +186,25 @@ module Browserctl
       with_page(req[:name]) { |session| { ok: true, url: session.page.current_url } }
     end
 
+    def cmd_pause(req)
+      session = @global_mutex.synchronize { @pages[req[:name]] }
+      return { error: "no page named '#{req[:name]}'" } unless session
+
+      session.mutex.synchronize { session.pause! }
+      { ok: true, paused: true }
+    end
+
+    def cmd_resume(req)
+      session = @global_mutex.synchronize { @pages[req[:name]] }
+      return { error: "no page named '#{req[:name]}'" } unless session
+
+      session.mutex.synchronize do
+        session.resume!
+        session.pause_cv.signal
+      end
+      { ok: true, paused: false }
+    end
+
     def cmd_ping(_req) = { ok: true, pid: Process.pid }
 
     def cmd_shutdown(_req)
@@ -195,7 +216,10 @@ module Browserctl
       session = @global_mutex.synchronize { @pages[name] }
       return { error: "no page named '#{name}'" } unless session
 
-      session.mutex.synchronize { yield session }
+      session.mutex.synchronize do
+        session.pause_cv.wait(session.mutex) while session.paused?
+        yield session
+      end
     end
 
     def resolve_selector_from(session, req)

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -21,7 +21,8 @@ module Browserctl
       "ping"       => :cmd_ping,
       "shutdown"   => :cmd_shutdown,
       "pause"      => :cmd_pause,
-      "resume"     => :cmd_resume
+      "resume"     => :cmd_resume,
+      "inspect"    => :cmd_inspect
     }.freeze
 
     SCREENSHOT_DIR  = File.expand_path("~/.browserctl/screenshots").freeze
@@ -196,6 +197,17 @@ module Browserctl
 
     def cmd_url(req)
       with_page(req[:name]) { |session| { ok: true, url: session.page.current_url } }
+    end
+
+    def cmd_inspect(req)
+      session = @global_mutex.synchronize { @pages[req[:name]] }
+      return { error: "no page named '#{req[:name]}'" } unless session
+
+      port      = @browser.process.port
+      target_id = session.page.target_id
+      devtools_url = "http://127.0.0.1:#{port}/devtools/inspector.html" \
+                     "?ws=127.0.0.1:#{port}/devtools/page/#{target_id}"
+      { ok: true, devtools_url: devtools_url }
     end
 
     def cmd_pause(req)

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -65,7 +65,7 @@ module Browserctl
     def cmd_goto(req)
       with_page(req[:name]) do |session|
         session.page.go_to(req[:url])
-        { ok: true, url: session.page.current_url }
+        { ok: true, url: session.page.current_url, challenge: cloudflare_challenge?(session.page) }
       end
     end
 
@@ -74,7 +74,11 @@ module Browserctl
     end
 
     def take_snapshot(session, format, diff)
-      return { ok: true, html: session.page.body } unless format == "ai"
+      challenge = cloudflare_challenge?(session.page)
+
+      unless format == "ai"
+        return { ok: true, html: session.page.body, challenge: challenge }
+      end
 
       snapshot = @snapshot_builder.call(session.page)
       registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }
@@ -84,7 +88,7 @@ module Browserctl
       session.prev_snapshot = snapshot
       result = diff && prev ? compute_diff(prev, snapshot) : snapshot
 
-      { ok: true, snapshot: result }
+      { ok: true, snapshot: result, challenge: challenge }
     end
 
     def compute_diff(prev, current)
@@ -220,6 +224,20 @@ module Browserctl
         session.pause_cv.wait(session.mutex) while session.paused?
         yield session
       end
+    end
+
+    CLOUDFLARE_SIGNALS = [
+      "cf-challenge-running",
+      "cf_chl_opt",
+      "__cf_chl_f_tk",
+      "Just a moment..."
+    ].freeze
+
+    def cloudflare_challenge?(page)
+      url  = page.current_url.to_s
+      body = page.body.to_s
+      url.include?("challenge-platform") ||
+        CLOUDFLARE_SIGNALS.any? { |sig| body.include?(sig) }
     end
 
     def resolve_selector_from(session, req)

--- a/lib/browserctl/server/page_session.rb
+++ b/lib/browserctl/server/page_session.rb
@@ -2,14 +2,20 @@
 
 module Browserctl
   class PageSession
-    attr_reader :page, :mutex
+    attr_reader :page, :mutex, :pause_cv
     attr_accessor :ref_registry, :prev_snapshot
 
     def initialize(page)
       @page          = page
       @mutex         = Mutex.new
+      @pause_cv      = ConditionVariable.new
       @ref_registry  = {}
       @prev_snapshot = nil
+      @paused        = false
     end
+
+    def paused? = @paused
+    def pause!  = (@paused = true)
+    def resume! = (@paused = false)
   end
 end

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -112,6 +112,13 @@ module Browserctl
       @steps << StepDef.new(label: label, block: block, retry_count: retry_count, timeout: timeout)
     end
 
+    def compose(workflow_name)
+      source = REGISTRY[workflow_name.to_s]
+      raise WorkflowError, "workflow '#{workflow_name}' not found for composition" unless source
+
+      @steps.concat(source.steps)
+    end
+
     def call(params, client)
       ctx = WorkflowContext.new(resolve_params(params), client)
       execute_steps(ctx)

--- a/sig/browserctl.rbs
+++ b/sig/browserctl.rbs
@@ -1,0 +1,12 @@
+module Browserctl
+  BROWSERCTL_DIR: String
+  IDLE_TTL: Integer
+  REGISTRY: Hash[String, WorkflowDefinition]
+  PLUGIN_COMMANDS: Hash[String, Proc]
+
+  def self.socket_path: (?String? name) -> String
+  def self.pid_path: (?String? name) -> String
+  def self.register_command: (String | Symbol name) { (PageSession?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped] } -> void
+  def self.workflow: (String name) { () -> void } -> void
+  def self.logger: () -> Logger
+end

--- a/sig/browserctl/client.rbs
+++ b/sig/browserctl/client.rbs
@@ -1,0 +1,22 @@
+module Browserctl
+  class Client
+    def initialize: (?String socket_path) -> void
+    def open_page: (String name, ?url: String?) -> Hash[Symbol, untyped]
+    def close_page: (String name) -> Hash[Symbol, untyped]
+    def list_pages: () -> Hash[Symbol, untyped]
+    def goto: (String name, String url) -> Hash[Symbol, untyped]
+    def click: (String name, ?String? selector, ?ref: String?) -> Hash[Symbol, untyped]
+    def fill: (String name, ?String? selector, ?String? value, ?ref: String?) -> Hash[Symbol, untyped]
+    def screenshot: (String name, ?path: String?, ?full: bool) -> Hash[Symbol, untyped]
+    def snapshot: (String name, ?format: String, ?diff: bool) -> Hash[Symbol, untyped]
+    def wait_for: (String name, String selector, ?timeout: Numeric) -> Hash[Symbol, untyped]
+    def watch: (String name, String selector, ?timeout: Numeric) -> Hash[Symbol, untyped]
+    def url: (String name) -> Hash[Symbol, untyped]
+    def evaluate: (String name, String expression) -> Hash[Symbol, untyped]
+    def ping: () -> Hash[Symbol, untyped]
+    def shutdown: () -> Hash[Symbol, untyped]
+    def pause: (String name) -> Hash[Symbol, untyped]
+    def resume: (String name) -> Hash[Symbol, untyped]
+    def inspect_page: (String name) -> Hash[Symbol, untyped]
+  end
+end

--- a/sig/browserctl/runner.rbs
+++ b/sig/browserctl/runner.rbs
@@ -1,0 +1,7 @@
+module Browserctl
+  class Runner
+    def run_workflow: (String name, **untyped params) -> bool
+    def list_workflows: () -> Array[{ name: String, desc: String? }]
+    def describe_workflow: (String name) -> Hash[Symbol, untyped]
+  end
+end

--- a/sig/browserctl/server/page_session.rbs
+++ b/sig/browserctl/server/page_session.rbs
@@ -1,0 +1,14 @@
+module Browserctl
+  class PageSession
+    attr_reader page: untyped
+    attr_reader mutex: Mutex
+    attr_reader pause_cv: ConditionVariable
+    attr_accessor ref_registry: Hash[String, String]
+    attr_accessor prev_snapshot: Array[Hash[Symbol, untyped]]?
+
+    def initialize: (untyped page) -> void
+    def paused?: () -> bool
+    def pause!: () -> bool
+    def resume!: () -> bool
+  end
+end

--- a/sig/browserctl/workflow.rbs
+++ b/sig/browserctl/workflow.rbs
@@ -1,0 +1,38 @@
+module Browserctl
+  class WorkflowError < StandardError
+  end
+
+  class ParamDef
+    attr_reader name: Symbol
+    attr_reader required: bool
+    attr_reader secret: bool
+    attr_reader default: untyped
+  end
+
+  class StepResult
+    attr_reader name: String
+    attr_reader ok: bool
+    attr_reader error: String?
+  end
+
+  class StepDef
+    attr_reader label: String
+    attr_reader block: Proc
+    attr_reader retry_count: Integer
+    attr_reader timeout: Numeric?
+  end
+
+  class WorkflowDefinition
+    attr_reader name: String
+    attr_reader description: String?
+    attr_reader param_defs: Hash[Symbol, ParamDef]
+    attr_reader steps: Array[StepDef]
+
+    def initialize: (String name) -> void
+    def desc: (String text) -> void
+    def param: (Symbol name, ?required: bool, ?secret: bool, ?default: untyped) -> void
+    def step: (String label, ?retry_count: Integer, ?timeout: Numeric?) { () -> void } -> void
+    def compose: (String workflow_name) -> void
+    def call: (Hash[Symbol, untyped] params, Client client) -> Array[StepResult]
+  end
+end

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -218,8 +218,10 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
 
     context "when page is normal" do
-      let(:page) { instance_double("Ferrum::Page", body: "<html><body>Normal</body></html>",
-                                                   current_url: "https://example.com/page") }
+      let(:page) do
+        instance_double("Ferrum::Page", body: "<html><body>Normal</body></html>",
+                                        current_url: "https://example.com/page")
+      end
 
       it "includes challenge: false in snapshot" do
         res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
@@ -319,7 +321,10 @@ RSpec.describe Browserctl::CommandDispatcher do
   end
 
   describe "#cmd_snapshot (state storage)" do
-    let(:page)    { instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>", current_url: "https://example.com") }
+    let(:page) do
+      instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>",
+                                      current_url: "https://example.com")
+    end
     let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
     let(:builder) { Browserctl::SnapshotBuilder.new }
     subject(:dispatcher) { described_class.new(pages, double("browser"), builder) }

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Browserctl::CommandDispatcher do
 
   describe "ref-based interaction" do
     let(:html) { '<html><body><input name="email"><button>Go</button></body></html>' }
-    let(:page) { instance_double("Ferrum::Page", body: html) }
+    let(:page) { instance_double("Ferrum::Page", body: html, current_url: "https://example.com") }
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("browser")) }
 
@@ -109,7 +109,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   describe "snap --diff" do
     let(:html_v1) { '<html><body><button id="a">A</button></body></html>' }
     let(:html_v2) { '<html><body><button id="a">A</button><button id="b">B</button></body></html>' }
-    let(:page)    { instance_double("Ferrum::Page") }
+    let(:page)    { instance_double("Ferrum::Page", current_url: "https://example.com") }
     let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("browser")) }
 
@@ -187,6 +187,53 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
   end
 
+  describe "Cloudflare challenge detection" do
+    let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
+    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+
+    context "when snapshot detects challenge page" do
+      let(:cf_html) { '<html><body class="cf-challenge-running">Just a moment...</body></html>' }
+      let(:page)    { instance_double("Ferrum::Page", body: cf_html, current_url: "https://example.com") }
+
+      it "includes challenge: true in ai snapshot response" do
+        res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+        expect(res[:challenge]).to be true
+      end
+
+      it "includes challenge: true in html snapshot response" do
+        res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
+        expect(res[:challenge]).to be true
+      end
+    end
+
+    context "when goto lands on challenge page" do
+      let(:cf_url) { "https://example.com/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1" }
+      let(:page)   { instance_double("Ferrum::Page", body: "<html></html>", current_url: cf_url) }
+
+      it "includes challenge: true in goto response" do
+        allow(page).to receive(:go_to)
+        res = dispatcher.dispatch({ cmd: "goto", name: "main", url: "https://example.com" })
+        expect(res[:challenge]).to be true
+      end
+    end
+
+    context "when page is normal" do
+      let(:page) { instance_double("Ferrum::Page", body: "<html><body>Normal</body></html>",
+                                                   current_url: "https://example.com/page") }
+
+      it "includes challenge: false in snapshot" do
+        res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
+        expect(res[:challenge]).to be false
+      end
+
+      it "includes challenge: false in goto" do
+        allow(page).to receive(:go_to)
+        res = dispatcher.dispatch({ cmd: "goto", name: "main", url: "https://example.com" })
+        expect(res[:challenge]).to be false
+      end
+    end
+  end
+
   describe "#cmd_pause and #cmd_resume" do
     let(:page)  { instance_double("Ferrum::Page") }
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
@@ -233,7 +280,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   end
 
   describe "#cmd_snapshot (state storage)" do
-    let(:page)    { instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>") }
+    let(:page)    { instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>", current_url: "https://example.com") }
     let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
     let(:builder) { Browserctl::SnapshotBuilder.new }
     subject(:dispatcher) { described_class.new(pages, double("browser"), builder) }
@@ -256,7 +303,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
 
     it "evicts ref_registry and prev_snapshot when page is closed" do
-      page2 = instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>")
+      page2 = instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>", current_url: "https://example.com")
       allow(page2).to receive(:close)
       pages["temp"] = Browserctl::PageSession.new(page2)
       dispatcher.dispatch({ cmd: "snapshot", name: "temp", format: "ai" })

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -187,6 +187,51 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
   end
 
+  describe "#cmd_pause and #cmd_resume" do
+    let(:page)  { instance_double("Ferrum::Page") }
+    let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
+    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+
+    it "pause returns ok and marks page as paused" do
+      res = dispatcher.dispatch({ cmd: "pause", name: "main" })
+      expect(res[:ok]).to be true
+      expect(res[:paused]).to be true
+      expect(pages["main"].paused?).to be true
+    end
+
+    it "resume returns ok and clears paused flag" do
+      pages["main"].pause!
+      res = dispatcher.dispatch({ cmd: "resume", name: "main" })
+      expect(res[:ok]).to be true
+      expect(res[:paused]).to be false
+      expect(pages["main"].paused?).to be false
+    end
+
+    it "pause returns error for unknown page" do
+      res = dispatcher.dispatch({ cmd: "pause", name: "ghost" })
+      expect(res[:error]).to match(/no page named 'ghost'/)
+    end
+
+    it "resumes unblocks a waiting thread" do
+      pages["main"].pause!
+      unblocked = false
+
+      t = Thread.new do
+        dispatcher.dispatch({ cmd: "pause", name: "main" })
+        pages["main"].mutex.synchronize do
+          pages["main"].pause_cv.wait(pages["main"].mutex) while pages["main"].paused?
+          unblocked = true
+        end
+      end
+
+      sleep 0.05
+      dispatcher.dispatch({ cmd: "resume", name: "main" })
+      t.join(1)
+
+      expect(unblocked).to be true
+    end
+  end
+
   describe "#cmd_snapshot (state storage)" do
     let(:page)    { instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>") }
     let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -352,4 +352,25 @@ RSpec.describe Browserctl::CommandDispatcher do
       expect(pages.key?("temp")).to be false
     end
   end
+
+  describe "#cmd_inspect" do
+    let(:browser) { double("browser") }
+    let(:page)    { instance_double("Ferrum::Page") }
+    let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
+    subject(:dispatcher) { described_class.new(pages, browser) }
+
+    it "returns a devtools_url for a known page" do
+      allow(browser).to receive_message_chain(:process, :port).and_return(9222)
+      allow(page).to receive(:target_id).and_return("ABCD1234")
+      res = dispatcher.dispatch({ cmd: "inspect", name: "main" })
+      expect(res[:ok]).to be true
+      expect(res[:devtools_url]).to include("9222")
+      expect(res[:devtools_url]).to include("ABCD1234")
+    end
+
+    it "returns error for unknown page" do
+      res = dispatcher.dispatch({ cmd: "inspect", name: "ghost" })
+      expect(res[:error]).to match(/no page named 'ghost'/)
+    end
+  end
 end

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -279,6 +279,45 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
   end
 
+  describe "plugin commands" do
+    let(:page)  { instance_double("Ferrum::Page") }
+    let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
+    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+
+    after { Browserctl::PLUGIN_COMMANDS.clear }
+
+    it "dispatches a registered plugin command" do
+      Browserctl.register_command(:test_echo) do |_session, req|
+        { ok: true, echoed: req[:value] }
+      end
+      res = dispatcher.dispatch({ cmd: "test_echo", name: "main", value: "hello" })
+      expect(res[:ok]).to be true
+      expect(res[:echoed]).to eq("hello")
+    end
+
+    it "passes the PageSession to the plugin" do
+      received_session = nil
+      Browserctl.register_command(:capture_session) do |session, _req|
+        received_session = session
+        { ok: true }
+      end
+      dispatcher.dispatch({ cmd: "capture_session", name: "main" })
+      expect(received_session).to be_a(Browserctl::PageSession)
+    end
+
+    it "plugin command name does not shadow built-in commands" do
+      Browserctl.register_command(:ping) { |_s, _r| { ok: false, hijacked: true } }
+      res = dispatcher.dispatch({ cmd: "ping" })
+      expect(res[:hijacked]).to be_nil
+      expect(res[:pid]).to eq(Process.pid)
+    end
+
+    it "returns unknown command error if neither built-in nor plugin" do
+      res = dispatcher.dispatch({ cmd: "no_such_cmd" })
+      expect(res[:error]).to match(/unknown command/)
+    end
+  end
+
   describe "#cmd_snapshot (state storage)" do
     let(:page)    { instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>", current_url: "https://example.com") }
     let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }

--- a/spec/unit/init_spec.rb
+++ b/spec/unit/init_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "browserctl/commands/init"
+
+RSpec.describe Browserctl::Commands::Init do
+  around do |ex|
+    Dir.mktmpdir { |d| Dir.chdir(d) { ex.run } }
+  end
+
+  describe ".run" do
+    it "creates .browserctl/workflows directory" do
+      described_class.run([])
+      expect(Dir.exist?(".browserctl/workflows")).to be true
+    end
+
+    it "creates .browserctl/config.yml" do
+      described_class.run([])
+      expect(File.exist?(".browserctl/config.yml")).to be true
+    end
+
+    it "config.yml contains daemon key as a comment" do
+      described_class.run([])
+      content = File.read(".browserctl/config.yml")
+      expect(content).to include("daemon")
+    end
+
+    it "creates .browserctl/workflows/.keep" do
+      described_class.run([])
+      expect(File.exist?(".browserctl/workflows/.keep")).to be true
+    end
+
+    it "is idempotent — running twice does not raise" do
+      described_class.run([])
+      expect { described_class.run([]) }.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/page_session_spec.rb
+++ b/spec/unit/page_session_spec.rb
@@ -38,4 +38,30 @@ RSpec.describe Browserctl::PageSession do
     other = described_class.new(double("page2"))
     expect(session.mutex).not_to equal(other.mutex)
   end
+
+  describe "pause/resume" do
+    it "starts unpaused" do
+      expect(session.paused?).to be false
+    end
+
+    it "pause! marks the session as paused" do
+      session.pause!
+      expect(session.paused?).to be true
+    end
+
+    it "resume! clears the paused flag" do
+      session.pause!
+      session.resume!
+      expect(session.paused?).to be false
+    end
+
+    it "exposes a ConditionVariable" do
+      expect(session.pause_cv).to be_a(ConditionVariable)
+    end
+
+    it "has a separate pause_cv per instance" do
+      other = described_class.new(double("page2"))
+      expect(session.pause_cv).not_to equal(other.pause_cv)
+    end
+  end
 end

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -145,8 +145,12 @@ RSpec.describe "compose" do
   end
 
   it "compose can be called multiple times to merge several workflows" do
-    Browserctl.workflow "first"  do; step("f1") { nil }; end
-    Browserctl.workflow "second" do; step("f2") { nil }; end
+    Browserctl.workflow "first" do
+      step("f1") { nil }
+    end
+    Browserctl.workflow "second" do
+      step("f2") { nil }
+    end
     Browserctl.workflow "combined" do
       compose "first"
       compose "second"

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -104,6 +104,59 @@ RSpec.describe Browserctl::WorkflowDefinition do
   end
 end
 
+RSpec.describe "compose" do
+  before { Browserctl::REGISTRY.clear }
+  after  { Browserctl::REGISTRY.clear }
+
+  it "inlines steps from another workflow" do
+    Browserctl.workflow "shared" do
+      step("shared step") { nil }
+    end
+
+    Browserctl.workflow "main" do
+      compose "shared"
+      step("own step") { nil }
+    end
+
+    defn = Browserctl::REGISTRY["main"]
+    expect(defn.steps.map(&:label)).to eq(["shared step", "own step"])
+  end
+
+  it "raises WorkflowError when composed workflow is not registered" do
+    expect do
+      Browserctl.workflow "broken" do
+        compose "nonexistent"
+      end
+    end.to raise_error(Browserctl::WorkflowError, /nonexistent/)
+  end
+
+  it "composed steps run in order" do
+    order = []
+    Browserctl.workflow "base" do
+      step("a") { order << :a }
+    end
+    Browserctl.workflow "extended" do
+      compose "base"
+      step("b") { order << :b }
+    end
+    client = double("client", ping: { ok: true })
+    Browserctl::REGISTRY["extended"].call({}, client)
+    expect(order).to eq(%i[a b])
+  end
+
+  it "compose can be called multiple times to merge several workflows" do
+    Browserctl.workflow "first"  do; step("f1") { nil }; end
+    Browserctl.workflow "second" do; step("f2") { nil }; end
+    Browserctl.workflow "combined" do
+      compose "first"
+      compose "second"
+      step("own") { nil }
+    end
+    labels = Browserctl::REGISTRY["combined"].steps.map(&:label)
+    expect(labels).to eq(%w[f1 f2 own])
+  end
+end
+
 RSpec.describe Browserctl::WorkflowContext do
   let(:client) { instance_double(Browserctl::Client) }
 


### PR DESCRIPTION
## Summary

- **HITL pause/resume**: `browserctl pause <page>` / `resume <page>` block queued commands via ConditionVariable until a human finishes manual interaction
- **Cloudflare detection**: `goto` and `snapshot` responses now include `challenge: true` when a Cloudflare bot-challenge page is detected, letting agents branch to pause/resume
- **`browserctl init`**: scaffolds `.browserctl/workflows/` and `.browserctl/config.yml` in one command (idempotent)
- **Workflow `compose`**: `WorkflowDefinition#compose "name"` inlines another workflow's steps at definition time — no runtime overhead
- **Plugin system**: `Browserctl.register_command(:name) { |session, req| … }` registers custom commands dispatched like built-ins; built-ins always take priority
- **`browserctl inspect`**: returns the Chrome DevTools URL for a named page and opens it with `open`/`xdg-open`
- **RBS type signatures**: `sig/` tree covers `Client`, `Runner`, `WorkflowDefinition`, `PageSession`, and the top-level module
- **YARD docs**: `@param`/`@return` annotations on all public `Client` and `Runner` methods; `yard gem` added as dev dependency

## Test Plan

- [ ] `bundle exec rspec` — 113 examples, 0 failures
- [ ] `browserctl pause main` / `browserctl resume main` — automation blocks and unblocks
- [ ] `browserctl init` in a clean directory — creates `.browserctl/` tree
- [ ] `browserctl inspect main` (with daemon running) — opens DevTools URL
- [ ] Workflow file using `compose` — steps from composed workflow run before own steps
- [ ] `Browserctl.register_command` in a workflow file — custom command dispatched correctly
- [ ] `bundle exec yard doc lib/` — generates without errors

## Notes

- `CLOUDFLARE_SIGNALS` uses a plain Array literal (not `%w[]`) to preserve the multi-word `"Just a moment..."` signal
- `inspect_page` (not `inspect`) used on Client to avoid collision with `Object#inspect`
- Existing dispatcher tests updated to stub `current_url` on `instance_double("Ferrum::Page")` — required now that all snapshot/goto paths call `cloudflare_challenge?`