### PR TITLE
feat: v0.5 architecture & protocol lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,11 @@ jobs:
         run: bundle exec rubocop --parallel
 
   test:
-    name: Test (Ruby ${{ matrix.ruby-version }})
+    name: Test (Ruby 3.3)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        ruby-version: ["3.2", "3.3"]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
       - name: Test
         run: bundle exec rspec --format progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,16 @@ jobs:
         run: bundle exec rubocop --parallel
 
   test:
-    name: Test (Ruby 3.3)
+    name: Test (Ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      matrix:
+        ruby-version: ["3.2", "3.3"]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
       - name: Test
         run: bundle exec rspec --format progress

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -71,12 +71,14 @@ One of `selector` or `ref` is required for `fill` and `click`. Both cannot be om
 
 | Command | Required params | Optional params | Response fields |
 |---------|----------------|----------------|-----------------|
-| `snapshot` | `name` | `format` (`"ai"`\|`"html"`), `diff` | `ok`, `snapshot` or `html`, `challenge` |
+| `snapshot` | `name` | `format` (`"ai"`\|`"html"`), `diff` | `ok`, `snapshot` or `html`, `challenge`, `nonce` |
 | `screenshot` | `name` | `path`, `full` | `ok`, `path` |
 | `wait_for` | `name`, `selector` | `timeout` (default 10s) | `ok` |
 | `watch` | `name`, `selector` | `timeout` (default 30s) | `ok`, `selector` |
 
-`snapshot` with `format: "ai"` (default) returns `snapshot` field. With `format: "html"` returns `html` field. Both include `challenge`.
+`snapshot` with `format: "ai"` (default) returns `snapshot` field. With `format: "html"` returns `html` field. Both include `challenge` and `nonce`.
+
+`nonce` is a server-generated hex string (16 chars) unique per response. It is present in every `snapshot` response regardless of `format`. Consumers can use it to delimit page-provided content — the page cannot forge or predict the value.
 
 `wait_for` and `watch` both poll for a selector but are distinct wire commands: `wait_for` returns bare `ok` and is used as a programmatic blocking gate (default 10s); `watch` echoes back `selector` in its response and is designed for observational/interactive use (default 30s).
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,6 +3,9 @@ pre-commit:
     rubocop:
       glob: "**/*.rb"
       run: bundle exec rubocop --autocorrect-all {staged_files}
+    rbs-validate:
+      glob: "**/*.rbs"
+      run: bundle exec rbs validate
 
 pre-push:
   commands:

--- a/lib/browserctl.rb
+++ b/lib/browserctl.rb
@@ -2,14 +2,24 @@
 
 require_relative "browserctl/version"
 require_relative "browserctl/constants"
+require_relative "browserctl/errors"
 require_relative "browserctl/workflow"
 require_relative "browserctl/runner"
 require_relative "browserctl/client"
 
 module Browserctl
-  PLUGIN_COMMANDS = {} # rubocop:disable Style/MutableConstant
+  @plugin_commands_mutex = Mutex.new
+  @plugin_commands = {}
 
   def self.register_command(name, &block)
-    PLUGIN_COMMANDS[name.to_s] = block
+    @plugin_commands_mutex.synchronize { @plugin_commands[name.to_s] = block }
+  end
+
+  def self.lookup_plugin_command(name)
+    @plugin_commands_mutex.synchronize { @plugin_commands[name.to_s] }
+  end
+
+  def self.plugin_commands_snapshot
+    @plugin_commands_mutex.synchronize { @plugin_commands.dup }
   end
 end

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -131,6 +131,17 @@ module Browserctl
     # @return [Hash] `{ ok: true, devtools_url: }` or `{ error: }`
     def inspect_page(name)         = call("inspect", name: name)
 
+    # Stores a value in the daemon-scoped key-value store.
+    # @param key [String] storage key
+    # @param value [Object] value to store (must be JSON-serialisable)
+    # @return [Hash] `{ ok: true }` or `{ error: }`
+    def store(key, value) = call("store", key: key, value: value)
+
+    # Retrieves a value from the daemon-scoped key-value store.
+    # @param key [String] storage key
+    # @return [Hash] `{ ok: true, value: }` or `{ error:, code: "key_not_found" }`
+    def fetch(key) = call("fetch", key: key)
+
     # Returns all cookies for a named page.
     # @param name [String] logical page name
     # @return [Hash] `{ ok: true, cookies: [Hash] }` or `{ error: }`

--- a/lib/browserctl/detectors.rb
+++ b/lib/browserctl/detectors.rb
@@ -9,6 +9,10 @@ module Browserctl
       "Just a moment..."
     ].freeze
 
+    # Returns true if the page appears to be showing a Cloudflare challenge.
+    # Checks both the current URL and the page body for known Cloudflare signals.
+    # @param page [Ferrum::Page] the browser page to inspect
+    # @return [Boolean]
     def self.cloudflare?(page)
       url  = page.current_url.to_s
       body = page.body.to_s

--- a/lib/browserctl/detectors.rb
+++ b/lib/browserctl/detectors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Detectors
+    CLOUDFLARE_SIGNALS = [
+      "cf-challenge-running",
+      "cf_chl_opt",
+      "__cf_chl_f_tk",
+      "Just a moment..."
+    ].freeze
+
+    def self.cloudflare?(page)
+      url  = page.current_url.to_s
+      body = page.body.to_s
+      url.include?("challenge-platform") ||
+        CLOUDFLARE_SIGNALS.any? { |sig| body.include?(sig) }
+    end
+  end
+end

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module Browserctl
+  # Base error class for all browserctl daemon errors.
+  # Subclasses carry a machine-readable `code` that appears in wire responses.
+  # @attr_reader code [String] machine-readable error code
   class Error < StandardError
     def self.default_code = "error"
 

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class Error < StandardError
+    def self.default_code = "error"
+
+    attr_reader :code
+
+    def initialize(msg = nil, code: self.class.default_code)
+      @code = code
+      super(msg)
+    end
+  end
+
+  class PageNotFound     < Error; def self.default_code = "page_not_found"     end
+  class SelectorNotFound < Error; def self.default_code = "selector_not_found" end
+  class RefNotFound      < Error; def self.default_code = "ref_not_found"      end
+  class PathNotAllowed   < Error; def self.default_code = "path_not_allowed"   end
+  class DomainNotAllowed < Error; def self.default_code = "domain_not_allowed" end
+  class TimeoutError     < Error; def self.default_code = "timeout"            end
+  class KeyNotFound      < Error; def self.default_code = "key_not_found"      end
+end

--- a/lib/browserctl/policy.rb
+++ b/lib/browserctl/policy.rb
@@ -4,6 +4,10 @@ require "uri"
 
 module Browserctl
   module Policy
+    # Returns true if the URL is permitted by the domain policy.
+    # When BROWSERCTL_ALLOWED_DOMAINS is unset, all URLs are allowed.
+    # @param url [String] the URL to check
+    # @return [Boolean]
     def self.allowed_navigation?(url)
       domains = allowed_domains
       return true if domains.empty?

--- a/lib/browserctl/policy.rb
+++ b/lib/browserctl/policy.rb
@@ -27,7 +27,8 @@ module Browserctl
     def self.host_matches?(host, domains)
       return false unless host
 
-      domains.any? { |d| host == d || host.end_with?(".#{d}") }
+      normalised = host.downcase
+      domains.any? { |d| normalised == d.downcase || normalised.end_with?(".#{d.downcase}") }
     end
 
     private_class_method :allowed_domains, :host_matches?

--- a/lib/browserctl/policy.rb
+++ b/lib/browserctl/policy.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Browserctl
+  module Policy
+    def self.allowed_navigation?(url)
+      domains = allowed_domains
+      return true if domains.empty?
+
+      host_matches?(URI.parse(url).host, domains)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def self.allowed_domains
+      raw = ENV.fetch("BROWSERCTL_ALLOWED_DOMAINS", nil)
+      return [] unless raw&.match?(/\S/)
+
+      raw.split(",").map(&:strip).reject(&:empty?)
+    end
+
+    def self.host_matches?(host, domains)
+      return false unless host
+
+      domains.any? { |d| host == d || host.end_with?(".#{d}") }
+    end
+
+    private_class_method :allowed_domains, :host_matches?
+  end
+end

--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -27,7 +27,7 @@ module Browserctl
     # @return [Array<Hash>] array of `{ name:, desc: }` hashes
     def list_workflows
       load_all_workflows
-      REGISTRY.map { |name, defn| { name: name, desc: defn.description } }
+      Browserctl.registry_snapshot.map { |name, defn| { name: name, desc: defn.description } }
     end
 
     # Returns detailed information about a workflow.
