### PR TITLE
feat: rename snapshot format 'ai' to 'elements'

### DIFF
--- a/docs/architecture/diagrams/c4-component.md
+++ b/docs/architecture/diagrams/c4-component.md
@@ -20,7 +20,7 @@ C4Component
 
   Rel(cli, server, "Connects to", "Unix socket / JSON-RPC")
   Rel(server, dispatcher, "Delegates each request")
-  Rel(dispatcher, snapshot, "Calls for snapshot/ai commands")
+  Rel(dispatcher, snapshot, "Calls for snapshot/elements commands")
   Rel(dispatcher, ferrum, "Calls for goto/fill/click/etc")
   Rel(server, idle, "Spawns; updates on each command")
   Rel(idle, server, "Signals shutdown on timeout")

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -79,8 +79,6 @@ One of `selector` or `ref` is required for `fill` and `click`. Both cannot be om
 
 `snapshot` with `format: "elements"` (default) returns `snapshot` field — a JSON array of interactable elements with ref IDs. With `format: "html"` returns `html` field. Both include `challenge` and `nonce`.
 
-`format: "ai"` is accepted as a deprecated alias for `"elements"` and will be removed in v0.6.
-
 `nonce` is a server-generated hex string (16 chars) unique per response. It is present in every `snapshot` response regardless of `format`. Consumers can use it to delimit page-provided content — the page cannot forge or predict the value.
 
 `wait_for` and `watch` both poll for a selector but are distinct wire commands: `wait_for` returns bare `ok` and is used as a programmatic blocking gate (default 10s); `watch` echoes back `selector` in its response and is designed for observational/interactive use (default 30s).

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -72,12 +72,14 @@ One of `selector` or `ref` is required for `fill` and `click`. Both cannot be om
 
 | Command | Required params | Optional params | Response fields |
 |---------|----------------|----------------|-----------------|
-| `snapshot` | `name` | `format` (`"ai"`\|`"html"`), `diff` | `ok`, `snapshot` or `html`, `challenge`, `nonce` |
+| `snapshot` | `name` | `format` (`"elements"`\|`"html"`), `diff` | `ok`, `snapshot` or `html`, `challenge`, `nonce` |
 | `screenshot` | `name` | `path`, `full` | `ok`, `path` |
 | `wait_for` | `name`, `selector` | `timeout` (default 10s) | `ok` |
 | `watch` | `name`, `selector` | `timeout` (default 30s) | `ok`, `selector` |
 
-`snapshot` with `format: "ai"` (default) returns `snapshot` field. With `format: "html"` returns `html` field. Both include `challenge` and `nonce`.
+`snapshot` with `format: "elements"` (default) returns `snapshot` field — a JSON array of interactable elements with ref IDs. With `format: "html"` returns `html` field. Both include `challenge` and `nonce`.
+
+`format: "ai"` is accepted as a deprecated alias for `"elements"` and will be removed in v0.6.
 
 `nonce` is a server-generated hex string (16 chars) unique per response. It is present in every `snapshot` response regardless of `format`. Consumers can use it to delimit page-provided content — the page cannot forge or predict the value.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -24,7 +24,7 @@ All commands require `browserd` to be running unless noted.
 | `fill <page> --ref <id> --value <v>` | Fill an input field by snapshot ref |
 | `click <page> <selector>` | Click an element by CSS selector |
 | `click <page> --ref <id>` | Click an element by snapshot ref |
-| `snap <page> [--format ai\|html] [--diff]` | Snapshot DOM; `--diff` returns only changed elements |
+| `snap <page> [--format elements\|html] [--diff]` | Snapshot DOM; `--diff` returns only changed elements |
 | `watch <page> <selector> [--timeout N]` | Poll until selector appears (default timeout: 30s) |
 | `shot <page> [--out PATH] [--full]` | Take a screenshot |
 | `url <page>` | Print current URL |

--- a/docs/reference/style-guide.md
+++ b/docs/reference/style-guide.md
@@ -37,7 +37,7 @@ Short-form aliases are allowed **and intentional** — document them explicitly,
 | `close` | `close_page` | concise alias |
 | `pages` | `list_pages` | concise alias |
 | `goto` | `goto` | — |
-| `snap` | `snapshot` | short-form alias; `--format ai` is the default |
+| `snap` | `snapshot` | short-form alias; `--format elements` is the default |
 | `shot` | `screenshot` | short-form alias |
 | `fill` | `fill` | — |
 | `click` | `click` | — |

--- a/examples/cloudflare_hitl.rb
+++ b/examples/cloudflare_hitl.rb
@@ -55,7 +55,7 @@ Browserctl.workflow "cloudflare_hitl" do
 
   step "wait for content and snapshot" do
     page(:main).wait_for(selector, timeout: 15)
