### PR TITLE
fix: dismiss on-load notifications before asserting counts

### DIFF
--- a/examples/test_automation_practices/notifications.rb
+++ b/examples/test_automation_practices/notifications.rb
@@ -15,6 +15,11 @@ Browserctl.workflow "test_automation_practices/notifications" do
 
   step "open notifications page" do
     client.open_page("main", url: "#{base_url}/#/notifications")
+    # Dismiss any notifications the app shows on load so counts start at zero
+    client.evaluate("main", <<~JS)
+      document.querySelectorAll('[data-test^="close-notification-"]').forEach(b => b.click())
+    JS
+    sleep 0.3
   end
 
   step "trigger success notification and verify" do


### PR DESCRIPTION
The notifications page renders a notification on load, so clicking `add-success` gives a count of 2 instead of the expected 1.

Fix: bulk-dismiss any existing notifications via `forEach` immediately after page open, so all count assertions start from a known-zero state.

Fixes the CI failure in https://github.com/patrick204nqh/browserctl/actions/runs/24945106020/job/73045123786