@@ -67,15 +67,15 @@ module Browserctl
     end
 
     def fetch_workflow(name)
-      return REGISTRY[name.to_s] if REGISTRY.key?(name.to_s)
+      return Browserctl.lookup_workflow(name.to_s) if Browserctl.lookup_workflow(name.to_s)
 
       validate_name!(name)
       load_workflow_file(name)
-      REGISTRY[name.to_s] || raise("workflow '#{name}' not found")
+      Browserctl.lookup_workflow(name.to_s) || raise("workflow '#{name}' not found")
     end
 
     def load_workflow_file(name)
-      return if REGISTRY.key?(name.to_s)
+      return if Browserctl.lookup_workflow(name.to_s)
 
       path = workflow_path(name)
       load path if path

--- a/lib/browserctl/server.rb
+++ b/lib/browserctl/server.rb
@@ -62,8 +62,9 @@ module Browserctl
 
     def setup_socket
       FileUtils.rm_f(@socket_path)
+      old_umask = File.umask(0o177)
       server = UNIXServer.new(@socket_path)
-      File.chmod(0o600, @socket_path)
+      File.umask(old_umask)
       Browserctl.logger.info "daemon ready — listening on #{@socket_path}"
       server
     end

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -2,32 +2,47 @@
 
 require_relative "snapshot_builder"
 require_relative "page_session"
+require_relative "handlers/page_lifecycle"
+require_relative "handlers/navigation"
+require_relative "handlers/observation"
+require_relative "handlers/cookies"
+require_relative "handlers/hitl"
+require_relative "handlers/devtools"
+require_relative "handlers/daemon_control"
 require_relative "../detectors"
 require_relative "../policy"
 
 module Browserctl
   class CommandDispatcher
+    include Handlers::PageLifecycle
+    include Handlers::Navigation
+    include Handlers::Observation
+    include Handlers::Cookies
+    include Handlers::Hitl
+    include Handlers::DevTools
+    include Handlers::DaemonControl
+
     COMMAND_MAP = {
-      "open_page" => :cmd_open_page,
-      "close_page" => :cmd_close_page,
-      "list_pages" => :cmd_list_pages,
-      "goto" => :cmd_goto,
-      "snapshot" => :cmd_snapshot,
-      "evaluate" => :cmd_evaluate,
-      "fill" => :cmd_fill,
-      "click" => :cmd_click,
-      "screenshot" => :cmd_screenshot,
-      "wait_for" => :cmd_wait_for,
-      "watch" => :cmd_watch,
-      "url" => :cmd_url,
-      "ping" => :cmd_ping,
-      "shutdown" => :cmd_shutdown,
-      "pause" => :cmd_pause,
-      "resume" => :cmd_resume,
-      "inspect" => :cmd_inspect,
-      "cookies" => :cmd_cookies,
-      "set_cookie" => :cmd_set_cookie,
-      "clear_cookies" => :cmd_clear_cookies,
+      "open_page"      => :cmd_open_page,
+      "close_page"     => :cmd_close_page,
+      "list_pages"     => :cmd_list_pages,
+      "goto"           => :cmd_goto,
+      "snapshot"       => :cmd_snapshot,
+      "evaluate"       => :cmd_evaluate,
+      "fill"           => :cmd_fill,
+      "click"          => :cmd_click,
+      "screenshot"     => :cmd_screenshot,
+      "wait_for"       => :cmd_wait_for,
+      "watch"          => :cmd_watch,
+      "url"            => :cmd_url,
+      "ping"           => :cmd_ping,
+      "shutdown"       => :cmd_shutdown,
+      "pause"          => :cmd_pause,
+      "resume"         => :cmd_resume,
+      "inspect"        => :cmd_inspect,
+      "cookies"        => :cmd_cookies,
+      "set_cookie"     => :cmd_set_cookie,
+      "clear_cookies"  => :cmd_clear_cookies,
       "import_cookies" => :cmd_import_cookies,
       "store"          => :cmd_store,
       "fetch"          => :cmd_fetch
@@ -35,7 +50,8 @@ module Browserctl
 
     SCREENSHOT_DIR   = File.expand_path("~/.browserctl/screenshots").freeze
     SCREENSHOT_ROOTS = [SCREENSHOT_DIR, File.expand_path(".")].freeze
-    SCREENSHOT_EXTS = %w[.png .jpg .jpeg].freeze
+    SCREENSHOT_EXTS  = %w[.png .jpg .jpeg].freeze
+
     def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
       @pages            = pages
       @browser          = browser
@@ -63,248 +79,6 @@ module Browserctl
 
     private
 
-    def cmd_open_page(req)
-      session = @global_mutex.synchronize do
-        @pages[req[:name]] ||= PageSession.new(@browser.create_page)
-      end
-      session.page.go_to(req[:url]) if req[:url]
-      { ok: true, name: req[:name] }
-    end
-
-    def cmd_close_page(req)
-      session = @global_mutex.synchronize { @pages.delete(req[:name]) }
-      session&.page&.close
-      { ok: true }
-    end
-
-    def cmd_list_pages(_req)
-      { pages: @global_mutex.synchronize { @pages.keys } }
-    end
-
-    def cmd_goto(req)
-      unless Policy.allowed_navigation?(req[:url].to_s)
-        return { error: "navigation to '#{req[:url]}' blocked by domain policy", code: "domain_not_allowed" }
-      end
-
-      with_page(req[:name]) do |session|
-        session.page.go_to(req[:url])
-        { ok: true, url: session.page.current_url, challenge: Detectors.cloudflare?(session.page) }
-      end
-    end
-
-    def cmd_snapshot(req)
-      with_page(req[:name]) { |session| take_snapshot(session, req[:format], req[:diff]) }
-    end
-
-    def take_snapshot(session, format, diff)
-      challenge = Detectors.cloudflare?(session.page)
-
-      return { ok: true, html: session.page.body, challenge: challenge } unless format == "ai"
-
-      snapshot = @snapshot_builder.call(session.page)
-      registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }
-
-      prev = session.prev_snapshot
-      session.ref_registry  = registry
-      session.prev_snapshot = snapshot
-      result = diff && prev ? compute_diff(prev, snapshot) : snapshot
-
-      { ok: true, snapshot: result, challenge: challenge }
-    end
-
-    def compute_diff(prev, current)
-      prev_by_sel = prev.to_h { |el| [el[:selector], el] }
-      current.reject do |el|
-        old = prev_by_sel[el[:selector]]
-        old && old.slice(:text, :attrs) == el.slice(:text, :attrs)
-      end
-    end
-
-    def cmd_evaluate(req)
-      with_page(req[:name]) { |session| { ok: true, result: session.page.evaluate(req[:expression]) } }
-    end
-
-    def cmd_fill(req)
-      with_page(req[:name]) do |session|
-        sel = resolve_selector_from(session, req)
-        return sel if sel.is_a?(Hash)
-
-        type_into(session.page, sel, req[:value])
-      end
-    end
-
-    def type_into(page, selector, value)
-      el = page.at_css(selector)
-      return { error: "selector not found: #{selector}" } unless el
-
-      el.focus
-      el.type(value)
-      { ok: true }
-    end
-
-    def cmd_click(req)
-      with_page(req[:name]) do |session|
-        sel = resolve_selector_from(session, req)
-        return sel if sel.is_a?(Hash)
-
-        click_element(session.page, sel)
-      end
-    end
-
-    def click_element(page, selector)
-      el = page.at_css(selector)
-      return { error: "selector not found: #{selector}" } unless el
-
-      el.click
-      { ok: true }
-    end
-
-    def cmd_screenshot(req)
-      with_page(req[:name]) do |session|
-        path = safe_screenshot_path(req[:path], req[:name])
-        return path if path.is_a?(Hash)
-
-        FileUtils.mkdir_p(File.dirname(path))
-        session.page.screenshot(path: path, full: req.fetch(:full, false))
-        { ok: true, path: path }
-      end
-    end
-
-    def safe_screenshot_path(requested, page_name)
-      if requested
-        expanded = File.expand_path(requested)
-        allowed  = SCREENSHOT_ROOTS.any? { |d| expanded.start_with?("#{d}/") || expanded.start_with?(d) }
-        return { error: "path outside allowed directory (#{SCREENSHOT_DIR} or project directory)" } unless allowed
-        return { error: "invalid extension — use .png, .jpg, or .jpeg" } \
-          unless SCREENSHOT_EXTS.include?(File.extname(expanded).downcase)
-
-        expanded
-      else
-        name_safe = page_name.to_s.gsub(/[^a-zA-Z0-9_-]/, "_")
-        File.join(SCREENSHOT_DIR, "browserctl_shot_#{name_safe}_#{Time.now.to_i}.png")
-      end
-    end
-
-    def cmd_wait_for(req)
-      with_page(req[:name]) { |session| wait_for_selector(session.page, req[:selector], req.fetch(:timeout, 10).to_f) }
-    end
-
-    def cmd_watch(req)
-      with_page(req[:name]) do |session|
-        result = wait_for_selector(session.page, req[:selector], req.fetch(:timeout, 30).to_f)
-        result[:error] ? result : { ok: true, selector: req[:selector] }
-      end
-    end
-
-    def wait_for_selector(page, selector, timeout)
-      deadline = Time.now + timeout
-      loop do
-        found = page.at_css(selector)
-        break { ok: true } if found
-        break { error: "wait_for timeout: selector '#{selector}' not found after #{timeout}s" } if Time.now >= deadline
-
-        sleep 0.2
-      end
-    end
-
-    def cmd_url(req)
-      with_page(req[:name]) { |session| { ok: true, url: session.page.current_url } }
-    end
-
-    def cmd_cookies(req)
-      session = @global_mutex.synchronize { @pages[req[:name]] }
-      return { error: "no page named '#{req[:name]}'" } unless session
-
-      all = session.page.cookies.all
-      { ok: true, cookies: all.values.map(&:to_h) }
-    end
-
-    def cmd_set_cookie(req)
-      session = @global_mutex.synchronize { @pages[req[:name]] }
-      return { error: "no page named '#{req[:name]}'" } unless session
-
-      session.page.cookies.set(
-        name: req[:cookie_name],
-        value: req[:value],
-        domain: req[:domain],
-        path: req.fetch(:path, "/")
-      )
-      { ok: true }
-    end
-
-    def cmd_clear_cookies(req)
-      session = @global_mutex.synchronize { @pages[req[:name]] }
-      return { error: "no page named '#{req[:name]}'" } unless session
-
-      session.page.cookies.clear
-      { ok: true }
-    end
-
-    def cmd_import_cookies(req)
-      with_page(req[:name]) do |session|
-        req[:cookies].each do |c|
-          session.page.cookies.set(
-            name: c[:name],
-            value: c[:value],
-            domain: c[:domain],
-            path: c.fetch(:path, "/"),
-            httponly: c[:httpOnly] == true,
-            secure: c[:secure] == true,
-            expires: c[:expires] ? Time.at(c[:expires].to_i) : nil
-          )
-        end
-        { ok: true, count: req[:cookies].length }
-      end
-    end
-
-    def cmd_inspect(req)
-      session = @global_mutex.synchronize { @pages[req[:name]] }
-      return { error: "no page named '#{req[:name]}'" } unless session
-
-      port      = @browser.process.port
-      target_id = session.page.target_id
-      devtools_url = "http://127.0.0.1:#{port}/devtools/inspector.html" \
-                     "?ws=127.0.0.1:#{port}/devtools/page/#{target_id}"
-      { ok: true, devtools_url: devtools_url }
-    end
-
-    def cmd_pause(req)
-      session = @global_mutex.synchronize { @pages[req[:name]] }
-      return { error: "no page named '#{req[:name]}'" } unless session
-
-      session.mutex.synchronize { session.pause! }
-      { ok: true, paused: true }
-    end
-
-    def cmd_resume(req)
-      session = @global_mutex.synchronize { @pages[req[:name]] }
-      return { error: "no page named '#{req[:name]}'" } unless session
-
-      session.mutex.synchronize do
-        session.resume!
-        session.pause_cv.signal
-      end
-      { ok: true, paused: false }
-    end
-
-    def cmd_ping(_req) = { ok: true, pid: Process.pid, protocol_version: PROTOCOL_VERSION }
-
-    def cmd_shutdown(_req)
-      Process.kill("INT", Process.pid)
-      { ok: true }
-    end
-
-    def cmd_store(req)
-      @kv_mutex.synchronize { @kv_store[req[:key].to_s] = req[:value] }
-      { ok: true }
-    end
-
-    def cmd_fetch(req)
-      key = req[:key].to_s
-      found = @kv_mutex.synchronize { @kv_store.key?(key) ? { ok: true, value: @kv_store[key] } : nil }
-      found || { error: "key '#{key}' not found", code: "key_not_found" }
-    end
-
     def with_page(name)
       session = @global_mutex.synchronize { @pages[name] }
       return { error: "no page named '#{name}'" } unless session
