### PR TITLE
fix: notifications workflow — exclude container from counts, use evaluate for dismiss

### DIFF
--- a/examples/test_automation_practices/notifications.rb
+++ b/examples/test_automation_practices/notifications.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Individual notification items have data-test="notification-{id}".
+# The wrapper has data-test="notification-container" — excluded from counts below.
+NOTIFICATION_ITEMS_JS = <<~JS.freeze
+  document.querySelectorAll('[data-test^="notification-"]:not([data-test="notification-container"])').length
+JS
+
 Browserctl.workflow "test_automation_practices/notifications" do
   desc "Notifications: trigger success, error, and info toasts — assert each appears then dismiss"
 
@@ -13,24 +19,18 @@ Browserctl.workflow "test_automation_practices/notifications" do
 
   step "trigger success notification and verify" do
     page(:main).click("[data-test='add-success']")
-    # notification IDs are dynamic; match any notification element by prefix
-    page(:main).wait_for("[data-test^='notification-']", timeout: 5)
-    count = client.evaluate(
-      "main",
-      "document.querySelectorAll('[data-test^=\"notification-\"]').length"
-    )[:result]
-    assert count >= 1, "expected at least one notification, got: #{count}"
+    page(:main).wait_for("[data-test^='notification-']:not([data-test='notification-container'])", timeout: 5)
+    count = client.evaluate("main", NOTIFICATION_ITEMS_JS)[:result]
+    assert count == 1, "expected 1 notification, got: #{count}"
   end
 
-  step "dismiss notification and verify container is empty" do
-    page(:main).click("[data-test^='close-notification-']")
+  step "dismiss notification and verify none remain" do
+    # Use evaluate to click the close button — more reliable than CSS prefix selectors
+    client.evaluate("main", "document.querySelector('[data-test^=\"close-notification-\"]')?.click()")
     deadline = Time.now + 5
     remaining = nil
     loop do
-      remaining = client.evaluate(
-        "main",
-        "document.querySelectorAll('[data-test^=\"notification-\"]').length"
-      )[:result]
+      remaining = client.evaluate("main", NOTIFICATION_ITEMS_JS)[:result]
       break if remaining.zero? || Time.now > deadline
 
       sleep 0.2
@@ -41,11 +41,8 @@ Browserctl.workflow "test_automation_practices/notifications" do
   step "trigger error and info notifications together" do
     page(:main).click("[data-test='add-error']")
     page(:main).click("[data-test='add-info']")
-    page(:main).wait_for("[data-test^='notification-']", timeout: 5)
-    count = client.evaluate(
-      "main",
-      "document.querySelectorAll('[data-test^=\"notification-\"]').length"
-    )[:result]
+    page(:main).wait_for("[data-test^='notification-']:not([data-test='notification-container'])", timeout: 5)
+    count = client.evaluate("main", NOTIFICATION_ITEMS_JS)[:result]
     assert count == 2, "expected 2 notifications (error + info), got: #{count}"
     page(:main).screenshot(path: screenshot_path)
   end

--- a/examples/test_automation_practices/notifications.rb
+++ b/examples/test_automation_practices/notifications.rb
@@ -2,7 +2,7 @@
 
 # Individual notification items have data-test="notification-{id}".
 # The wrapper has data-test="notification-container" — excluded from counts below.
-NOTIFICATION_ITEMS_JS = <<~JS.freeze
+NOTIFICATION_ITEMS_JS = <<~JS
   document.querySelectorAll('[data-test^="notification-"]:not([data-test="notification-container"])').length
 JS
 


### PR DESCRIPTION
Two bugs in `notifications.rb` caught by CI:

1. **Wrong count selector** — `[data-test^="notification-"]` also matches `notification-container` (the wrapper div, always present), inflating counts by 1. Fixed with `:not([data-test="notification-container"])` and extracted into a constant.

2. **Unreliable dismiss click** — `page(:main).click("[data-test^='close-notification-']")` with a prefix selector was not reliably targeting the close button. Switched to `evaluate` + `querySelector` which handles the dynamic ID correctly.

Fixes the CI failure in https://github.com/patrick204nqh/browserctl/actions/runs/24945013354/job/73044884027