### PR TITLE
chore: clean up CI workflows post GitHub App migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -40,8 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: rubygems-release
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- `release.yml`: remove now-redundant `permissions` block at workflow level and on `publish` job — app token permissions are controlled by the GitHub App installation, not the workflow YAML
- `screenshots.yml`: replace runtime `gh api /app` slug lookup with hard-coded `p204-helm`, removing the extra API call and `GH_TOKEN` env var from the commit step