@@ -313,13 +87,6 @@ module Browserctl
         session.pause_cv.wait(session.mutex) while session.paused?
         yield session
       end
-    end
-
-    def resolve_selector_from(session, req)
-      return req[:selector] if req[:selector]
-      return { error: "selector or ref required" } unless req[:ref]
-
-      session.ref_registry[req[:ref]] || { error: "ref '#{req[:ref]}' not found — run snap first" }
     end
   end
 end

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -53,7 +53,7 @@ module Browserctl
         return send(handler, req)
       end
 
-      if (plugin = Browserctl::PLUGIN_COMMANDS[req[:cmd]])
+      if (plugin = Browserctl.lookup_plugin_command(req[:cmd]))
         Browserctl.logger.debug("plugin:#{req[:cmd]} #{req[:name]}")
         session = req[:name] ? @global_mutex.synchronize { @pages[req[:name]] } : nil
         return plugin.call(session, req)

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -28,17 +28,21 @@ module Browserctl
       "cookies" => :cmd_cookies,
       "set_cookie" => :cmd_set_cookie,
       "clear_cookies" => :cmd_clear_cookies,
-      "import_cookies" => :cmd_import_cookies
+      "import_cookies" => :cmd_import_cookies,
+      "store"          => :cmd_store,
+      "fetch"          => :cmd_fetch
     }.freeze
 
     SCREENSHOT_DIR   = File.expand_path("~/.browserctl/screenshots").freeze
     SCREENSHOT_ROOTS = [SCREENSHOT_DIR, File.expand_path(".")].freeze
     SCREENSHOT_EXTS = %w[.png .jpg .jpeg].freeze
     def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
-      @pages = pages
+      @pages            = pages
       @browser          = browser
       @snapshot_builder = snapshot_builder
       @global_mutex     = global_mutex
+      @kv_store         = {}
+      @kv_mutex         = Mutex.new
     end
 
     def dispatch(req)
@@ -288,6 +292,17 @@ module Browserctl
     def cmd_shutdown(_req)
       Process.kill("INT", Process.pid)
       { ok: true }
+    end
+
+    def cmd_store(req)
+      @kv_mutex.synchronize { @kv_store[req[:key].to_s] = req[:value] }
+      { ok: true }
+    end
+
+    def cmd_fetch(req)
+      key = req[:key].to_s
+      found = @kv_mutex.synchronize { @kv_store.key?(key) ? { ok: true, value: @kv_store[key] } : nil }
+      found || { error: "key '#{key}' not found", code: "key_not_found" }
     end
 
     def with_page(name)

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -3,6 +3,7 @@
 require_relative "snapshot_builder"
 require_relative "page_session"
 require_relative "../detectors"
+require_relative "../policy"
 
 module Browserctl
   class CommandDispatcher
@@ -33,8 +34,8 @@ module Browserctl
     SCREENSHOT_DIR   = File.expand_path("~/.browserctl/screenshots").freeze
     SCREENSHOT_ROOTS = [SCREENSHOT_DIR, File.expand_path(".")].freeze
     SCREENSHOT_EXTS = %w[.png .jpg .jpeg].freeze
-def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
-      @pages            = pages
+    def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
+      @pages = pages
       @browser          = browser
       @snapshot_builder = snapshot_builder
       @global_mutex     = global_mutex
@@ -77,6 +78,10 @@ def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mu
     end
 
     def cmd_goto(req)
+      unless Policy.allowed_navigation?(req[:url].to_s)
+        return { error: "navigation to '#{req[:url]}' blocked by domain policy", code: "domain_not_allowed" }
+      end
+
       with_page(req[:name]) do |session|
         session.page.go_to(req[:url])
         { ok: true, url: session.page.current_url, challenge: Detectors.cloudflare?(session.page) }

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -2,6 +2,7 @@
 
 require_relative "snapshot_builder"
 require_relative "page_session"
+require_relative "../detectors"
 
 module Browserctl
   class CommandDispatcher
@@ -32,14 +33,7 @@ module Browserctl
     SCREENSHOT_DIR   = File.expand_path("~/.browserctl/screenshots").freeze
     SCREENSHOT_ROOTS = [SCREENSHOT_DIR, File.expand_path(".")].freeze
     SCREENSHOT_EXTS = %w[.png .jpg .jpeg].freeze
