### PR TITLE
fix: fill replaces existing input value instead of appending

### DIFF
--- a/docs/guides/smoke-testing.md
+++ b/docs/guides/smoke-testing.md
@@ -1,6 +1,9 @@
-# Smoke Testing with the-internet.herokuapp.com
+# Smoke Testing with Practice Sites
 
-[the-internet.herokuapp.com](https://the-internet.herokuapp.com) is a publicly available test site purpose-built for browser automation practice. browserctl ships with ready-to-run examples covering its most common scenarios.
+browserctl ships with ready-to-run examples against two publicly available test sites purpose-built for browser automation practice.
+
+- **[the-internet.herokuapp.com](https://the-internet.herokuapp.com)** — a wide-ranging sandbox covering common UI patterns (login, checkboxes, dropdowns, dynamic loading, DOM mutation)
+- **[practicetestautomation.com](https://practicetestautomation.com)** — a focused site with a clean login sandbox and dedicated exception-reproduction scenarios
 
 ## Running the examples
 
@@ -8,12 +11,17 @@
 # Start the daemon with a visible browser window
 browserd --headed &
 
-# Run any example directly by file path
+# the-internet examples
 browserctl run examples/the_internet/login.rb
 browserctl run examples/the_internet/checkboxes.rb
 browserctl run examples/the_internet/dropdown.rb
 browserctl run examples/the_internet/dynamic_loading.rb
 browserctl run examples/the_internet/add_remove_elements.rb
+
+# practicetestautomation.com examples
+browserctl run examples/practice_test_automation/login.rb
+browserctl run examples/practice_test_automation/login_negative.rb
+browserctl run examples/practice_test_automation/exceptions.rb
 
 browserctl shutdown
 ```
@@ -130,6 +138,64 @@ Clicks "Add Element" three times, asserts three delete buttons are present, remo
 
 ---
 
+---
+
+## practicetestautomation.com examples
+
+### `practice_test_automation/login.rb` — Login and Logout
+
+Covers: `fill`, `click`, `url`, `evaluate`
+
+Navigates to the login sandbox, fills in the public test credentials, submits the form, asserts the redirect to the success page and the heading text, then clicks the logout link and verifies the return to the login page.
+
+**Test credentials:** `student` / `Password123`
+
+```
+  [ok]   open login page
+  [ok]   fill and submit credentials
+  [ok]   verify successful login
+  [ok]   logout and verify
+```
+
+---
+
+### `practice_test_automation/login_negative.rb` — Invalid Credentials
+
+Covers: `fill`, `click`, `evaluate`
+
+Submits an invalid username (keeping the correct password) and asserts the "Your username is invalid!" error message, then submits an invalid password (keeping the correct username) and asserts the "Your password is invalid!" error message.
+
+Demonstrates negative-path testing: verifying that error states are correctly surfaced rather than silently failing.
+
+```
+  [ok]   open login page
+  [ok]   submit invalid username — expect username error
+  [ok]   submit invalid password — expect password error
+```
+
+---
+
+### `practice_test_automation/exceptions.rb` — Dynamic Elements and Disabled Fields
+
+Covers: `click`, `fill`, `evaluate`, `watch`
+
+Demonstrates three patterns that trip up naive automation scripts:
+
+1. **Disabled input (InvalidElementStateException avoidance)** — clicks the Edit button to enable a read-only field before filling it.
+2. **Dynamically added element (NoSuchElementException avoidance)** — clicks Add and uses `watch` to poll until row 2 appears after its 5-second server-side delay.
+3. **Confirmation message** — asserts the transient "Row 2 was added" text before it fades.
+
+```
+  [ok]   open test exceptions page
+  [ok]   enable row 1 input and edit it (InvalidElementStateException avoidance)
+  [ok]   click Add and wait for row 2 to appear (NoSuchElementException avoidance)
+  [ok]   verify confirmation message
+  [ok]   type into row 2 input and save
+  [ok]   remove row 2
+```
+
+---
+
 ## Patterns demonstrated
 
 | Pattern | Where it appears |
@@ -140,5 +206,7 @@ Clicks "Add Element" three times, asserts three delete buttons are present, remo
 | Assert current URL | `login.rb` — `page(:main).url` |
 | Read DOM state via JS | `checkboxes.rb`, `dropdown.rb`, `add_remove_elements.rb` — `client.evaluate("main", expression)[:result]` |
 | Set DOM state via JS | `dropdown.rb` — `client.evaluate("main", "document.querySelector('select#dropdown').value = '1'")` |
-| Wait for async element | `dynamic_loading.rb` — `page(:main).wait_for(selector, timeout:)` |
+| Wait for async element (short) | `dynamic_loading.rb` — `page(:main).wait_for(selector, timeout:)` |
+| Poll for async element (long) | `exceptions.rb` — `page(:main).watch(selector, timeout:)` |
+| Negative-path assertion | `login_negative.rb` — assert error message text on failed login |
 | Assert with message | All examples — `assert condition, "message"` |

--- a/examples/practice_test_automation/exceptions.rb
+++ b/examples/practice_test_automation/exceptions.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+Browserctl.workflow "practice_test_automation/exceptions" do
+  desc "Test exceptions: wait for dynamic row, edit disabled field, remove row"
+
+  param :base_url,        default: "https://practicetestautomation.com"
+  param :screenshot_path, default: File.expand_path(".browserctl/screenshots/practice_test_automation_exceptions.png")
+
+  step "open test exceptions page" do
+    client.open_page("main", url: "#{base_url}/practice-test-exceptions/")
+  end
+
+  step "enable row 1 input and edit it (InvalidElementStateException avoidance)" do
+    # Input starts disabled — click Edit to enable it first
+    page(:main).click("button#edit_btn")
+    page(:main).fill("#row1 input.input-field", "Pasta")
+    value = client.evaluate("main", "document.querySelector('#row1 input.input-field').value")[:result]
+    assert value == "Pasta", "expected row 1 value 'Pasta', got: #{value.inspect}"
+  end
+
+  step "click Add and wait for row 2 to appear (NoSuchElementException avoidance)" do
+    page(:main).click("button#add_btn")
+    # Row 2 is injected after a 5-second loading delay — watch polls until it appears
+    page(:main).watch("#row2", timeout: 10)
+    visible = client.evaluate("main", "document.querySelector('#row2')?.style?.display !== 'none'")[:result]
+    assert visible, "expected row 2 to be visible after loading"
+  end
+
+  step "verify confirmation message" do
+    text = client.evaluate("main", "document.querySelector('#confirmation')?.innerText?.trim()")[:result]
+    assert text == "Row 2 was added", "expected confirmation 'Row 2 was added', got: #{text.inspect}"
+  end
+
+  step "type into row 2 input and save" do
+    page(:main).fill("#row2 input.input-field", "Sushi")
+    value = client.evaluate("main", "document.querySelector('#row2 input.input-field').value")[:result]
+    assert value == "Sushi", "expected row 2 value 'Sushi', got: #{value.inspect}"
+    page(:main).click("#row2 button[name='Save']")
+    page(:main).screenshot(path: screenshot_path)
+  end
+
+  step "remove row 2" do
+    page(:main).click("button#remove_btn")
+    # Remove hides row 2 (display:none) rather than deleting it from the DOM
+    hidden = client.evaluate("main", "document.querySelector('#row2').style.display === 'none'")[:result]
+    assert hidden, "expected row 2 to be hidden after removal"
+  end
+end

--- a/examples/practice_test_automation/login.rb
+++ b/examples/practice_test_automation/login.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Browserctl.workflow "practice_test_automation/login" do
+  desc "Login page: fill credentials, verify success, logout"
+
+  param :username,        default: "student"
+  param :password,        default: "Password123", secret: true
+  param :base_url,        default: "https://practicetestautomation.com"
+  param :screenshot_path, default: File.expand_path(".browserctl/screenshots/practice_test_automation_login.png")
+
+  step "open login page" do
+    client.open_page("main", url: "#{base_url}/practice-test-login/")
+  end
+
+  step "fill and submit credentials" do
+    page(:main).fill("input#username", username)
+    page(:main).fill("input#password", password)
+    page(:main).click("button#submit")
+  end
+
+  step "verify successful login" do
+    assert page(:main).url.include?("logged-in-successfully"), "expected redirect to logged-in-successfully"
+    heading = client.evaluate("main", "document.querySelector('h1.post-title')?.innerText?.trim()")[:result]
+    assert heading == "Logged In Successfully", "expected success heading, got: #{heading.inspect}"
+    page(:main).screenshot(path: screenshot_path)
+  end
+
+  step "logout and verify" do
+    page(:main).click("a.wp-block-button__link")
+    assert page(:main).url.include?("practice-test-login"), "expected redirect back to login page"
+  end
+end

--- a/examples/practice_test_automation/login_negative.rb
+++ b/examples/practice_test_automation/login_negative.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+Browserctl.workflow "practice_test_automation/login_negative" do
+  desc "Login page: invalid username and invalid password each show the correct error"
+
+  param :base_url, default: "https://practicetestautomation.com"
+  param :screenshot_path,
+        default: File.expand_path(".browserctl/screenshots/practice_test_automation_login_negative.png")
+
+  step "open login page" do
+    client.open_page("main", url: "#{base_url}/practice-test-login/")
+  end
+
+  step "submit invalid username — expect username error" do
+    page(:main).fill("input#username", "incorrectUser")
+    page(:main).fill("input#password", "Password123")
+    page(:main).click("button#submit")
+    error = client.evaluate("main", "document.querySelector('#error')?.innerText?.trim()")[:result]
+    assert error&.include?("Your username is invalid!"), "expected username error, got: #{error.inspect}"
+  end
+
+  step "submit invalid password — expect password error" do
+    page(:main).fill("input#username", "student")
+    page(:main).fill("input#password", "wrongPassword")
+    page(:main).click("button#submit")
+    error = client.evaluate("main", "document.querySelector('#error')?.innerText?.trim()")[:result]
+    assert error&.include?("Your password is invalid!"), "expected password error, got: #{error.inspect}"
+    page(:main).screenshot(path: screenshot_path)
+  end
+end

--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -48,6 +48,7 @@ module Browserctl
           return { error: "selector not found: #{selector}" } unless el
 
           el.focus
+          el.evaluate("this.select()")
           el.type(value)
           { ok: true }
         end

--- a/spec/integration/daemon_spec.rb
+++ b/spec/integration/daemon_spec.rb
@@ -103,6 +103,20 @@ RSpec.describe "browserd daemon", :integration do
       clicked = @client.evaluate("form", "document.getElementById('go').dataset.clicked")
       expect(clicked[:result]).to eq("1")
     end
+
+    it "replaces existing input value rather than appending" do
+      html = <<~HTML
+        <html><body>
+          <input id="name" type="text" value="existing">
+        </body></html>
+      HTML
+      encoded = "data:text/html;base64,#{[html].pack('m0')}"
+      @client.goto("form", encoded)
+
+      expect(@client.fill("form", "input#name", "replacement")[:ok]).to be true
+      val = @client.evaluate("form", "document.getElementById('name').value")
+      expect(val[:result]).to eq("replacement")
+    end
   end
 
   describe "snapshot" do

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
 
     it "resolves ref to selector for fill" do
-      el = double("el", focus: nil, type: nil)
+      el = double("el", focus: nil, evaluate: nil, type: nil)
       allow(page).to receive(:at_css).and_return(el)
       res = dispatcher.dispatch({ cmd: "fill", name: "main", ref: "e1", value: "test@example.com" })
       expect(res[:ok]).to be true


### PR DESCRIPTION
## Summary

- `fill` called Ferrum's `Node#type` which types at cursor position, so filling a pre-populated field appended to the existing value (e.g. `"Pizza"` + `"Pasta"` → `"PastaPizza"`)
- Fix: call `this.select()` on the element before typing so the new value always replaces existing content — matching the behaviour of Playwright, Capybara, and Ferrum's own fill method
- Adds an integration test covering the replace-not-append contract
- Ships the `practicetestautomation.com` example set that surfaced the bug

## Changed files

| File | Change |
|------|--------|
| `lib/browserctl/server/handlers/navigation.rb` | Add `el.evaluate("this.select()")` before `el.type(value)` in `type_into` |
| `spec/unit/command_dispatcher_spec.rb` | Update element double to include `evaluate` stub |
| `spec/integration/daemon_spec.rb` | Add "replaces existing input value rather than appending" test |
| `examples/practice_test_automation/` | New login, login_negative, exceptions workflows (removed JS workaround now that fill is fixed) |
| `docs/guides/smoke-testing.md` | Document the new practicetestautomation.com examples |

## Test plan

- [ ] Unit: `bundle exec rspec spec/unit/command_dispatcher_spec.rb`
- [ ] Integration (requires Chrome): `bundle exec rspec spec/integration/daemon_spec.rb`
- [ ] Live: `bundle exec browserctl run examples/practice_test_automation/exceptions.rb` — "enable row 1 input and edit it" step previously failed with `"PastaPizza"`, now passes with `"Pasta"`