### PR TITLE
chore: switch CI to GitHub App token and add lefthook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,17 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
   publish:
     name: Publish

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -19,7 +19,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: ./.github/actions/setup-ruby
 
@@ -41,9 +49,13 @@ jobs:
         run: bundle exec browserctl shutdown || true
 
       - name: Commit screenshots
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          APP_SLUG=$(gh api /app --jq '.slug')
+          APP_ID="${{ secrets.APP_ID }}"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add docs/screenshots/
           git diff --staged --quiet || git commit -m "chore: update smoke test screenshots [skip ci]"
           git push

--- a/browserctl.gemspec
+++ b/browserctl.gemspec
@@ -32,7 +32,8 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_dependency "nokogiri", "~> 1.16"
   s.add_dependency "optimist", "~> 3.1"
 
-  s.add_development_dependency "rspec",   "~> 3.13"
-  s.add_development_dependency "rubocop", "~> 1.65"
-  s.add_development_dependency "yard",    "~> 0.9"
+  s.add_development_dependency "lefthook", "~> 1.11"
+  s.add_development_dependency "rspec",    "~> 3.13"
+  s.add_development_dependency "rubocop",  "~> 1.65"
+  s.add_development_dependency "yard",     "~> 0.9"
 end

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,10 @@
+pre-commit:
+  commands:
+    rubocop:
+      glob: "**/*.rb"
+      run: bundle exec rubocop --autocorrect-all {staged_files}
+
+pre-push:
+  commands:
+    rspec:
+      run: bundle exec rspec


### PR DESCRIPTION
## Summary

- Replace `github.token` with `actions/create-github-app-token` in `release.yml` and `screenshots.yml` so release-please PRs and screenshot commits are attributed to the GitHub App instead of `github-actions[bot]`
- Add `lefthook` as a dev dependency (`browserctl.gemspec`) with `lefthook.yml` configured for pre-commit rubocop and pre-push rspec

## Test plan

- [ ] Merge this PR — release-please should re-open the release PR attributed to the GitHub App
- [ ] Trigger the screenshots workflow manually (`workflow_dispatch`) and verify commits are attributed to the app bot