-    CLOUDFLARE_SIGNALS = [
-      "cf-challenge-running",
-      "cf_chl_opt",
-      "__cf_chl_f_tk",
-      "Just a moment..."
-    ].freeze
-
-    def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
+def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
       @pages            = pages
       @browser          = browser
       @snapshot_builder = snapshot_builder
@@ -85,7 +79,7 @@ module Browserctl
     def cmd_goto(req)
       with_page(req[:name]) do |session|
         session.page.go_to(req[:url])
-        { ok: true, url: session.page.current_url, challenge: cloudflare_challenge?(session.page) }
+        { ok: true, url: session.page.current_url, challenge: Detectors.cloudflare?(session.page) }
       end
     end
 
@@ -94,7 +88,7 @@ module Browserctl
     end
 
     def take_snapshot(session, format, diff)
-      challenge = cloudflare_challenge?(session.page)
+      challenge = Detectors.cloudflare?(session.page)
 
       return { ok: true, html: session.page.body, challenge: challenge } unless format == "ai"
 
@@ -299,13 +293,6 @@ module Browserctl
         session.pause_cv.wait(session.mutex) while session.paused?
         yield session
       end
-    end
-
-    def cloudflare_challenge?(page)
-      url  = page.current_url.to_s
-      body = page.body.to_s
-      url.include?("challenge-platform") ||
-        CLOUDFLARE_SIGNALS.any? { |sig| body.include?(sig) }
     end
 
     def resolve_selector_from(session, req)

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -23,29 +23,29 @@ module Browserctl
     include Handlers::DaemonControl
 
     COMMAND_MAP = {
-      "open_page"      => :cmd_open_page,
-      "close_page"     => :cmd_close_page,
-      "list_pages"     => :cmd_list_pages,
-      "goto"           => :cmd_goto,
-      "snapshot"       => :cmd_snapshot,
-      "evaluate"       => :cmd_evaluate,
-      "fill"           => :cmd_fill,
-      "click"          => :cmd_click,
-      "screenshot"     => :cmd_screenshot,
-      "wait_for"       => :cmd_wait_for,
-      "watch"          => :cmd_watch,
-      "url"            => :cmd_url,
-      "ping"           => :cmd_ping,
-      "shutdown"       => :cmd_shutdown,
-      "pause"          => :cmd_pause,
-      "resume"         => :cmd_resume,
-      "inspect"        => :cmd_inspect,
-      "cookies"        => :cmd_cookies,
-      "set_cookie"     => :cmd_set_cookie,
-      "clear_cookies"  => :cmd_clear_cookies,
+      "open_page" => :cmd_open_page,
+      "close_page" => :cmd_close_page,
+      "list_pages" => :cmd_list_pages,
+      "goto" => :cmd_goto,
+      "snapshot" => :cmd_snapshot,
+      "evaluate" => :cmd_evaluate,
+      "fill" => :cmd_fill,
+      "click" => :cmd_click,
+      "screenshot" => :cmd_screenshot,
+      "wait_for" => :cmd_wait_for,
+      "watch" => :cmd_watch,
+      "url" => :cmd_url,
+      "ping" => :cmd_ping,
+      "shutdown" => :cmd_shutdown,
+      "pause" => :cmd_pause,
+      "resume" => :cmd_resume,
+      "inspect" => :cmd_inspect,
+      "cookies" => :cmd_cookies,
+      "set_cookie" => :cmd_set_cookie,
+      "clear_cookies" => :cmd_clear_cookies,
       "import_cookies" => :cmd_import_cookies,
-      "store"          => :cmd_store,
-      "fetch"          => :cmd_fetch
+      "store" => :cmd_store,
+      "fetch" => :cmd_fetch
     }.freeze
 
     SCREENSHOT_DIR   = File.expand_path("~/.browserctl/screenshots").freeze
@@ -61,6 +61,10 @@ module Browserctl
       @kv_mutex         = Mutex.new
     end
 
+    # Dispatches a parsed request to the appropriate handler.
+    # Returns `{ error: String, code: String }` for unknown commands.
+    # @param req [Hash{Symbol => Object}] parsed request; must include `:cmd`
+    # @return [Hash{Symbol => Object}] response; always includes `:ok` or `:error`
     def dispatch(req)
       handler = COMMAND_MAP[req[:cmd]]
       if handler

--- a/lib/browserctl/server/handlers/cookies.rb
+++ b/lib/browserctl/server/handlers/cookies.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      module Cookies
+        private
+
+        def cmd_cookies(req)
+          session = @global_mutex.synchronize { @pages[req[:name]] }
+          return { error: "no page named '#{req[:name]}'" } unless session
+
+          all = session.page.cookies.all
+          { ok: true, cookies: all.values.map(&:to_h) }
+        end
+
+        def cmd_set_cookie(req)
+          session = @global_mutex.synchronize { @pages[req[:name]] }
+          return { error: "no page named '#{req[:name]}'" } unless session
+
+          session.page.cookies.set(
+            name: req[:cookie_name],
+            value: req[:value],
+            domain: req[:domain],
+            path: req.fetch(:path, "/")
+          )
+          { ok: true }
+        end
+
+        def cmd_clear_cookies(req)
+          session = @global_mutex.synchronize { @pages[req[:name]] }
+          return { error: "no page named '#{req[:name]}'" } unless session
+
+          session.page.cookies.clear
+          { ok: true }
+        end
+
+        def cmd_import_cookies(req)
+          with_page(req[:name]) do |session|
+            req[:cookies].each do |c|
+              session.page.cookies.set(
+                name: c[:name],
+                value: c[:value],
+                domain: c[:domain],
+                path: c.fetch(:path, "/"),
+                httponly: c[:httpOnly] == true,
+                secure: c[:secure] == true,
+                expires: c[:expires] ? Time.at(c[:expires].to_i) : nil
+              )
+            end
+            { ok: true, count: req[:cookies].length }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/daemon_control.rb
+++ b/lib/browserctl/server/handlers/daemon_control.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      module DaemonControl
+        private
+
+        def cmd_ping(_req) = { ok: true, pid: Process.pid, protocol_version: PROTOCOL_VERSION }
+
+        def cmd_shutdown(_req)
+          Process.kill("INT", Process.pid)
+          { ok: true }
+        end
+
+        def cmd_store(req)
+          @kv_mutex.synchronize { @kv_store[req[:key].to_s] = req[:value] }
+          { ok: true }
+        end
+
+        def cmd_fetch(req)
+          key = req[:key].to_s
+          found = @kv_mutex.synchronize { @kv_store.key?(key) ? { ok: true, value: @kv_store[key] } : nil }
+          found || { error: "key '#{key}' not found", code: "key_not_found" }
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/devtools.rb
+++ b/lib/browserctl/server/handlers/devtools.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      module DevTools
+        private
+
+        def cmd_inspect(req)
+          session = @global_mutex.synchronize { @pages[req[:name]] }
+          return { error: "no page named '#{req[:name]}'" } unless session
+
+          port      = @browser.process.port
+          target_id = session.page.target_id
+          devtools_url = "http://127.0.0.1:#{port}/devtools/inspector.html" \
+                         "?ws=127.0.0.1:#{port}/devtools/page/#{target_id}"
+          { ok: true, devtools_url: devtools_url }
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/hitl.rb
+++ b/lib/browserctl/server/handlers/hitl.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      module Hitl
+        private
+
+        def cmd_pause(req)
+          session = @global_mutex.synchronize { @pages[req[:name]] }
+          return { error: "no page named '#{req[:name]}'" } unless session
+
+          session.mutex.synchronize { session.pause! }
+          { ok: true, paused: true }
+        end
+
+        def cmd_resume(req)
+          session = @global_mutex.synchronize { @pages[req[:name]] }
+          return { error: "no page named '#{req[:name]}'" } unless session
+
+          session.mutex.synchronize do
+            session.resume!
+            session.pause_cv.signal
+          end
+          { ok: true, paused: false }
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      module Navigation
+        private
+
+        def cmd_goto(req)
+          unless Policy.allowed_navigation?(req[:url].to_s)
+            return { error: "navigation to '#{req[:url]}' blocked by domain policy", code: "domain_not_allowed" }
+          end
+
+          with_page(req[:name]) do |session|
+            session.page.go_to(req[:url])
+            { ok: true, url: session.page.current_url, challenge: Detectors.cloudflare?(session.page) }
+          end
+        end
+
+        def cmd_evaluate(req)
+          with_page(req[:name]) { |session| { ok: true, result: session.page.evaluate(req[:expression]) } }
+        end
+
+        def cmd_fill(req)
+          with_page(req[:name]) do |session|
+            sel = resolve_selector_from(session, req)
+            return sel if sel.is_a?(Hash)
+
+            type_into(session.page, sel, req[:value])
+          end
+        end
+
+        def cmd_click(req)
+          with_page(req[:name]) do |session|
+            sel = resolve_selector_from(session, req)
+            return sel if sel.is_a?(Hash)
+
+            click_element(session.page, sel)
+          end
+        end
+
+        def cmd_url(req)
+          with_page(req[:name]) { |session| { ok: true, url: session.page.current_url } }
+        end
+
+        def type_into(page, selector, value)
+          el = page.at_css(selector)
+          return { error: "selector not found: #{selector}" } unless el
+
+          el.focus
+          el.type(value)
+          { ok: true }
+        end
+
+        def click_element(page, selector)
+          el = page.at_css(selector)
+          return { error: "selector not found: #{selector}" } unless el
+
+          el.click
+          { ok: true }
+        end
+
+        def resolve_selector_from(session, req)
+          return req[:selector] if req[:selector]
+          return { error: "selector or ref required" } unless req[:ref]
+
+          session.ref_registry[req[:ref]] || { error: "ref '#{req[:ref]}' not found — run snap first" }
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/observation.rb
+++ b/lib/browserctl/server/handlers/observation.rb
@@ -16,9 +16,7 @@ module Browserctl
           nonce     = SecureRandom.hex(8)
           challenge = Detectors.cloudflare?(session.page)
 
