### PR TITLE
fix: use DOM native click() to fire JS-only event listeners

### DIFF
--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -56,7 +56,10 @@ module Browserctl
           el = page.at_css(selector)
           return { error: "selector not found: #{selector}" } unless el
 
-          el.click
+          # Use the DOM native click() so JS-only event listeners fire.
+          # CDP mouse simulation (el.click) dispatches events at screen coordinates
+          # and misses handlers on elements with no form submit chain.
+          el.evaluate("this.click()")
           { ok: true }
         end
 

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
 
     it "resolves ref to selector for click" do
-      allow(page).to receive(:at_css).and_return(double("el", click: nil))
+      allow(page).to receive(:at_css).and_return(double("el", evaluate: nil))
       res = dispatcher.dispatch({ cmd: "click", name: "main", ref: "e2" })
       expect(res[:ok]).to be true
     end


### PR DESCRIPTION
## Summary

- `browserctl click` was using Ferrum's `el.click` which dispatches `Input.dispatchMouseEvent` via CDP — routing events through the browser's coordinate-based hit-testing pipeline
- Pure JS click handlers on elements without a form submit chain were not reliably triggered this way (confirmed bug: practicetestautomation.com login form)
- Switched to `el.evaluate("this.click()")` which calls the DOM native `.click()` directly on the element via `Runtime.callFunctionOn`, equivalent to the confirmed working workaround

## Test plan

- [x] Unit tests updated to stub `evaluate` on the element double instead of `click`
- [x] All 162 unit examples pass
- [x] Rubocop clean
- [x] RBS validation passes
- [x] Pre-push hook (rspec full suite) passes — 175 examples, 0 failures