### PR TITLE
fix: correct initial checkbox state assertion

### DIFF
--- a/examples/test_automation_practices/checkboxes.rb
+++ b/examples/test_automation_practices/checkboxes.rb
@@ -10,10 +10,10 @@ Browserctl.workflow "test_automation_practices/checkboxes" do
     client.open_page("main", url: "#{base_url}/#/checkboxes")
   end
 
-  step "read initial state — all unchecked" do
+  step "read initial state — checkbox 2 pre-checked" do
     js = "[1,2,3].map(i => document.querySelector(`[data-test=\"checkbox-checkbox${i}\"]`)?.checked)"
     states = client.evaluate("main", js)[:result]
-    assert states.none?, "expected all unchecked initially, got: #{states.inspect}"
+    assert states == [false, true, false], "expected initial state [false, true, false], got: #{states.inspect}"
   end
 
   step "toggle checkbox 1 on" do


### PR DESCRIPTION
The checkboxes page initialises checkbox 2 as checked by default, so the actual initial state is `[false, true, false]`, not all-unchecked.

Fixes the CI failure in https://github.com/patrick204nqh/browserctl/actions/runs/24944852961/job/73044448157