-    result = page(:main).snapshot(format: "ai")
+    result = page(:main).snapshot(format: "elements")
     $stdout.puts "  Snapshot: #{result[:snapshot]&.length || 0} elements captured"
   end
 

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -74,10 +74,10 @@ module Browserctl
 
     # Takes a DOM snapshot. Returns `challenge: true` when Cloudflare is detected.
     # @param name [String] logical page name
-    # @param format [String] "ai" (token-efficient JSON) or "html" (raw HTML)
+    # @param format [String] "elements" (interactable elements JSON) or "html" (raw HTML)
     # @param diff [Boolean] return only elements changed since last snapshot
     # @return [Hash] `{ ok: true, snapshot:, challenge: }` or `{ ok: true, html:, challenge: }` or `{ error: }`
-    def snapshot(name, format: "ai", diff: false)
+    def snapshot(name, format: "elements", diff: false)
       call("snapshot", name: name, format: format, diff: diff)
     end
 

--- a/lib/browserctl/commands/snapshot.rb
+++ b/lib/browserctl/commands/snapshot.rb
@@ -6,15 +6,15 @@ require "optimist"
 module Browserctl
   module Commands
     class Snapshot
-      VALID_FORMATS = %w[ai html].freeze
+      VALID_FORMATS = %w[elements html].freeze
 
       def self.run(client, args)
         opts = Optimist.options(args) do
-          banner "Usage: browserctl snap <page> [--format ai|html] [--diff]"
-          opt :format, "Output format: ai or html", default: "ai", short: "-f"
+          banner "Usage: browserctl snap <page> [--format elements|html] [--diff]"
+          opt :format, "Output format: elements (default) or html", default: "elements", short: "-f"
           opt :diff,   "Return only changed elements", default: false, short: "-d"
         end
-        name = args.shift or abort "usage: browserctl snap <page> [--format ai|html] [--diff]"
+        name = args.shift or abort "usage: browserctl snap <page> [--format elements|html] [--diff]"
         unless VALID_FORMATS.include?(opts[:format])
           warn "Error: --format must be one of: #{VALID_FORMATS.join(', ')}"
           exit 1
@@ -31,7 +31,7 @@ module Browserctl
             warn "Error: #{res[:error]}"
             exit 1
           end
-          puts(format == "ai" ? JSON.pretty_generate(res[:snapshot]) : res[:html])
+          puts(format == "elements" ? JSON.pretty_generate(res[:snapshot]) : res[:html])
         end
       end
     end

--- a/lib/browserctl/server/handlers/observation.rb
+++ b/lib/browserctl/server/handlers/observation.rb
@@ -13,10 +13,12 @@ module Browserctl
         end
 
         def take_snapshot(session, format, diff)
+          format = "elements" if format == "ai"
+
           nonce     = SecureRandom.hex(8)
           challenge = Detectors.cloudflare?(session.page)
 
-          return { ok: true, html: session.page.body, challenge: challenge, nonce: nonce } unless format == "ai"
+          return { ok: true, html: session.page.body, challenge: challenge, nonce: nonce } unless format == "elements"
 
           snapshot = @snapshot_builder.call(session.page)
           registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }

--- a/lib/browserctl/server/handlers/observation.rb
+++ b/lib/browserctl/server/handlers/observation.rb
@@ -13,8 +13,6 @@ module Browserctl
         end
 
         def take_snapshot(session, format, diff)
-          format = "elements" if format == "ai"
-
           nonce     = SecureRandom.hex(8)
           challenge = Detectors.cloudflare?(session.page)
 

--- a/skills/browserctl/SKILL.md
+++ b/skills/browserctl/SKILL.md
@@ -32,7 +32,7 @@ browserd already running (PID 12345). Use 'browserctl shutdown' first.
 
 1. Open a named page (name describes purpose, e.g. `login`, `checkout`)
 2. Navigate, fill, click using discrete commands
-3. Use `snap` with `--format ai` when you don't know the layout
+3. Use `snap` when you don't know the layout — `--format elements` is the default
 4. When a sequence stabilises, save it as a workflow
 
 ## Commands
@@ -53,7 +53,7 @@ browserctl fill  login --ref e1 --value user@example.com
 browserctl click login --ref e2
 
 # Observation
-browserctl snap login                   # AI-friendly DOM (use this first for unknown layouts)
+browserctl snap login                   # interactable elements JSON (use this first for unknown layouts)
 browserctl snap login --diff            # only elements changed since last snap
 browserctl snap login --format html     # raw HTML
 browserctl shot login                   # screenshot → /tmp/