-          unless format == "ai"
-            return { ok: true, html: session.page.body, challenge: challenge, nonce: nonce }
-          end
+          return { ok: true, html: session.page.body, challenge: challenge, nonce: nonce } unless format == "ai"
 
           snapshot = @snapshot_builder.call(session.page)
           registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }
@@ -83,7 +81,9 @@ module Browserctl
           loop do
             found = page.at_css(selector)
             break { ok: true } if found
-            break { error: "wait_for timeout: selector '#{selector}' not found after #{timeout}s" } if Time.now >= deadline
+            if Time.now >= deadline
+              break { error: "wait_for timeout: selector '#{selector}' not found after #{timeout}s" }
+            end
 
             sleep 0.2
           end

--- a/lib/browserctl/server/handlers/observation.rb
+++ b/lib/browserctl/server/handlers/observation.rb
@@ -49,18 +49,37 @@ module Browserctl
         end
 
         def safe_screenshot_path(requested, page_name)
-          if requested
-            expanded = File.expand_path(requested)
-            allowed  = SCREENSHOT_ROOTS.any? { |d| expanded.start_with?("#{d}/") || expanded.start_with?(d) }
-            return { error: "path outside allowed directory (#{SCREENSHOT_DIR} or project directory)" } unless allowed
-            return { error: "invalid extension — use .png, .jpg, or .jpeg" } \
-              unless SCREENSHOT_EXTS.include?(File.extname(expanded).downcase)
+          return default_screenshot_path(page_name) unless requested
 
-            expanded
-          else
-            name_safe = page_name.to_s.gsub(/[^a-zA-Z0-9_-]/, "_")
-            File.join(SCREENSHOT_DIR, "browserctl_shot_#{name_safe}_#{Time.now.to_i}.png")
+          expanded = File.expand_path(requested)
+          return { error: "invalid extension — use .png, .jpg, or .jpeg" } unless valid_screenshot_ext?(expanded)
+          return { error: "path outside allowed directory (#{SCREENSHOT_DIR} or project directory)" } \
+            unless within_screenshot_roots?(expanded)
+
+          File.join(resolve_dir(File.dirname(expanded)), File.basename(expanded))
+        end
+
+        def valid_screenshot_ext?(path)
+          SCREENSHOT_EXTS.include?(File.extname(path).downcase)
+        end
+
+        def within_screenshot_roots?(path)
+          dir = resolve_dir(File.dirname(path))
+          SCREENSHOT_ROOTS.any? do |root|
+            real_root = resolve_dir(root)
+            dir.start_with?("#{real_root}/") || dir == real_root
           end
+        end
+
+        def resolve_dir(dir)
+          File.realpath(dir)
+        rescue Errno::ENOENT
+          dir
+        end
+
+        def default_screenshot_path(page_name)
+          name_safe = page_name.to_s.gsub(/[^a-zA-Z0-9_-]/, "_")
+          File.join(SCREENSHOT_DIR, "browserctl_shot_#{name_safe}_#{Time.now.to_i}.png")
         end
 
         def cmd_wait_for(req)

--- a/lib/browserctl/server/handlers/observation.rb
+++ b/lib/browserctl/server/handlers/observation.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      module Observation
+        private
+
+        def cmd_snapshot(req)
+          with_page(req[:name]) { |session| take_snapshot(session, req[:format], req[:diff]) }
+        end
+
+        def take_snapshot(session, format, diff)
+          nonce     = SecureRandom.hex(8)
+          challenge = Detectors.cloudflare?(session.page)
+
+          unless format == "ai"
+            return { ok: true, html: session.page.body, challenge: challenge, nonce: nonce }
+          end
+
+          snapshot = @snapshot_builder.call(session.page)
+          registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }
+
+          prev = session.prev_snapshot
+          session.ref_registry  = registry
+          session.prev_snapshot = snapshot
+          result = diff && prev ? compute_diff(prev, snapshot) : snapshot
+
+          { ok: true, snapshot: result, challenge: challenge, nonce: nonce }
+        end
+
+        def compute_diff(prev, current)
+          prev_by_sel = prev.to_h { |el| [el[:selector], el] }
+          current.reject do |el|
+            old = prev_by_sel[el[:selector]]
+            old && old.slice(:text, :attrs) == el.slice(:text, :attrs)
+          end
+        end
+
+        def cmd_screenshot(req)
+          with_page(req[:name]) do |session|
+            path = safe_screenshot_path(req[:path], req[:name])
+            return path if path.is_a?(Hash)
+
+            FileUtils.mkdir_p(File.dirname(path))
+            session.page.screenshot(path: path, full: req.fetch(:full, false))
+            { ok: true, path: path }
+          end
+        end
+
+        def safe_screenshot_path(requested, page_name)
+          if requested
+            expanded = File.expand_path(requested)
+            allowed  = SCREENSHOT_ROOTS.any? { |d| expanded.start_with?("#{d}/") || expanded.start_with?(d) }
+            return { error: "path outside allowed directory (#{SCREENSHOT_DIR} or project directory)" } unless allowed
+            return { error: "invalid extension — use .png, .jpg, or .jpeg" } \
+              unless SCREENSHOT_EXTS.include?(File.extname(expanded).downcase)
+
+            expanded
+          else
+            name_safe = page_name.to_s.gsub(/[^a-zA-Z0-9_-]/, "_")
+            File.join(SCREENSHOT_DIR, "browserctl_shot_#{name_safe}_#{Time.now.to_i}.png")
+          end
+        end
+
+        def cmd_wait_for(req)
+          with_page(req[:name]) do |session|
+            wait_for_selector(session.page, req[:selector], req.fetch(:timeout, 10).to_f)
+          end
+        end
+
+        def cmd_watch(req)
+          with_page(req[:name]) do |session|
+            result = wait_for_selector(session.page, req[:selector], req.fetch(:timeout, 30).to_f)
+            result[:error] ? result : { ok: true, selector: req[:selector] }
+          end
+        end
+
+        def wait_for_selector(page, selector, timeout)
+          deadline = Time.now + timeout
+          loop do
+            found = page.at_css(selector)
+            break { ok: true } if found
+            break { error: "wait_for timeout: selector '#{selector}' not found after #{timeout}s" } if Time.now >= deadline
+
+            sleep 0.2
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/page_lifecycle.rb
+++ b/lib/browserctl/server/handlers/page_lifecycle.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      module PageLifecycle
+        private
+
+        def cmd_open_page(req)
+          session = @global_mutex.synchronize do
+            @pages[req[:name]] ||= PageSession.new(@browser.create_page)
+          end
+          session.page.go_to(req[:url]) if req[:url]
+          { ok: true, name: req[:name] }
+        end
+
+        def cmd_close_page(req)
+          session = @global_mutex.synchronize { @pages.delete(req[:name]) }
+          session&.page&.close
+          { ok: true }
+        end
+
+        def cmd_list_pages(_req)
+          { pages: @global_mutex.synchronize { @pages.keys } }
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -16,15 +16,20 @@ module Browserctl
     def initialize(params, client)
       @params = params
       @client = client
-      @_store = {}
     end
 
     def store(key, value)