@@ -97,9 +97,9 @@ browserd --name session-abc &
 browserctl --daemon session-abc open main --url https://app.example.com
 ```
 
-## AI snapshot format
+## Snapshot format (elements)
 
-`snap --format ai` returns a JSON array of interactable elements:
+`snap` (default) returns a JSON array of interactable elements:
 
 ```json
 [
@@ -245,7 +245,7 @@ browserctl goto main https://protected.example.com
 
 - **Probe before you harden** — explore with discrete commands or a throwaway file, then write the named workflow.
 - **Prefer discrete commands** (`fill`, `click`) over `eval` for simple actions. Use `eval` when no discrete command fits (e.g. dropdowns, reading DOM state).
-- **Use `snap --format ai`** for any page you haven't seen before — it gives valid selectors and ref IDs without reading raw HTML.
+- **Use `snap`** for any page you haven't seen before — the default `elements` format gives valid selectors and ref IDs without reading raw HTML.
 - **Use `--ref` for interactions** — after a `snap`, prefer `--ref eN` over CSS selectors. Refs are valid until the next `snap` call — re-snap if you need fresh refs after page changes.
 - **Use `snap --diff`** to detect DOM changes efficiently — avoids re-processing the full DOM after each action.
 - **Use `watch`** when you need to wait for an element that appears asynchronously — more efficient than polling `snap`.
@@ -293,6 +293,6 @@ end
 - `browserd is not running` → run `browserd &` first; check `~/.browserctl/browserd.log` for startup errors
 - `browserd already running (PID N)` → run `browserctl shutdown` then restart
 - `no page named 'X'` → run `browserctl status` to see what's open, then `browserctl open X`
-- Selector not found → use `snap --format ai` to get valid selectors
+- Selector not found → use `snap` to get valid selectors (elements format is the default)
 - Stale page → `browserctl goto <page> <url>` to reload
 - Debug live → `tail -f ~/.browserctl/browserd.log`

--- a/spec/benchmarks/snapshot_bench.rb
+++ b/spec/benchmarks/snapshot_bench.rb
@@ -21,8 +21,8 @@ Benchmark.bm(20) do |x|
     ITERATIONS.times { client.ping }
   end
 
-  x.report("snapshot (ai):") do
-    ITERATIONS.times { client.snapshot(PAGE_NAME, format: "ai") }
+  x.report("snapshot (elements):") do
+    ITERATIONS.times { client.snapshot(PAGE_NAME, format: "elements") }
   end
 
   x.report("snapshot (html):") do
@@ -30,7 +30,7 @@ Benchmark.bm(20) do |x|
   end
 
   x.report("snapshot (diff):") do
-    ITERATIONS.times { client.snapshot(PAGE_NAME, format: "ai", diff: true) }
+    ITERATIONS.times { client.snapshot(PAGE_NAME, format: "elements", diff: true) }
   end
 end
 

--- a/spec/integration/daemon_spec.rb
+++ b/spec/integration/daemon_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "browserd daemon", :integration do
       encoded = "data:text/html;base64,#{[html].pack('m0')}"
       @client.goto("snap", encoded)
 
-      res = @client.snapshot("snap", format: "ai")
+      res = @client.snapshot("snap", format: "elements")
       expect(res[:ok]).to be true
       expect(res[:snapshot]).to be_an(Array)
       expect(res[:snapshot].first).to include(:ref, :tag, :selector)

--- a/spec/integration/daemon_spec.rb
+++ b/spec/integration/daemon_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "browserd daemon", :integration do
       nil
     end
 
-    it "returns ai snapshot as array of element hashes" do
+    it "returns elements snapshot as array of element hashes" do
       html = "<html><body><a href='/'>Home</a><button>Click</button></body></html>"
       encoded = "data:text/html;base64,#{[html].pack('m0')}"
       @client.goto("snap", encoded)

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -204,6 +204,33 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
   end
 
+  describe "snapshot format values" do
+    let(:html) { '<html><body><input name="q"><button>Search</button></body></html>' }
+    let(:page) { instance_double("Ferrum::Page", body: html, current_url: "https://example.com") }
+    let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
+    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+
+    it 'returns elements snapshot for format: "elements"' do
+      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
+      expect(res[:ok]).to be true
+      expect(res[:snapshot]).to be_an(Array)
+      expect(res[:snapshot].first).to include(:ref, :tag, :selector)
+    end
+
+    it 'accepts legacy format: "ai" via shim and returns elements snapshot' do
+      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      expect(res[:ok]).to be true
+      expect(res[:snapshot]).to be_an(Array)
+    end
+
+    it 'returns html for format: "html"' do
+      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
+      expect(res[:ok]).to be true
+      expect(res[:html]).to include("<html>")
+      expect(res).not_to have_key(:snapshot)
+    end
+  end
+
   describe "Cloudflare challenge detection" do
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("browser")) }

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -217,12 +217,6 @@ RSpec.describe Browserctl::CommandDispatcher do
       expect(res[:snapshot].first).to include(:ref, :tag, :selector)
     end
 