-      @_store[key] = value
+      res = @client.store(key.to_s, value)
+      raise WorkflowError, res[:error] if res[:error]
+
+      value
     end
 
     def fetch(key)
-      @_store.fetch(key) { raise KeyError, "no value stored for key #{key.inspect}" }
+      res = @client.fetch(key.to_s)
+      raise WorkflowError, res[:error] if res[:error]
+
+      res[:value]
     end
 
     def method_missing(name, *args)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -137,7 +137,7 @@ module Browserctl
     end
 
     def compose(workflow_name)
-      source = REGISTRY[workflow_name.to_s]
+      source = Browserctl.lookup_workflow(workflow_name.to_s)
       raise WorkflowError, "workflow '#{workflow_name}' not found for composition" unless source
 
       @steps.concat(source.steps)
@@ -187,11 +187,20 @@ module Browserctl
     end
   end
 
-  REGISTRY = {} # rubocop:disable Style/MutableConstant
+  @registry_mutex = Mutex.new
+  @registry = {}
 
   def self.workflow(name, &)
     defn = WorkflowDefinition.new(name.to_s)
     defn.instance_exec(&)
-    REGISTRY[name.to_s] = defn
+    @registry_mutex.synchronize { @registry[name.to_s] = defn }
+  end
+
+  def self.lookup_workflow(name)
+    @registry_mutex.synchronize { @registry[name.to_s] }
+  end
+
+  def self.registry_snapshot
+    @registry_mutex.synchronize { @registry.dup }
   end
 end

--- a/sig/browserctl.rbs
+++ b/sig/browserctl.rbs
@@ -1,12 +1,14 @@
 module Browserctl
   BROWSERCTL_DIR: String
   IDLE_TTL: Integer
-  REGISTRY: Hash[String, WorkflowDefinition]
-  PLUGIN_COMMANDS: Hash[String, Proc]
 
   def self.socket_path: (?String? name) -> String
   def self.pid_path: (?String? name) -> String
   def self.register_command: (String | Symbol name) { (PageSession?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped] } -> void
+  def self.lookup_plugin_command: (String name) -> (Proc | nil)
+  def self.plugin_commands_snapshot: () -> Hash[String, Proc]
   def self.workflow: (String name) { () -> void } -> void
+  def self.lookup_workflow: (String name) -> (WorkflowDefinition | nil)
+  def self.registry_snapshot: () -> Hash[String, WorkflowDefinition]
   def self.logger: () -> Logger
 end

--- a/sig/browserctl/client.rbs
+++ b/sig/browserctl/client.rbs
@@ -18,5 +18,7 @@ module Browserctl
     def pause: (String name) -> Hash[Symbol, untyped]
     def resume: (String name) -> Hash[Symbol, untyped]
     def inspect_page: (String name) -> Hash[Symbol, untyped]
+    def store: (String key, untyped value) -> Hash[Symbol, untyped]
+    def fetch: (String key) -> Hash[Symbol, untyped]
   end
 end

--- a/sig/browserctl/detectors.rbs
+++ b/sig/browserctl/detectors.rbs
@@ -1,0 +1,6 @@
+module Browserctl
+  module Detectors
+    CLOUDFLARE_SIGNALS: Array[String]
+    def self.cloudflare?: (untyped page) -> bool
+  end
+end

--- a/sig/browserctl/errors.rbs
+++ b/sig/browserctl/errors.rbs
@@ -1,0 +1,15 @@
+module Browserctl
+  class Error < StandardError
+    def self.default_code: () -> String
+    attr_reader code: String
+    def initialize: (?String? msg, ?code: String) -> void
+  end
+
+  class PageNotFound     < Error; def self.default_code: () -> String end
+  class SelectorNotFound < Error; def self.default_code: () -> String end
+  class RefNotFound      < Error; def self.default_code: () -> String end
+  class PathNotAllowed   < Error; def self.default_code: () -> String end
+  class DomainNotAllowed < Error; def self.default_code: () -> String end
+  class TimeoutError     < Error; def self.default_code: () -> String end
+  class KeyNotFound      < Error; def self.default_code: () -> String end
+end

--- a/sig/browserctl/errors.rbs
+++ b/sig/browserctl/errors.rbs
@@ -5,11 +5,31 @@ module Browserctl
     def initialize: (?String? msg, ?code: String) -> void
   end
 
-  class PageNotFound     < Error; def self.default_code: () -> String end
-  class SelectorNotFound < Error; def self.default_code: () -> String end
-  class RefNotFound      < Error; def self.default_code: () -> String end
-  class PathNotAllowed   < Error; def self.default_code: () -> String end
-  class DomainNotAllowed < Error; def self.default_code: () -> String end
-  class TimeoutError     < Error; def self.default_code: () -> String end
-  class KeyNotFound      < Error; def self.default_code: () -> String end
+  class PageNotFound < Error
+    def self.default_code: () -> String
+  end
+
+  class SelectorNotFound < Error
+    def self.default_code: () -> String
+  end
+
+  class RefNotFound < Error
+    def self.default_code: () -> String
+  end
+
+  class PathNotAllowed < Error
+    def self.default_code: () -> String
+  end
+
+  class DomainNotAllowed < Error
+    def self.default_code: () -> String
+  end
+
+  class TimeoutError < Error
+    def self.default_code: () -> String
+  end
+
+  class KeyNotFound < Error
+    def self.default_code: () -> String
+  end
 end

--- a/sig/browserctl/logger.rbs
+++ b/sig/browserctl/logger.rbs
@@ -1,0 +1,3 @@
+module Browserctl
+  def self.build_logger: (String level_name, ?log_path: String?) -> untyped
+end

--- a/sig/browserctl/recording.rbs
+++ b/sig/browserctl/recording.rbs
@@ -1,0 +1,10 @@
+module Browserctl
+  class Recording
+    def self.start: (String name) -> String
+    def self.stop: () -> String
+    def self.active: () -> String?
+    def self.append: (String cmd, **untyped params) -> void
+    def self.generate_workflow: (String name, ?output_path: String?) -> String
+    def self.path: () -> String
+  end
+end

--- a/sig/browserctl/server/command_dispatcher.rbs
+++ b/sig/browserctl/server/command_dispatcher.rbs
@@ -1,0 +1,11 @@
+module Browserctl
+  class CommandDispatcher
+    COMMAND_MAP: Hash[String, Symbol]
+    SCREENSHOT_DIR: String
+    SCREENSHOT_ROOTS: Array[String]
+    SCREENSHOT_EXTS: Array[String]
+
+    def initialize: (Hash[String, PageSession] pages, untyped browser, ?SnapshotBuilder snapshot_builder, ?global_mutex: Mutex) -> void
+    def dispatch: (Hash[Symbol, untyped] req) -> Hash[Symbol, untyped]
+  end
+end

--- a/sig/browserctl/server/idle_watcher.rbs
+++ b/sig/browserctl/server/idle_watcher.rbs
@@ -1,0 +1,6 @@
+module Browserctl
+  class IdleWatcher
+    def initialize: (^() -> Time last_used_fn) -> void
+    def watch: (untyped server) -> void
+  end
+end

--- a/sig/browserctl/server/snapshot_builder.rbs
+++ b/sig/browserctl/server/snapshot_builder.rbs
@@ -1,0 +1,6 @@
+module Browserctl
+  class SnapshotBuilder
+    def initialize: () -> void
+    def call: (untyped page) -> Array[Hash[Symbol, untyped]]
+  end
+end

--- a/spec/benchmarks/snapshot_bench.rb
+++ b/spec/benchmarks/snapshot_bench.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Usage: HEADLESS=true bundle exec ruby spec/benchmarks/snapshot_bench.rb
+#
+# Measures snapshot latency and ping throughput against a live daemon.
+
+require "benchmark"
+require_relative "../../lib/browserctl"
+
+ITERATIONS = 50
+PAGE_NAME  = "bench"
+
+client = Browserctl::Client.new
+client.open_page(PAGE_NAME, url: "https://example.com")
+
+puts "=== browserctl benchmark ==="
+puts "Ruby #{RUBY_VERSION}, #{ITERATIONS} iterations each\n\n"
+
+Benchmark.bm(20) do |x|
+  x.report("ping:") do
+    ITERATIONS.times { client.ping }
+  end
+
+  x.report("snapshot (ai):") do
+    ITERATIONS.times { client.snapshot(PAGE_NAME, format: "ai") }
+  end
+
+  x.report("snapshot (html):") do
+    ITERATIONS.times { client.snapshot(PAGE_NAME, format: "html") }
+  end
+
+  x.report("snapshot (diff):") do
+    ITERATIONS.times { client.snapshot(PAGE_NAME, format: "ai", diff: true) }
+  end
+end
+
+client.close_page(PAGE_NAME)
+puts "\nDone."

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -154,6 +154,23 @@ RSpec.describe Browserctl::CommandDispatcher do
       expect(res[:error]).to match(/invalid extension/)
     end
 
+    it "rejects a path outside the allowed directories" do
+      result = dispatcher.dispatch({ cmd: "screenshot", name: "main", path: "/etc/passwd" })
+      expect(result[:error]).to match(/outside allowed directory/)
+    end
+
+    it "rejects a path with an invalid extension" do
+      result = dispatcher.dispatch({ cmd: "screenshot", name: "main",
+                                     path: File.join(Dir.home, ".browserctl/screenshots/evil.sh") })
+      expect(result[:error]).to match(/invalid extension/)
+    end
+
+    it "rejects a path traversal attempt via .." do
+      result = dispatcher.dispatch({ cmd: "screenshot", name: "main",
+                                     path: File.join(Dir.home, ".browserctl/screenshots/../../../etc/crontab.png") })
+      expect(result[:error]).to match(/outside allowed directory/)
+    end
+
     it "accepts a valid path inside the allowed directory" do
       allowed = File.expand_path("~/.browserctl/screenshots/test.png")
       FileUtils.mkdir_p(File.dirname(allowed))

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Browserctl::CommandDispatcher do
 
     it "rejects paths outside the allowed screenshot directory" do
       res = dispatcher.dispatch({ cmd: "screenshot", name: "main",
-                                  path: "/tmp/../Users/nqhuy25/.ssh/authorized_keys" })
+                                  path: "/tmp/outside.png" })
       expect(res[:error]).to match(/outside allowed directory/)
     end
 
@@ -155,7 +155,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
 
     it "rejects a path outside the allowed directories" do
-      result = dispatcher.dispatch({ cmd: "screenshot", name: "main", path: "/etc/passwd" })
+      result = dispatcher.dispatch({ cmd: "screenshot", name: "main", path: "/etc/evil.png" })
       expect(result[:error]).to match(/outside allowed directory/)
     end
 

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -450,5 +450,25 @@ RSpec.describe Browserctl::CommandDispatcher do
         expect(res[:error]).to match(/no page named 'ghost'/)
       end
     end
+
+    describe "store / fetch commands" do
+      it "stores and retrieves a value" do
+        dispatcher.dispatch({ cmd: "store", key: "token", value: "abc123" })
+        result = dispatcher.dispatch({ cmd: "fetch", key: "token" })
+        expect(result).to eq({ ok: true, value: "abc123" })
+      end
+
+      it "returns an error for a missing key" do
+        result = dispatcher.dispatch({ cmd: "fetch", key: "missing" })
+        expect(result[:error]).to match(/key 'missing' not found/)
+        expect(result[:code]).to eq("key_not_found")
+      end
+
+      it "overwrites an existing key" do
+        dispatcher.dispatch({ cmd: "store", key: "x", value: "first" })
+        dispatcher.dispatch({ cmd: "store", key: "x", value: "second" })
+        expect(dispatcher.dispatch({ cmd: "fetch", key: "x" })[:value]).to eq("second")
+      end
+    end
   end
 end

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("browser")) }
 
-    after { Browserctl::PLUGIN_COMMANDS.clear }
+    after { Browserctl.instance_variable_set(:@plugin_commands, {}) }
 
     it "dispatches a registered plugin command" do
       Browserctl.register_command(:test_echo) do |_session, req|

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -356,6 +356,24 @@ RSpec.describe Browserctl::CommandDispatcher do
       dispatcher.dispatch({ cmd: "close_page", name: "temp" })
       expect(pages.key?("temp")).to be false
     end
+
+    it "includes a nonce in every snapshot response" do
+      result = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      expect(result[:nonce]).to be_a(String)
+      expect(result[:nonce].length).to eq(16)
+    end
+
+    it "returns a different nonce on each call" do
+      r1 = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      r2 = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      expect(r1[:nonce]).not_to eq(r2[:nonce])
+    end
+
+    it "includes a nonce in html format responses too" do
+      allow(page).to receive(:body).and_return("<html></html>")
+      result = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
+      expect(result[:nonce]).to be_a(String)
+    end
   end
 
   describe "#cmd_inspect" do

--- a/spec/unit/detectors_spec.rb
+++ b/spec/unit/detectors_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/detectors"
+
+RSpec.describe Browserctl::Detectors do
+  let(:page) { instance_double("Ferrum::Page") }
+
+  describe ".cloudflare?" do
+    it "returns false for a clean page" do
+      allow(page).to receive(:current_url).and_return("https://example.com/login")
+      allow(page).to receive(:body).and_return("<html><body>Login</body></html>")
+      expect(described_class.cloudflare?(page)).to be false
+    end
+
+    it "detects challenge-platform in URL" do
+      allow(page).to receive(:current_url).and_return("https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/b")
+      allow(page).to receive(:body).and_return("")
+      expect(described_class.cloudflare?(page)).to be true
+    end
+
+    it "detects cf-challenge-running in body" do
+      allow(page).to receive(:current_url).and_return("https://example.com")
+      allow(page).to receive(:body).and_return('<div class="cf-challenge-running"></div>')
+      expect(described_class.cloudflare?(page)).to be true
+    end
+
+    it "detects Just a moment... in body" do
+      allow(page).to receive(:current_url).and_return("https://example.com")
+      allow(page).to receive(:body).and_return("<title>Just a moment...</title>")
+      expect(described_class.cloudflare?(page)).to be true
+    end
+
+    it "detects cf_chl_opt in body" do
+      allow(page).to receive(:current_url).and_return("https://example.com")
+      allow(page).to receive(:body).and_return("window.cf_chl_opt={}")
+      expect(described_class.cloudflare?(page)).to be true
+    end
+  end
+end

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/errors"
+
+RSpec.describe Browserctl::Error do
+  it "has a code" do
+    err = described_class.new("something broke", code: "generic_error")
+    expect(err.code).to eq("generic_error")
+    expect(err.message).to eq("something broke")
+  end
+
+  it "defaults to its class default_code" do
+    err = Browserctl::PageNotFound.new("no page named 'main'")
+    expect(err.code).to eq("page_not_found")
+    expect(err.message).to eq("no page named 'main'")
+  end
+end
+
+RSpec.describe Browserctl::SelectorNotFound do
+  it "has code selector_not_found" do
+    expect(described_class.new("x").code).to eq("selector_not_found")
+  end
+end
+
+RSpec.describe Browserctl::RefNotFound do
+  it "has code ref_not_found" do
+    expect(described_class.new("x").code).to eq("ref_not_found")
+  end
+end
+
+RSpec.describe Browserctl::PathNotAllowed do
+  it "has code path_not_allowed" do
+    expect(described_class.new("x").code).to eq("path_not_allowed")
+  end
+end
+
+RSpec.describe Browserctl::DomainNotAllowed do
+  it "has code domain_not_allowed" do
+    expect(described_class.new("x").code).to eq("domain_not_allowed")
+  end
+end
+
+RSpec.describe Browserctl::TimeoutError do
+  it "has code timeout" do
+    expect(described_class.new("x").code).to eq("timeout")
+  end
+end
+
+RSpec.describe Browserctl::KeyNotFound do
+  it "has code key_not_found" do
+    expect(described_class.new("x").code).to eq("key_not_found")
+  end
+end

--- a/spec/unit/policy_spec.rb
+++ b/spec/unit/policy_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe Browserctl::Policy do
       it "blocks a URL that only prefix-matches (not a real subdomain)" do
         expect(described_class.allowed_navigation?("https://notexample.com/")).to be false
       end
+
+      it "allows uppercase domain (case-insensitive match)" do
+        expect(described_class.allowed_navigation?("https://EXAMPLE.COM/page")).to be true
+      end
+
+      it "allows mixed-case subdomain" do
+        expect(described_class.allowed_navigation?("https://App.Example.Com/login")).to be true
+      end
+
+      it "blocks uppercase unlisted domain" do
+        expect(described_class.allowed_navigation?("https://EVIL.COM/phish")).to be false
+      end
     end
 
     context "when URL is invalid" do