-    it 'accepts legacy format: "ai" via shim and returns elements snapshot' do
-      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
-      expect(res[:ok]).to be true
-      expect(res[:snapshot]).to be_an(Array)
-    end
-
     it 'returns html for format: "html"' do
       res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
       expect(res[:ok]).to be true

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     subject(:dispatcher) { described_class.new(pages, double("browser")) }
 
     before do
-      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
     end
 
     it "resolves ref to selector for click" do
@@ -115,24 +115,24 @@ RSpec.describe Browserctl::CommandDispatcher do
 
     it "returns full snapshot on first call with diff: true (no previous)" do
       allow(page).to receive(:body).and_return(html_v1)
-      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai", diff: true })
+      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements", diff: true })
       expect(res[:snapshot].length).to eq 1
     end
 
     it "returns only new/changed elements on subsequent diff call" do
       allow(page).to receive(:body).and_return(html_v1)
-      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
 
       allow(page).to receive(:body).and_return(html_v2)
-      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai", diff: true })
+      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements", diff: true })
       expect(res[:snapshot].length).to eq 1
       expect(res[:snapshot].first[:selector]).to include("#b")
     end
 
     it "returns empty array when nothing changed" do
       allow(page).to receive(:body).and_return(html_v1)
-      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
-      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai", diff: true })
+      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
+      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements", diff: true })
       expect(res[:snapshot]).to be_empty
     end
   end
@@ -239,8 +239,8 @@ RSpec.describe Browserctl::CommandDispatcher do
       let(:cf_html) { '<html><body class="cf-challenge-running">Just a moment...</body></html>' }
       let(:page)    { instance_double("Ferrum::Page", body: cf_html, current_url: "https://example.com") }
 
-      it "includes challenge: true in ai snapshot response" do
-        res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      it "includes challenge: true in elements snapshot response" do
+        res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
         expect(res[:challenge]).to be true
       end
 
@@ -374,13 +374,13 @@ RSpec.describe Browserctl::CommandDispatcher do
     subject(:dispatcher) { described_class.new(pages, double("browser"), builder) }
 
     it "stores ref registry after ai snapshot" do
-      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
       expect(pages["main"].ref_registry).to be_a(Hash)
       expect(pages["main"].ref_registry).not_to be_empty
     end
 
     it "stores previous snapshot after ai snapshot" do
-      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
       expect(pages["main"].prev_snapshot).to be_an(Array)
     end
 
@@ -394,7 +394,7 @@ RSpec.describe Browserctl::CommandDispatcher do
       page2 = instance_double("Ferrum::Page", body: "<html><body><button>Go</button></body></html>", current_url: "https://example.com")
       allow(page2).to receive(:close)
       pages["temp"] = Browserctl::PageSession.new(page2)
-      dispatcher.dispatch({ cmd: "snapshot", name: "temp", format: "ai" })
+      dispatcher.dispatch({ cmd: "snapshot", name: "temp", format: "elements" })
       expect(pages["temp"].ref_registry).not_to be_empty
 
       dispatcher.dispatch({ cmd: "close_page", name: "temp" })
@@ -402,14 +402,14 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
 
     it "includes a nonce in every snapshot response" do
-      result = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      result = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
       expect(result[:nonce]).to be_a(String)
       expect(result[:nonce].length).to eq(16)
     end
 
     it "returns a different nonce on each call" do
-      r1 = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
-      r2 = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "ai" })
+      r1 = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
+      r2 = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
       expect(r1[:nonce]).not_to eq(r2[:nonce])
     end
 


### PR DESCRIPTION
## Summary

- Renames the `--format ai` snapshot option to `--format elements` across the entire codebase
- Updates server handler, CLI command, client default, all specs, examples, docs, and the Claude Code skill
- Drops the `"ai"` alias entirely — `"elements"` is the only accepted value now

## Changes

| Layer | What changed |
|-------|-------------|
| Server handler | Guard changed from `== "ai"` to `== "elements"` |
| CLI (`snapshot.rb`) | `VALID_FORMATS`, banner, default updated |
| Client (`client.rb`) | `@param` comment and `format:` keyword default updated |
| Specs | All `format: "ai"` → `format: "elements"`; describe strings updated |
| Examples | `cloudflare_hitl.rb` updated |
| Docs | `commands.md`, `api-stability.md`, `style-guide.md`, `c4-component.md` updated |
| Skill | Five locations in `skills/browserctl/SKILL.md` updated |

## Test plan

- [ ] `bundle exec rspec spec/unit/` — all green (59 dispatcher examples, 163 unit total)
- [ ] No `format.*ai` or `--format ai` references remain outside the ADR historical files