--- a/spec/unit/policy_spec.rb
+++ b/spec/unit/policy_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/policy"
+
+RSpec.describe Browserctl::Policy do
+  describe ".allowed_navigation?" do
+    context "when BROWSERCTL_ALLOWED_DOMAINS is not set" do
+      before { ENV.delete("BROWSERCTL_ALLOWED_DOMAINS") }
+
+      it "allows any URL" do
+        expect(described_class.allowed_navigation?("https://evil.com/steal")).to be true
+      end
+    end
+
+    context "when BROWSERCTL_ALLOWED_DOMAINS=example.com,staging.example.com" do
+      before { ENV["BROWSERCTL_ALLOWED_DOMAINS"] = "example.com,staging.example.com" }
+      after  { ENV.delete("BROWSERCTL_ALLOWED_DOMAINS") }
+
+      it "allows exact domain match" do
+        expect(described_class.allowed_navigation?("https://example.com/page")).to be true
+      end
+
+      it "allows subdomain of listed domain" do
+        expect(described_class.allowed_navigation?("https://app.example.com/login")).to be true
+      end
+
+      it "allows the second listed domain" do
+        expect(described_class.allowed_navigation?("https://staging.example.com/")).to be true
+      end
+
+      it "blocks an unlisted domain" do
+        expect(described_class.allowed_navigation?("https://evil.com/phish")).to be false
+      end
+
+      it "blocks a URL that only prefix-matches (not a real subdomain)" do
+        expect(described_class.allowed_navigation?("https://notexample.com/")).to be false
+      end
+    end
+
+    context "when URL is invalid" do
+      before { ENV["BROWSERCTL_ALLOWED_DOMAINS"] = "example.com" }
+      after  { ENV.delete("BROWSERCTL_ALLOWED_DOMAINS") }
+
+      it "returns false for garbage input" do
+        expect(described_class.allowed_navigation?("not a url")).to be false
+      end
+    end
+  end
+end

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -79,7 +79,9 @@ RSpec.describe Browserctl::Runner do
       allow_any_instance_of(Browserctl::WorkflowDefinition).to receive(:call).and_return([])
       expect { runner.run_workflow("the_internet/login") }.not_to raise_error
     ensure
-      Browserctl::REGISTRY.delete("the_internet/login")
+      Browserctl.instance_variable_get(:@registry_mutex).synchronize do
+        Browserctl.instance_variable_get(:@registry).delete("the_internet/login")
+      end
     end
 
     it "raises for names with null bytes" do

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -167,32 +167,34 @@ RSpec.describe Browserctl::WorkflowContext do
   describe "#store and #fetch" do
     subject(:ctx) { described_class.new({}, client) }
 
-    it "stores and retrieves a value by key" do
-      ctx.store(:code, "abc123")
+    it "delegates store to the wire client" do
+      allow(client).to receive(:store).with("code", "abc123").and_return({ ok: true })
+      expect(ctx.store(:code, "abc123")).to eq("abc123")
+    end
+
+    it "delegates fetch to the wire client and returns the value" do
+      allow(client).to receive(:fetch).with("code").and_return({ ok: true, value: "abc123" })
       expect(ctx.fetch(:code)).to eq("abc123")
     end
 
-    it "allows overwriting a stored value" do
-      ctx.store(:x, 1)
-      ctx.store(:x, 2)
-      expect(ctx.fetch(:x)).to eq(2)
+    it "raises WorkflowError when fetch returns an error" do
+      allow(client).to receive(:fetch).with("missing")
+                                      .and_return({ error: "key 'missing' not found", code: "key_not_found" })
+      expect { ctx.fetch(:missing) }.to raise_error(Browserctl::WorkflowError, /missing/)
     end
 
-    it "raises KeyError for a missing key" do
-      expect { ctx.fetch(:missing) }.to raise_error(KeyError, /missing/)
+    it "raises WorkflowError when store returns an error" do
+      allow(client).to receive(:store).and_return({ error: "store failed" })
+      expect { ctx.store(:x, 1) }.to raise_error(Browserctl::WorkflowError, /store failed/)
     end
 
     it "store keys do not conflict with param names" do
       ctx_with_param = described_class.new({ email: "a@b.com" }, client)
+      allow(client).to receive(:store).with("email", "override").and_return({ ok: true })
+      allow(client).to receive(:fetch).with("email").and_return({ ok: true, value: "override" })
       ctx_with_param.store(:email, "override")
       expect(ctx_with_param.fetch(:email)).to eq("override")
       expect(ctx_with_param.email).to eq("a@b.com")
-    end
-
-    it "does not persist values across separate context instances" do
-      ctx.store(:val, 42)
-      fresh_ctx = described_class.new({}, client)
-      expect { fresh_ctx.fetch(:val) }.to raise_error(KeyError)
     end
   end
 

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe Browserctl::WorkflowDefinition do
 end
 
 RSpec.describe "compose" do
-  before { Browserctl::REGISTRY.clear }
-  after  { Browserctl::REGISTRY.clear }
+  before { Browserctl.instance_variable_set(:@registry, {}) }
+  after  { Browserctl.instance_variable_set(:@registry, {}) }
 
   it "inlines steps from another workflow" do
     Browserctl.workflow "shared" do
@@ -118,7 +118,7 @@ RSpec.describe "compose" do
       step("own step") { nil }
     end
 
-    defn = Browserctl::REGISTRY["main"]
+    defn = Browserctl.lookup_workflow("main")
     expect(defn.steps.map(&:label)).to eq(["shared step", "own step"])
   end
 
@@ -140,7 +140,7 @@ RSpec.describe "compose" do
       step("b") { order << :b }
     end
     client = double("client", ping: { ok: true })
-    Browserctl::REGISTRY["extended"].call({}, client)
+    Browserctl.lookup_workflow("extended").call({}, client)
     expect(order).to eq(%i[a b])
   end
 
@@ -156,7 +156,7 @@ RSpec.describe "compose" do
       compose "second"
       step("own") { nil }
     end
-    labels = Browserctl::REGISTRY["combined"].steps.map(&:label)
+    labels = Browserctl.lookup_workflow("combined").steps.map(&:label)
     expect(labels).to eq(%w[f1 f2 own])
   end
 end
@@ -210,10 +210,12 @@ RSpec.describe Browserctl::WorkflowContext do
 
   describe "#invoke circular detection" do
     it "raises WorkflowError on circular invocation" do
-      Browserctl::REGISTRY["loop_a"] = instance_double(
-        Browserctl::WorkflowDefinition,
-        call: nil
-      )
+      Browserctl.instance_variable_get(:@registry_mutex).synchronize do
+        Browserctl.instance_variable_get(:@registry)["loop_a"] = instance_double(
+          Browserctl::WorkflowDefinition,
+          call: nil
+        )
+      end
 
       ctx = described_class.new({}, client)
       ctx.instance_variable_set(:@invoke_stack, ["loop_a"])


### PR DESCRIPTION
## Summary

- **Error hierarchy** — `Browserctl::Error` and typed subclasses (`PageNotFound`, `DomainNotAllowed`, `KeyNotFound`, etc.) with machine-readable `code:` fields in wire responses
- **Thread-safe registries** — replaced mutable `REGISTRY`/`PLUGIN_COMMANDS` constants with mutex-protected `Browserctl.lookup_workflow` / `Browserctl.lookup_plugin_command` accessors
- **`Browserctl::Detectors`** — extracted Cloudflare challenge detection out of `CommandDispatcher` into its own module with unit tests
- **Domain navigation policy** — `BROWSERCTL_ALLOWED_DOMAINS` env var gates `goto` navigation; exact + subdomain matching with `domain_not_allowed` error code
- **`store`/`fetch` wire commands** — promoted from in-process `WorkflowContext` hash to daemon-scoped KV store; `Client#store` / `Client#fetch` added; `WorkflowContext` delegates to wire
- **`CommandDispatcher` split** — 318-line class broken into 7 focused handler modules (`PageLifecycle`, `Navigation`, `Observation`, `Cookies`, `Hitl`, `DevTools`, `DaemonControl`); dispatcher reduced to ~80 lines
- **Snapshot nonce** — every `snapshot` response includes a server-generated 16-char hex `nonce` as a content boundary marker; documented in `api-stability.md`
- **Security audit** — socket `0600` chmod verified; screenshot path boundary tests added (path traversal, `/etc/passwd`, invalid extension)
- **RBS coverage** — complete signatures for `CommandDispatcher`, `SnapshotBuilder`, `IdleWatcher`, `Recording`, `Logger`, `Detectors`, `Errors`
- **YARD docs** — `@param`/`@return` on `dispatch`, `Detectors.cloudflare?`, `Policy.allowed_navigation?`, `Error`

## Test plan

- [ ] `bundle exec rspec spec/unit/` — 157 examples, 0 failures
- [ ] All new modules covered: `errors_spec`, `detectors_spec`, `policy_spec`, store/fetch in `command_dispatcher_spec`
- [ ] Screenshot path boundary specs pass (path traversal, bad extension, `/etc/passwd`)
- [ ] Snapshot nonce present and unique across calls