### PR TITLE
feat(v0.6): page_focus command, integration specs, and doc polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Every browser automation tool restarts the browser when your script ends. That m
 
 ```bash
 browserd &                                               # start the daemon (headless)
-browserctl open login --url https://example.com/login
-browserctl snap login                                    # AI-friendly JSON snapshot with ref IDs
+browserctl page open login --url https://example.com/login
+browserctl snapshot login                                # AI-friendly JSON snapshot with ref IDs
 browserctl fill login --ref e1 --value me@example.com   # interact by ref, no selectors needed
 browserctl click login --ref e2
-browserctl shutdown
+browserctl daemon stop
 ```
 
 ---
@@ -71,10 +71,10 @@ gem install browserctl
 browserd &
 
 # 3. Open a named page
-browserctl open main --url https://moatazeldebsy.github.io/test-automation-practices/#/auth
+browserctl page open main --url https://moatazeldebsy.github.io/test-automation-practices/#/auth
 
 # 4. Snapshot the page — get AI-friendly JSON with ref IDs
-browserctl snap main
+browserctl snapshot main
 
 # 5. Interact using refs
 browserctl fill  main --ref e1 --value admin
@@ -83,10 +83,10 @@ browserctl click main --ref e3
 
 # 6. Observe
 browserctl url  main
-browserctl snap main --diff   # only what changed
+browserctl snapshot main --diff   # only what changed
 
 # 7. Done
-browserctl shutdown
+browserctl daemon stop
 ```
 
 → [Full Getting Started guide](docs/getting-started.md)
@@ -178,7 +178,7 @@ Start multiple named instances for agent isolation:
 ```bash
 browserd --name agent-a &
 browserd --name agent-b &
-browserctl --daemon agent-a open main --url https://app.example.com
+browserctl --daemon agent-a page open main --url https://app.example.com
 ```
 
 The daemon shuts itself down after 30 minutes of inactivity.

--- a/demo/login.tape
+++ b/demo/login.tape
@@ -31,13 +31,13 @@ Enter
 Sleep 5s
 
 # ---------- open the login page ----------
-Type "bundle exec browserctl open main --url https://moatazeldebsy.github.io/test-automation-practices/#/auth"
+Type "bundle exec browserctl page open main --url https://moatazeldebsy.github.io/test-automation-practices/#/auth"
 Sleep 400ms
 Enter
 Sleep 4s
 
 # ---------- snapshot ----------
-Type "bundle exec browserctl snap main"
+Type "bundle exec browserctl snapshot main"
 Sleep 400ms
 Enter
 Sleep 4s
@@ -59,19 +59,19 @@ Enter
 Sleep 4s
 
 # ---------- snapshot after login ----------
-Type "bundle exec browserctl snap main"
+Type "bundle exec browserctl snapshot main"
 Sleep 400ms
 Enter
 Sleep 4s
 
 # ---------- screenshot ----------
-Type "bundle exec browserctl shot main --out docs/assets/demo_auth.png"
+Type "bundle exec browserctl screenshot main --out docs/assets/demo_auth.png"
 Sleep 400ms
 Enter
 Sleep 3s
 
 # ---------- tear down ----------
-Type "bundle exec browserctl shutdown"
+Type "bundle exec browserctl daemon stop"
 Sleep 400ms
 Enter
 Sleep 3s

--- a/docs/architecture/decisions/0003-named-page-handles.md
+++ b/docs/architecture/decisions/0003-named-page-handles.md
@@ -27,9 +27,9 @@ Pages are identified by a caller-provided string name (e.g., `login`, `dashboard
 ## Consequences
 
 ### Positive
-- Workflow scripts are self-documenting — `page(:login).goto(url)` reads clearly
+- Workflow scripts are self-documenting — `page(:login).navigate(url)` reads clearly
 - Named pages survive across CLI invocations — the name is the stable reference
-- `list_pages` command gives a human-readable view of what's open
+- `page list` command gives a human-readable view of what's open
 
 ### Negative
 - Name collision is the caller's responsibility — opening `login` twice replaces the first

--- a/docs/concepts/hitl.md
+++ b/docs/concepts/hitl.md
@@ -30,15 +30,15 @@ This is not a workaround for a limitation. It is the intended workflow for tasks
 
 Knowing *when* to pause is as important as being able to pause. browserctl builds detection directly into the browsing primitives.
 
-Both `goto` and `snap` include a `challenge` field in their response:
+Both `navigate` and `snapshot` include a `challenge` field in their response:
 
 ```ruby
-res = client.goto("main", url)
+res = client.navigate("main", url)
 res[:challenge]   # => true when Cloudflare interstitial is detected
 ```
 
 ```bash
-browserctl snap main   # JSON includes "challenge": true when blocked
+browserctl snapshot main   # JSON includes "challenge": true when blocked
 ```
 
 When `challenge` is true, the workflow decides what to do: pause and wait, retry the navigation, or abort.
@@ -67,7 +67,7 @@ Cloudflare is just the first detector. The detection layer is designed to grow �
 
 The philosophy is: **surface the signal, let the workflow decide.** browserctl doesn't try to auto-solve challenges (fragile, constantly broken by vendor updates, often illegal). It identifies that the situation requires attention and hands it off cleanly.
 
-A `register_detector` plugin API is planned for v0.6 — third-party detectors will be registerable without modifying the core. For now, additional detection logic can be added via the plugin system using `register_command`.
+A `register_detector` plugin API is planned for v0.7 — third-party detectors will be registerable without modifying the core. For now, additional detection logic can be added via the plugin system using `register_command`.
 
 ---
 
@@ -77,12 +77,12 @@ After a human solves a Cloudflare challenge, the browser holds a `cf_clearance` 
 
 ```bash
 # after solving the challenge:
-browserctl cookies main | jq '.cookies[] | select(.name == "cf_clearance")'
+browserctl cookie list main | jq '.cookies[] | select(.name == "cf_clearance")'
 
 # in a new session:
-browserctl open main
-browserctl set-cookie main cf_clearance "xyz..." ".example.com"
-browserctl goto main https://example.com   # passes without a challenge
+browserctl page open main
+browserctl cookie set main cf_clearance "xyz..." --domain .example.com
+browserctl navigate main https://example.com   # passes without a challenge
 ```
 
 `cf_clearance` cookies expire (typically 30 minutes to a few hours). When they age out, Cloudflare will serve a new challenge.
@@ -95,7 +95,7 @@ The pattern in code — detect, pause, poll for resolution, continue:
 
 ```ruby
 step "navigate to protected page" do
-  res = client.goto("main", target_url)
+  res = client.navigate("main", target_url)
 
   if res[:challenge]
     puts "⚠  Challenge detected — solve it in the browser, then: browserctl resume main"
@@ -111,7 +111,7 @@ step "navigate to protected page" do
 end
 
 step "continue as normal" do
-  page(:main).wait_for("[data-test=main-content]", timeout: 15)
+  page(:main).wait("[data-test=main-content]", timeout: 15)
   # ...
 end
 ```

--- a/docs/concepts/sessions-and-pages.md
+++ b/docs/concepts/sessions-and-pages.md
@@ -21,7 +21,7 @@ browserd --headed # starts with a visible window
 
 The daemon listens on a Unix socket at `~/.browserctl/browserd.sock`. Every `browserctl` command sends a JSON-RPC message over that socket and prints the result. The browser never closes between commands — it waits.
 
-The daemon shuts itself down after 30 minutes of inactivity to avoid orphan processes. `browserctl shutdown` stops it immediately.
+The daemon shuts itself down after 30 minutes of inactivity to avoid orphan processes. `browserctl daemon stop` stops it immediately.
 
 ---
 
@@ -30,10 +30,10 @@ The daemon shuts itself down after 30 minutes of inactivity to avoid orphan proc
 Inside the daemon, each browser tab is a **named page**. You give it a name when you open it, and you use that name for every subsequent command.
 
 ```bash
-browserctl open login --url https://app.example.com/login
+browserctl page open login --url https://app.example.com/login
 browserctl fill login "input[name=email]" me@example.com
-browserctl snap login
-browserctl close login
+browserctl snapshot login
+browserctl page close login
 ```
 
 Names are arbitrary strings — `login`, `dashboard`, `checkout`, `agent-session-42`. Naming matters for two reasons:
@@ -43,12 +43,12 @@ Names are arbitrary strings — `login`, `dashboard`, `checkout`, `agent-session
 **2. Resumability.** After a pause, after a retry, after any interruption, the name is the stable reference. You don't track a tab ID or an index. You track a name you chose.
 
 ```bash
-browserctl pages   # lists all open named pages and their current URLs
+browserctl page list   # lists all open named pages and their current URLs
 ```
 
 ---
 
-## Session state
+## In-memory session state
 
 Everything the browser accumulates — cookies, localStorage, authenticated sessions, form input, open tabs — stays alive as long as the daemon runs. A later command picks up exactly where an earlier one left off.
 
@@ -63,6 +63,72 @@ No re-authentication. No cookie injection. The session is just alive.
 
 ---
 
+## Saving and restoring sessions
+
+In-memory state is lost when the daemon stops. `session save` captures everything — open pages, cookies, and localStorage — to a plain JSON bundle on disk. `session load` restores it into a running daemon, including re-opening every saved page at its saved URL.
+
+```bash
+# After logging in and navigating to the right state:
+browserctl session save github_work
+
+# Next time, on a fresh daemon:
+browserd &
+browserctl session load github_work
+# → pages are back, cookies are restored, localStorage is seeded
+```
+
+Session files live in `~/.browserctl/sessions/<name>/` as readable JSON:
+
+```
+~/.browserctl/sessions/github_work/
+  metadata.json       # page names + URLs + timestamps
+  cookies.json        # all cookies from the shared daemon jar
+  local_storage.json  # localStorage by origin
+```
+
+To share a session or move it to another machine, export it as a zip:
+
+```bash
+browserctl session export github_work ~/sessions/github_work.zip
+browserctl session import ~/sessions/github_work.zip
+```
+
+List and manage sessions:
+
+```bash
+browserctl session list
+browserctl session delete github_work
+```
+
+---
+
+## localStorage and sessionStorage
+
+`storage get/set/export/import/delete` give direct access to the page's Web Storage without injecting custom scripts.
+
+```bash
+browserctl storage get  main user_id
+browserctl storage set  main theme dark
+browserctl storage export main /tmp/storage.json
+browserctl storage import main /tmp/storage.json
+browserctl storage delete main
+```
+
+Use `--store session` for sessionStorage (default is `local`):
+
+```bash
+browserctl storage get main session_token --store session
+```
+
+Inside a workflow, `storage_get` and `storage_set` are available directly on the page proxy:
+
+```ruby
+token = page(:main).storage_get("auth_token")
+page(:main).storage_set("theme", "dark")
+```
+
+---
+
 ## Multi-agent isolation
 
 When you need multiple independent browser sessions running in parallel — separate agents, separate users, separate contexts — run multiple named daemon instances:
@@ -71,8 +137,17 @@ When you need multiple independent browser sessions running in parallel — sepa
 browserd --name agent-a &
 browserd --name agent-b &
 
-browserctl --daemon agent-a open main --url https://app.example.com
-browserctl --daemon agent-b open main --url https://staging.example.com
+browserctl --daemon agent-a page open main --url https://app.example.com
+browserctl --daemon agent-b page open main --url https://staging.example.com
 ```
 
-Each daemon manages its own Chrome instance with its own cookie jar. Commands routed to `agent-a` never affect `agent-b`. This is the mechanism for agent fleet use cases where you need N isolated sessions running simultaneously.
+Each daemon manages its own Chrome instance with its own cookie jar. Commands routed to `agent-a` never affect `agent-b`.
+
+If you start a second unnamed daemon while the first is running, it auto-picks the next available slot rather than aborting:
+
+```bash
+browserd &   # starts as "default"
+browserd &   # default slot taken — starts as "d1", prints connection hint
+```
+
+Use `browserctl daemon list` to see all running instances.

--- a/docs/concepts/snapshots-and-refs.md
+++ b/docs/concepts/snapshots-and-refs.md
@@ -14,10 +14,10 @@ browserctl uses a different model: **refs**.
 
 ## The snapshot
 
-`browserctl snap <page>` inspects the live page and returns a compact JSON array of every interactable element — inputs, buttons, links, selects, textareas. Static elements that cannot be acted on are omitted.
+`browserctl snapshot <page>` inspects the live page and returns a compact JSON array of every interactable element — inputs, buttons, links, selects, textareas. Static elements that cannot be acted on are omitted.
 
 ```bash
-browserctl snap login
+browserctl snapshot login
 ```
 
 ```json
@@ -81,11 +81,11 @@ Refs are valid until the next `snap` call. Every snapshot assigns refs from scra
 An agent workflow looks like this:
 
 ```
-1. snap login           → receive JSON with refs
+1. snapshot login           → receive JSON with refs
 2. identify e1 as the email field (by tag, name, placeholder)
 3. fill login --ref e1  → no selector reasoning required
 4. click login --ref e3 → submit
-5. snap login           → observe the result
+5. snapshot login           → observe the result
 ```
 
 The model sees semantics, not structure. The selector is there in the JSON if needed, but in practice the ref + metadata is enough to act correctly.
@@ -97,12 +97,12 @@ The model sees semantics, not structure. The selector is there in the JSON if ne
 After the first snapshot, subsequent snapshots can return only the elements that changed since the last one:
 
 ```bash
-browserctl snap login --diff
+browserctl snapshot login --diff
 ```
 
 This is useful in two situations:
 
-**Async updates.** After clicking a button that triggers an API call, `snap --diff` tells you exactly which elements appeared or changed — a loading spinner becoming a success message, a table row added, a disabled button becoming enabled. You don't have to diff the full page yourself.
+**Async updates.** After clicking a button that triggers an API call, `snapshot --diff` tells you exactly which elements appeared or changed — a loading spinner becoming a success message, a table row added, a disabled button becoming enabled. You don't have to diff the full page yourself.
 
 **Token efficiency.** If the page has 80 elements and only 3 changed after an action, there's no reason to re-read all 80. The diff surfaces just the signal.
 
@@ -139,7 +139,7 @@ The easiest fix: take the `selector` value from the snapshot JSON for that ref a
 When a model needs to understand page structure rather than interact with specific elements, pass `--format html`:
 
 ```bash
-browserctl snap login --format html
+browserctl snapshot login --format html
 ```
 
 This returns the full page HTML. Useful for reading content, understanding layout, or extracting information. For interaction, use the default JSON format.
@@ -148,7 +148,7 @@ This returns the full page HTML. Useful for reading content, understanding layou
 
 ## Cloudflare challenge signals
 
-Both `snap` and `goto` include a `challenge` field in their response when a Cloudflare interstitial is detected on the page:
+Both `snapshot` and `navigate` include a `challenge` field in their response when a Cloudflare interstitial is detected on the page:
 
 ```json
 { "challenge": true, ... }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,8 +47,8 @@ browserd --headed &
 Confirm it's running:
 
 ```bash
-browserctl ping
-# → {"ok":true,"pid":12345,"protocol_version":"1"}
+browserctl daemon ping
+# → {"ok":true,"pid":12345,"protocol_version":"2"}
 ```
 
 ---
@@ -58,7 +58,7 @@ browserctl ping
 Open a browser tab and give it a name:
 
 ```bash
-browserctl open main --url https://example.com
+browserctl page open main --url https://example.com
 ```
 
 The name (`main`) is what you'll use to address this tab in every subsequent command. Call it anything — `login`, `dashboard`, `session-1`.
@@ -70,7 +70,7 @@ The name (`main`) is what you'll use to address this tab in every subsequent com
 Snapshot the page to see what's on it:
 
 ```bash
-browserctl snap main
+browserctl snapshot main
 ```
 
 You'll get a compact JSON array of every interactable element on the page, each with a short ref ID:
@@ -96,13 +96,13 @@ These ref IDs are how you interact with elements without writing CSS selectors.
 Navigate to a different URL on the same named page:
 
 ```bash
-browserctl goto main https://the-internet.herokuapp.com/login
+browserctl navigate main https://the-internet.herokuapp.com/login
 ```
 
 Snapshot again to discover the form fields:
 
 ```bash
-browserctl snap main
+browserctl snapshot main
 ```
 
 Fill and submit using refs:
@@ -126,13 +126,13 @@ browserctl url main
 Take a screenshot:
 
 ```bash
-browserctl shot main --out /tmp/after-login.png --full
+browserctl screenshot main --out /tmp/after-login.png --full
 ```
 
-Snap again to see what changed — use `--diff` to get only the elements that are different from the last snapshot:
+Snapshot again to see what changed — use `--diff` to get only the elements that are different from the last snapshot:
 
 ```bash
-browserctl snap main --diff
+browserctl snapshot main --diff
 ```
 
 ---
@@ -140,7 +140,7 @@ browserctl snap main --diff
 ## 6. Shut down
 
 ```bash
-browserctl shutdown
+browserctl daemon stop
 ```
 
 The daemon stops and the browser closes. Your session state is gone — next time you'll start fresh.

--- a/docs/guides/handling-challenges.md
+++ b/docs/guides/handling-challenges.md
@@ -15,9 +15,9 @@ For the concepts behind HITL, see [Human-in-the-Loop](../concepts/hitl.md).
 browserd --headed &
 
 # Run the example
-browserctl run examples/cloudflare_hitl.rb --url https://nopecha.com/demo/cloudflare
+browserctl workflow run examples/cloudflare_hitl.rb --url https://nopecha.com/demo/cloudflare
 
-browserctl shutdown
+browserctl daemon stop
 ```
 
 When the challenge fires, the terminal pauses:
@@ -48,7 +48,7 @@ The workflow unblocks and continues:
 
 ## How challenge detection works
 
-`goto` and `snapshot` inspect the page body for known Cloudflare signals and include a `challenge:` boolean in their response:
+`navigate` and `snapshot` inspect the page body for known Cloudflare signals and include a `challenge:` boolean in their response:
 
 | Signal | Meaning |
 |--------|---------|
@@ -59,7 +59,7 @@ The workflow unblocks and continues:
 | URL contains `challenge-platform` | Challenge platform redirect |
 
 ```ruby
-res = client.goto("main", url)
+res = client.navigate("main", url)
 res[:challenge]   # => true when any signal is present
 ```
 
@@ -69,7 +69,7 @@ res[:challenge]   # => true when any signal is present
 
 ```ruby
 step "navigate to target URL" do
-  res = client.goto("main", url)
+  res = client.navigate("main", url)
 
   if res[:challenge]
     client.pause("main")
@@ -93,16 +93,16 @@ end
 After solving a challenge, the browser holds a `cf_clearance` cookie. Capture it to skip re-solving in future sessions:
 
 ```bash
-browserctl cookies main | jq '.cookies[] | select(.name == "cf_clearance")'
+browserctl cookie list main | jq '.cookies[] | select(.name == "cf_clearance")'
 # → { "name": "cf_clearance", "value": "xyz...", "domain": ".example.com", "path": "/" }
 ```
 
 Restore it in a new session:
 
 ```bash
-browserctl open main
-browserctl set-cookie main cf_clearance "xyz..." ".example.com"
-browserctl goto main https://example.com   # no challenge
+browserctl page open main
+browserctl cookie set main cf_clearance "xyz..." --domain .example.com
+browserctl navigate main https://example.com   # no challenge
 ```
 
 Or from Ruby:
@@ -118,7 +118,7 @@ client.set_cookie("main", "cf_clearance", "xyz...", ".example.com")
 ## Adapting to your own URL
 
 ```bash
-browserctl run examples/cloudflare_hitl.rb --url https://your-protected-site.com
+browserctl workflow run examples/cloudflare_hitl.rb --url https://your-protected-site.com
 ```
 
 Because headed Chrome is a real browser, many Cloudflare zones pass silently without showing a widget. The `if res[:challenge]` branch is a no-op in that case and automation continues normally.

--- a/docs/guides/smoke-testing.md
+++ b/docs/guides/smoke-testing.md
@@ -12,21 +12,21 @@ browserctl ships with ready-to-run examples against two publicly available test 
 browserd --headed &
 
 # the-internet examples
-browserctl run examples/the_internet/login.rb
-browserctl run examples/the_internet/checkboxes.rb
-browserctl run examples/the_internet/dropdown.rb
-browserctl run examples/the_internet/dynamic_loading.rb
-browserctl run examples/the_internet/add_remove_elements.rb
+browserctl workflow run examples/the_internet/login.rb
+browserctl workflow run examples/the_internet/checkboxes.rb
+browserctl workflow run examples/the_internet/dropdown.rb
+browserctl workflow run examples/the_internet/dynamic_loading.rb
+browserctl workflow run examples/the_internet/add_remove_elements.rb
 
 # test-automation-practices examples
-browserctl run examples/test_automation_practices/login.rb
-browserctl run examples/test_automation_practices/login_negative.rb
-browserctl run examples/test_automation_practices/dynamic_elements.rb
-browserctl run examples/test_automation_practices/checkboxes.rb
-browserctl run examples/test_automation_practices/notifications.rb
-browserctl run examples/test_automation_practices/key_press.rb
+browserctl workflow run examples/test_automation_practices/login.rb
+browserctl workflow run examples/test_automation_practices/login_negative.rb
+browserctl workflow run examples/test_automation_practices/dynamic_elements.rb
+browserctl workflow run examples/test_automation_practices/checkboxes.rb
+browserctl workflow run examples/test_automation_practices/notifications.rb
+browserctl workflow run examples/test_automation_practices/key_press.rb
 
-browserctl shutdown
+browserctl daemon stop
 ```
 
 Expected output for the login example:
@@ -48,7 +48,7 @@ Target: `https://moatazeldebsy.github.io/test-automation-practices` — a self-h
 
 ### `test_automation_practices/login.rb` — Login and Logout
 
-Covers: `fill`, `click`, `wait_for`, `evaluate`
+Covers: `fill`, `click`, `wait`, `evaluate`
 
 Fills the public test credentials into the auth form, submits, waits for the success element to appear, then clicks logout and verifies the login button reappears.
 
@@ -67,7 +67,7 @@ Fills the public test credentials into the auth form, submits, waits for the suc
 
 ### `test_automation_practices/login_negative.rb` — Invalid Credentials
 
-Covers: `fill`, `click`, `wait_for`, `evaluate`
+Covers: `fill`, `click`, `wait`, `evaluate`
 
 Submits wrong credentials and asserts the error element appears while no success element is present. Demonstrates negative-path testing.
 
@@ -83,9 +83,9 @@ Submits wrong credentials and asserts the error element appears while no success
 
 ### `test_automation_practices/dynamic_elements.rb` — Dynamic Content Loading
 
-Covers: `click`, `watch`, `wait_for`, `evaluate`
+Covers: `click`, `wait`, `wait`, `evaluate`
 
-Asserts no dynamic items exist before triggering a reload, clicks the reload button, uses `watch` to poll until items appear after a built-in network delay, then toggles hidden content on and verifies it renders.
+Asserts no dynamic items exist before triggering a reload, clicks the reload button, uses `wait` to poll until items appear after a built-in network delay, then toggles hidden content on and verifies it renders.
 
 ```
   [ok]   open dynamic elements page
@@ -119,7 +119,7 @@ Reads initial state (all unchecked), toggles one checkbox individually, then use
 
 ### `test_automation_practices/notifications.rb` — Toast Notifications
 
-Covers: `click`, `wait_for`, `evaluate`
+Covers: `click`, `wait`, `evaluate`
 
 Triggers a success notification and waits for it using a `data-test` attribute prefix selector (`[data-test^="notification-"]`), dismisses it, then triggers error and info notifications simultaneously and verifies both appear.
 
@@ -206,11 +206,11 @@ Asserts the default dropdown has no selection, then selects Option 1 and Option 
 
 ### `the_internet/dynamic_loading.rb` — Dynamic Loading
 
-Covers: `click`, `wait_for`, `evaluate`
+Covers: `click`, `wait`, `evaluate`
 
 Verifies the finish element is hidden before clicking Start, then clicks the Start button and waits up to 10 seconds for `#finish h4` to appear, asserting its text is `"Hello World!"`.
 
-This example demonstrates the `wait_for` command — useful any time a page renders content asynchronously.
+This example demonstrates the `wait` command — useful any time a page renders content asynchronously.
 
 ```
   [ok]   open dynamic loading page
@@ -249,8 +249,8 @@ Clicks "Add Element" three times, asserts three delete buttons are present, remo
 | Read DOM state via JS | `checkboxes.rb`, `dropdown.rb`, `add_remove_elements.rb` — `client.evaluate("main", expression)[:result]` |
 | Set DOM state via JS | `dropdown.rb` — `client.evaluate("main", "document.querySelector('select#dropdown').value = '1'")` |
 | Dispatch synthetic events via JS | `key_press.rb` — `client.evaluate("main", "document.dispatchEvent(new KeyboardEvent(...))")` |
-| Wait for async element (short) | `dynamic_loading.rb` — `page(:main).wait_for(selector, timeout:)` |
-| Poll for async element (long) | `dynamic_elements.rb` — `page(:main).watch(selector, timeout:)` |
+| Wait for async element | `dynamic_loading.rb` — `page(:main).wait(selector, timeout:)` |
+| Poll for async element | `dynamic_elements.rb` — `page(:main).wait(selector, timeout:)` |
 | Attribute prefix selector | `notifications.rb` — `[data-test^="notification-"]` for dynamic IDs |
 | Share state across steps | `key_press.rb` — `store(:key, value)` / `fetch(:key)` |
 | Negative-path assertion | `login_negative.rb` — assert error shown, success absent |

--- a/docs/guides/writing-workflows.md
+++ b/docs/guides/writing-workflows.md
@@ -11,7 +11,7 @@ Place workflow files in either:
 | `.browserctl/workflows/<name>.rb` | Project-level (committed to repo) |
 | `~/.browserctl/workflows/<name>.rb` | User-level (shared across projects) |
 
-The filename becomes the workflow name used with `browserctl run`.
+The filename becomes the workflow name used with `workflow run`.
 
 ---
 
@@ -32,7 +32,7 @@ end
 ```
 
 ```bash
-browserctl run hello
+browserctl workflow run hello
 ```
 
 ---
@@ -42,7 +42,7 @@ browserctl run hello
 ### `desc`
 
 ```ruby
-desc "Human-readable description shown by browserctl workflows"
+desc "Human-readable description shown by browserctl workflow list"
 ```
 
 ### `param`
@@ -64,13 +64,13 @@ param :base_url, default: "https://app.example.com"
 Pass params at runtime with `--key value` flags:
 
 ```bash
-browserctl run my_workflow --email me@example.com --password s3cr3t
+browserctl workflow run my_workflow --email me@example.com --password s3cr3t
 ```
 
 Or load them from a YAML or JSON file to keep credentials out of your shell history:
 
 ```bash
-browserctl run my_workflow --params .browserctl/params.yml
+browserctl workflow run my_workflow --params .browserctl/params.yml
 ```
 
 ```yaml
@@ -101,7 +101,7 @@ end
 
 # fail the step if it takes longer than 10 seconds
 step "wait for results", timeout: 10 do
-  page(:main).wait_for(".results-list")
+  page(:main).wait(".results-list")
 end
 
 # combine both
@@ -131,7 +131,7 @@ step "enter code on target site" do
 end
 ```
 
-`fetch` raises `WorkflowError` with a descriptive message if the key was never stored. Values are stored in the daemon's KV store and persist for as long as the daemon is running — a later `browserctl run` that connects to the same daemon can read a value stored by an earlier run. Values are lost when the daemon stops.
+`fetch` raises `WorkflowError` with a descriptive message if the key was never stored. Values are stored in the daemon's KV store and persist for as long as the daemon is running — a later `workflow run` that connects to the same daemon can read a value stored by an earlier run. Values are lost when the daemon stops.
 
 ---
 
@@ -146,16 +146,16 @@ assert count == 3, "expected 3 items, got #{count}"
 
 ### `open_page` and `close_page`
 
-Open or close a named browser page from within a workflow step. Use these instead of reaching into `client` directly for page lifecycle.
+Open or close a named browser page from within a workflow step.
 
 ```ruby
 step "open login page" do
   open_page(:login, url: "https://app.example.com/login")
 end
 
-step "open dashboard in parallel" do
+step "open dashboard separately" do
   open_page(:dashboard)
-  page(:dashboard).goto("#{base_url}/dashboard")
+  page(:dashboard).navigate("#{base_url}/dashboard")
 end
 
 step "close login tab when done" do
@@ -163,11 +163,27 @@ step "close login tab when done" do
 end
 ```
 
-`open_page` without a `url:` creates the page but does not navigate. Navigate separately with `page(:name).goto(url)` or pass `url:` directly.
+`open_page` without a `url:` creates the page but does not navigate. Navigate separately with `page(:name).navigate(url)` or pass `url:` directly.
+
+### `save_session` and `load_session`
+
+Persist the full browser state — open pages, cookies, and localStorage — to a named session. Load it back in a later run or on a fresh daemon.
+
+```ruby
+step "save authenticated session" do
+  save_session("github_work")
+end
+
+step "restore session" do
+  load_session("github_work")
+end
+```
+
+Sessions are stored as plain JSON files in `~/.browserctl/sessions/<name>/`. Use `list_sessions` to see all saved sessions.
 
 ### `page(:name)`
 
-Returns a `PageProxy` for a named browser page. The page must already be open (via `open_page` or `browserctl open`) before calling methods on it.
+Returns a `PageProxy` for a named browser page. The page must already be open (via `open_page` or `browserctl page open`) before calling methods on it.
 
 ```ruby
 page(:login).fill("input[name=email]", email)
@@ -190,33 +206,34 @@ Circular invocation (`a → b → a`) raises immediately.
 
 | Method | Description |
 |---|---|
-| `goto(url)` | Navigate the page to a URL |
+| `navigate(url)` | Navigate the page to a URL |
 | `fill(selector, value)` | Fill an input field |
 | `click(selector)` | Click an element |
-| `watch(selector, timeout: 30)` | Poll until selector appears (default 30s) — for async content |
-| `wait_for(selector, timeout: 10)` | Wait up to N seconds for an element to appear (short-form gate, default 10s) |
+| `wait(selector, timeout: 30)` | Wait until selector appears (default 30s) |
 | `url` | Return the current page URL as a string |
 | `evaluate(expression)` | Evaluate a JS expression and return the result |
-| `snapshot(**opts)` | Return a DOM snapshot (same as `browserctl snap`) |
-| `screenshot(**opts)` | Take a screenshot (same as `browserctl shot`) |
+| `snapshot(**opts)` | Return a DOM snapshot |
+| `screenshot(**opts)` | Take a screenshot |
+| `storage_get(key, store: "local")` | Read a localStorage or sessionStorage key |
+| `storage_set(key, value, store: "local")` | Write a localStorage or sessionStorage key |
+| `delete_cookies` | Delete all cookies for this page |
+| `devtools` | Return the Chrome DevTools URL for this page |
 
 All methods raise `WorkflowError` on a daemon error, which fails the current step.
 
-Use `watch` for async content that may take seconds to load (API responses, animations, page transitions). Use `wait_for` as a quick synchronisation gate when the element is already expected to be present.
-
-For HITL pause/resume and direct cookie management inside a workflow, use `client` — the raw daemon client available in every step block:
+For HITL pause/resume inside a workflow, use `client` — the raw daemon client available in every step block:
 
 ```ruby
 step "handle challenge" do
-  res = client.goto("main", url)
+  res = client.navigate("main", target_url)
   if res[:challenge]
-    client.pause("main")
-    loop { break unless client.snapshot("main", format: "html")[:challenge]; sleep 3 }
+    client.pause("main", message: "Solve the challenge, then: browserctl resume main")
+    loop do
+      snap = client.snapshot("main", format: "html")
+      break unless snap[:challenge]
+      sleep 3
+    end
   end
-end
-
-step "restore session" do
-  client.import_cookies("main", ".browserctl/sessions/app.json")
 end
 ```
 
@@ -229,7 +246,7 @@ For the complete `client` API, see the [Command Reference](../reference/commands
 ```ruby
 # .browserctl/workflows/smoke_login.rb
 Browserctl.workflow "smoke_login" do
-  desc "Log in, verify the dashboard, then log out"
+  desc "Log in, verify the dashboard, then capture a screenshot"
 
   param :email,    required: true
   param :password, required: true, secret: true
@@ -246,7 +263,7 @@ Browserctl.workflow "smoke_login" do
   end
 
   step "verify dashboard" do
-    page(:main).watch("[data-test=dashboard]", timeout: 10)
+    page(:main).wait("[data-test=dashboard]", timeout: 10)
     assert page(:main).url.include?("/dashboard"), "redirect to dashboard failed"
   end
 
@@ -257,7 +274,7 @@ end
 ```
 
 ```bash
-browserctl run smoke_login --email me@example.com --password s3cr3t
+browserctl workflow run smoke_login --email me@example.com --password s3cr3t
 ```
 
 Expected output:
@@ -276,7 +293,7 @@ Expected output:
 If the file is not in a search path (e.g. a one-off script), pass the path directly:
 
 ```bash
-browserctl run path/to/my_workflow.rb --key value
+browserctl workflow run path/to/my_workflow.rb --key value
 ```
 
 ---
@@ -284,8 +301,8 @@ browserctl run path/to/my_workflow.rb --key value
 ## Listing and inspecting workflows
 
 ```bash
-browserctl workflows          # list all discoverable workflows with descriptions
-browserctl describe <name>    # show params and step labels for a workflow
+browserctl workflow list              # list all discoverable workflows with descriptions
+browserctl workflow describe <name>   # show params and step labels for a workflow
 ```
 
 ---
@@ -307,33 +324,37 @@ end
 ```ruby
 step "wait for results" do
   page(:main).click("button#search")
-  page(:main).watch(".results-list", timeout: 15)
+  page(:main).wait(".results-list", timeout: 15)
   count = page(:main).evaluate("document.querySelectorAll('.result-item').length")
   assert count > 0, "no results returned"
 end
 ```
 
-### Skipping login with cookie export/import
+### Saving and restoring a session
 
-Authenticate once, export the session, then import it in future runs to skip the login step entirely.
+Authenticate once, save the full session, then load it in future runs to skip login entirely.
 
 ```bash
 # After a successful login session:
-browserctl export-cookies main .browserctl/sessions/app.json
+browserctl session save myapp
 
 # On the next run (daemon restarted):
-browserctl import-cookies main .browserctl/sessions/app.json
+browserctl session load myapp
 ```
-
-The `sessions/` directory is git-ignored by default when you run `browserctl init`.
 
 You can also do this inside a workflow:
 
 ```ruby
-step "restore session" do
-  client.import_cookies("main", ".browserctl/sessions/app.json")
+step "restore authenticated session" do
+  load_session("myapp")
+end
+
+step "save session after login" do
+  save_session("myapp")
 end
 ```
+
+Sessions capture cookies, localStorage, and all open page URLs. The `~/.browserctl/sessions/` directory is git-ignored by default when you run `browserctl init`.
 
 ---
 
@@ -364,7 +385,7 @@ When a step hits a wall that needs human action, pause the session and resume wh
 
 ```ruby
 step "navigate to protected page" do
-  res = client.goto("main", target_url)
+  res = client.navigate("main", target_url)
   if res[:challenge]
     puts "→ Challenge detected. Solve it in the browser, then: browserctl resume main"
     client.pause("main")

--- a/docs/product.md
+++ b/docs/product.md
@@ -44,10 +44,12 @@ The `record` command captures a live browser session as a replayable Ruby workfl
 
 ```bash
 # Record the session
-browserctl record my-bug
+browserctl record start my-bug
+# ... interact in the browser ...
+browserctl record stop
 
 # Later: replay it against any environment
-browserctl run my-bug --url https://staging.example.com
+browserctl workflow run my-bug --url https://staging.example.com
 ```
 
 Evidence is not an afterthought. Screenshots are named, dated, and stored. Every HITL pause is logged with context. The session trace is yours to export.
@@ -70,19 +72,18 @@ Browserctl.workflow :verify_checkout do
   param :password, required: true, secret: true
 
   step "navigate to login" do
-    page(:main).goto("https://shop.example.com/login")
-    page(:main).screenshot(out: "evidence/login-page.png")
+    page(:main).navigate("https://shop.example.com/login")
+    page(:main).screenshot(path: "evidence/login-page.png")
   end
 
   step "authenticate" do
-    snap = page(:main).snapshot
-    page(:main).fill(snap.ref(:email_field), email)
-    page(:main).fill(snap.ref(:password_field), password)
-    page(:main).click(snap.ref(:submit))
+    page(:main).fill("input[name=email]", email)
+    page(:main).fill("input[name=password]", password)
+    page(:main).click("button[type=submit]")
   end
 
   step "confirm checkout reached" do
-    page(:main).wait_for("[data-test=checkout-header]", timeout: 15)
+    page(:main).wait("[data-test=checkout-header]", timeout: 15)
     page(:main).screenshot(out: "evidence/checkout.png")
   end
 end

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -9,7 +9,7 @@ browserctl's public surface is split into three stability zones. Every command, 
 ### Fixed — Protocol layer
 **The wire protocol: JSON-RPC command names, response field names, socket path convention.**
 
-Locked after v0.5. Never changes without a major version bump and an explicit migration path. External tools (non-Ruby clients, other language bindings) depend on this layer.
+Locked after v0.6. Never changes without a major version bump and an explicit migration path. External tools (non-Ruby clients, other language bindings) depend on this layer.
 
 What is Fixed:
 - Command names in `COMMAND_MAP` (the strings sent over the Unix socket)
@@ -46,25 +46,27 @@ What is Extension:
 
 ## Fixed zone — command reference
 
-Every command that flows over the wire. Name, required params, optional params, and response fields are all Fixed once v0.5 ships.
+Every command that flows over the wire. Name, required params, optional params, and response fields are all Fixed once v0.6 ships.
 
 ### Page lifecycle
 
 | Command | Required params | Optional params | Response fields |
 |---------|----------------|----------------|-----------------|
-| `open_page` | `name` | `url` | `ok`, `name` |
-| `close_page` | `name` | — | `ok` |
-| `list_pages` | — | — | `pages` (array of strings) |
+| `page_open` | `name` | `url` | `ok`, `name` |
+| `page_close` | `name` | — | `ok` |
+| `page_list` | — | — | `pages` (array of strings) |
+| `page_focus` | `name` | — | `ok` |
 
 ### Navigation & interaction
 
 | Command | Required params | Optional params | Response fields |
 |---------|----------------|----------------|-----------------|
-| `goto` | `name`, `url` | — | `ok`, `url`, `challenge` |
+| `navigate` | `name`, `url` | — | `ok`, `url`, `challenge` |
 | `fill` | `name`, `value` | `selector`, `ref` | `ok` |
 | `click` | `name` | `selector`, `ref` | `ok` |
 | `evaluate` | `name`, `expression` | — | `ok`, `result` |
 | `url` | `name` | — | `ok`, `url` |
+| `wait` | `name`, `selector` | `timeout` (default 30s) | `ok`, `selector` |
 
 One of `selector` or `ref` is required for `fill` and `click`. Both cannot be omitted.
 
@@ -74,20 +76,16 @@ One of `selector` or `ref` is required for `fill` and `click`. Both cannot be om
 |---------|----------------|----------------|-----------------|
 | `snapshot` | `name` | `format` (`"elements"`\|`"html"`), `diff` | `ok`, `snapshot` or `html`, `challenge`, `nonce` |
 | `screenshot` | `name` | `path`, `full` | `ok`, `path` |
-| `wait_for` | `name`, `selector` | `timeout` (default 10s) | `ok` |
-| `watch` | `name`, `selector` | `timeout` (default 30s) | `ok`, `selector` |
 
 `snapshot` with `format: "elements"` (default) returns `snapshot` field — a JSON array of interactable elements with ref IDs. With `format: "html"` returns `html` field. Both include `challenge` and `nonce`.
 
 `nonce` is a server-generated hex string (16 chars) unique per response. It is present in every `snapshot` response regardless of `format`. Consumers can use it to delimit page-provided content — the page cannot forge or predict the value.
 
-`wait_for` and `watch` both poll for a selector but are distinct wire commands: `wait_for` returns bare `ok` and is used as a programmatic blocking gate (default 10s); `watch` echoes back `selector` in its response and is designed for observational/interactive use (default 30s).
-
 ### HITL (Human-in-the-loop)
 
 | Command | Required params | Optional params | Response fields |
 |---------|----------------|----------------|-----------------|
-| `pause` | `name` | — | `ok`, `paused: true` |
+| `pause` | `name` | `message` | `ok`, `paused: true`, `message` |
 | `resume` | `name` | — | `ok`, `paused: false` |
 
 ### Cookies
@@ -96,16 +94,35 @@ One of `selector` or `ref` is required for `fill` and `click`. Both cannot be om
 |---------|----------------|----------------|-----------------|
 | `cookies` | `name` | — | `ok`, `cookies` (array) |
 | `set_cookie` | `name`, `cookie_name`, `value`, `domain` | `path` (default `/`) | `ok` |
-| `clear_cookies` | `name` | — | `ok` |
+| `delete_cookies` | `name` | — | `ok` |
 | `import_cookies` | `name`, `cookies` (array) | — | `ok`, `count` |
 
 `export_cookies` has no wire command — it is implemented client-side by calling `cookies` then writing a file.
+
+### Storage
+
+| Command | Required params | Optional params | Response fields |
+|---------|----------------|----------------|-----------------|
+| `storage_get` | `name`, `key` | `store` (`"local"`\|`"session"`, default `"local"`) | `ok`, `value` |
+| `storage_set` | `name`, `key`, `value` | `store` (default `"local"`) | `ok` |
+| `storage_export` | `name`, `path` | `stores` (`"local"`\|`"session"`\|`"all"`, default `"all"`) | `ok`, `path`, `key_count` |
+| `storage_import` | `name`, `path` | — | `ok`, `origins`, `key_count` |
+| `storage_delete` | `name` | `stores` (default `"all"`) | `ok` |
+
+### Session
+
+| Command | Required params | Optional params | Response fields |
+|---------|----------------|----------------|-----------------|
+| `session_save` | `session_name` | — | `ok`, `path`, `pages`, `cookies` |
+| `session_load` | `session_name` | — | `ok`, `cookies`, `pages`, `local_storage_keys` |
+| `session_list` | — | — | `ok`, `sessions` (array of metadata hashes) |
+| `session_delete` | `session_name` | — | `ok` |
 
 ### DevTools
 
 | Command | Required params | Optional params | Response fields |
 |---------|----------------|----------------|-----------------|
-| `inspect` | `name` | — | `ok`, `devtools_url` |
+| `devtools` | `name` | — | `ok`, `devtools_url` |
 
 ### Daemon control
 
@@ -116,40 +133,51 @@ One of `selector` or `ref` is required for `fill` and `click`. Both cannot be om
 | `store` | `key`, `value` | — | `ok` |
 | `fetch` | `key` | — | `ok`, `value` |
 
-`fetch` returns `{ error: "key '<key>' not found", code: "key_not_found" }` when the key has never been stored. Values are scoped to the daemon process — they persist across `browserctl run` invocations for as long as the daemon is running, and are lost when the daemon stops.
+`fetch` returns `{ error: "key '<key>' not found", code: "key_not_found" }` when the key has never been stored. Values are scoped to the daemon process — they persist across `workflow run` invocations for as long as the daemon is running, and are lost when the daemon stops.
 
 ---
 
 ## Stable zone — CLI reference
 
-CLI command names and their flags. See [style-guide.md](style-guide.md) for the mapping from CLI names to wire names.
-
-### Intentional aliases (documented, not bugs)
-
-| CLI name | Maps to wire | Reason |
-|----------|-------------|--------|
-| `open` | `open_page` | brevity |
-| `close` | `close_page` | brevity |
-| `pages` | `list_pages` | brevity |
-| `snap` | `snapshot` | brevity |
-| `shot` | `screenshot` | brevity |
-| `eval` | `evaluate` | brevity |
-| `watch` | `watch` | 30s default, returns `selector` echo |
+CLI command names and their flags map 1-to-1 to wire commands via the subcommand routers in `lib/browserctl/commands/`. There are no abbreviation aliases — CLI names match their wire counterparts exactly.
 
 ---
 
-## Breaking changes before v0.5 (the lock)
+## Breaking changes log
+
+### v0.6 — Protocol version 2
+
+v0.6 is a breaking release. `PROTOCOL_VERSION` was bumped from `"1"` to `"2"`. Clients must check `ping[:protocol_version]` and reject `"1"` daemons.
+
+| Old wire command | New wire command | Change |
+|---|---|---|
+| `open_page` | `page_open` | noun-verb reorder |
+| `close_page` | `page_close` | noun-verb reorder |
+| `list_pages` | `page_list` | noun-verb reorder |
+| `goto` | `navigate` | full English word |
+| `wait_for` + `watch` | `wait` | unified (single timeout param) |
+| `clear_cookies` | `delete_cookies` | `delete` prefix convention |
+| `inspect` | `devtools` | descriptive name |
+| — | `storage_get/set/export/import/delete` | new (localStorage/sessionStorage) |
+| — | `session_save/load/list/delete` | new (session persistence) |
+| `pause` | `pause` (+ optional `message:` param) | backward-compatible addition |
+
+### v0.5 — Protocol version 1
 
 | Issue | Status |
 |-------|--------|
-| CLI cookie commands used underscores (`set_cookie`, `clear_cookies`) | ✅ Fixed — renamed to `set-cookie`, `clear-cookies` |
+| CLI cookie commands used underscores (`set_cookie`, `clear_cookies`) | ✅ Fixed — renamed to `set-cookie`, `clear-cookies` at the CLI layer |
 | `ping` response lacked protocol version | ✅ Fixed — `protocol_version: "1"` added |
-| `pause_resume.rb` grouped two commands in one file | ✅ Fixed — split into `pause.rb` and `resume.rb` |
-
-`watch` was audited and **retained** as a distinct wire command. It differs from `wait_for` in both its default timeout (30s vs 10s) and its response shape (`selector:` echo vs bare `ok:`). The distinction is intentional and both are Fixed.
 
 ---
 
 ## Protocol versioning
 
-The `ping` response includes `protocol_version: "1"` (shipped in v0.4). Future incompatible protocol changes increment this number. Clients can check this field to negotiate capabilities.
+The `ping` response includes `protocol_version` — currently `"2"` (shipped in v0.6). Clients can check this field before sending commands to verify compatibility:
+
+```ruby
+res = client.ping
+raise "incompatible daemon" unless res[:protocol_version] == "2"
+```
+
+Future incompatible protocol changes will increment this number and document the migration path here.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -4,7 +4,7 @@ All commands require `browserd` to be running unless noted.
 
 ---
 
-## Setup commands
+## Setup
 
 | Command | Description |
 |---|---|
@@ -12,49 +12,116 @@ All commands require `browserd` to be running unless noted.
 
 ---
 
-## Browser commands
+## Page
 
 | Command | Description |
 |---|---|
-| `open <page> [--url URL]` | Open or focus a named page |
-| `close <page>` | Close a named page |
-| `pages` | List open pages |
-| `goto <page> <url>` | Navigate a page to a URL |
+| `page open <name> [--url URL]` | Open a named browser tab, optionally navigating to a URL |
+| `page close <name>` | Close a named tab |
+| `page list` | List all open named pages and their current URLs |
+| `page focus <name>` | Bring a tab to front (headed mode only) |
+
+---
+
+## Interaction
+
+Page is always the first argument after the verb.
+
+| Command | Description |
+|---|---|
+| `navigate <page> <url>` | Navigate a page to a URL |
 | `fill <page> <selector> <value>` | Fill an input field by CSS selector |
 | `fill <page> --ref <id> --value <v>` | Fill an input field by snapshot ref |
 | `click <page> <selector>` | Click an element by CSS selector |
 | `click <page> --ref <id>` | Click an element by snapshot ref |
-| `snap <page> [--format elements\|html] [--diff]` | Snapshot DOM; `--diff` returns only changed elements |
-| `watch <page> <selector> [--timeout N]` | Poll until selector appears (default timeout: 30s) |
-| `shot <page> [--out PATH] [--full]` | Take a screenshot |
-| `url <page>` | Print current URL |
-| `eval <page> <expression>` | Evaluate a JS expression |
-| `pause <page>` | Pause automation — browser stays live for manual interaction |
+| `snapshot <page> [--format elements\|html] [--diff]` | Snapshot DOM; `--diff` returns only changed elements |
+| `screenshot <page> [--out PATH] [--full]` | Take a screenshot |
+| `evaluate <page> <expression>` | Evaluate a JavaScript expression |
+| `url <page>` | Print the current URL |
+| `wait <page> <selector> [--timeout N]` | Wait until selector appears (default: 30s) |
+| `pause <page> [--message MSG]` | Pause automation — browser stays live for manual interaction |
 | `resume <page>` | Resume automation after manual action |
-| `inspect <page>` | Open Chrome DevTools for a named page |
-| `cookies <page>` | List all cookies as JSON |
-| `set-cookie <page> <name> <value> <domain>` | Set a cookie (path defaults to `/`) |
-| `clear-cookies <page>` | Clear all cookies for a page |
-| `export-cookies <page> <path>` | Export all cookies to a JSON file |
-| `import-cookies <page> <path>` | Import cookies from a JSON file |
+| `devtools <page>` | Open Chrome DevTools for a named page |
+
+`navigate` and `snapshot` responses include `"challenge": true` when a Cloudflare interstitial is detected. See [Handling Challenges](../guides/handling-challenges.md).
+
+---
+
+## Cookie
+
+| Command | Description |
+|---|---|
+| `cookie list <page>` | List all cookies as JSON |
+| `cookie set <page> <name> <value> --domain DOMAIN [--path /]` | Set a cookie |
+| `cookie delete <page>` | Delete all cookies for a page |
+| `cookie export <page> <path>` | Export all cookies to a JSON file |
+| `cookie import <page> <path>` | Import cookies from a JSON file |
+
+---
+
+## Storage
+
+| Command | Description |
+|---|---|
+| `storage get <page> <key> [--store local\|session]` | Read a localStorage or sessionStorage key |
+| `storage set <page> <key> <value> [--store local\|session]` | Write a localStorage or sessionStorage key |
+| `storage export <page> <path> [--store local\|session\|all]` | Export storage to a JSON file |
+| `storage import <page> <path>` | Import storage keys from a JSON file |
+| `storage delete <page> [--store local\|session\|all]` | Clear localStorage and/or sessionStorage |
+
+`--store` defaults to `local`. The export format is `{ "https://origin": { key: value } }`.
+
+---
+
+## Session
+
+A session bundles everything needed to resume a browser state: all open pages (names + URLs), all cookies, and localStorage for each origin. Session files are plain JSON stored in `~/.browserctl/sessions/<name>/`.
+
+| Command | Description |
+|---|---|
+| `session save <name>` | Save the current browser state to a named session |
+| `session load <name>` | Restore a saved session into the running daemon |
+| `session list` | List all saved sessions |
+| `session delete <name>` | Delete a saved session |
+| `session export <name> <path>` | Zip a saved session to a portable archive |
+| `session import <path>` | Unzip a session archive into the sessions directory |
+
+---
+
+## Recording
+
+| Command | Description |
+|---|---|
 | `record start <name>` | Begin recording commands as a replayable workflow |
-| `record stop [--out path]` | End recording; saves to `.browserctl/workflows/` or custom path |
+| `record stop [--out PATH]` | End recording; saves to `.browserctl/workflows/` or custom path |
 | `record status` | Show whether a recording is active |
 
 ---
 
-## Daemon commands
+## Workflow
 
 | Command | Description |
 |---|---|
-| `ping` | Check if `browserd` is alive — returns `{ ok: true, pid: N, protocol_version: "1" }` |
-| `status` | Show daemon status, PID, and all open pages with their current URLs |
-| `shutdown` | Stop `browserd` |
+| `workflow run <name\|file.rb> [--params file] [--key value ...]` | Run a named workflow or workflow file |
+| `workflow list` | List all discoverable workflows with descriptions |
+| `workflow describe <name>` | Show params and step labels for a workflow |
 
-`browserctl status` response:
+---
+
+## Daemon
+
+| Command | Description |
+|---|---|
+| `daemon ping` | Check if `browserd` is alive — returns `{ ok: true, pid: N, protocol_version: "2" }` |
+| `daemon status` | Show daemon status, PID, and all open pages with their current URLs |
+| `daemon start [--headed] [--name NAME]` | Start a new `browserd` instance in the background |
+| `daemon stop` | Stop the running `browserd` gracefully |
+| `daemon list` | List all running daemon instances with name, PID, and page count |
+
+`daemon status` response:
 
 ```json
-{ "daemon": "online", "pid": 12345, "protocol_version": "1", "pages": [
+{ "daemon": "online", "pid": 12345, "protocol_version": "2", "pages": [
   { "name": "main", "url": "https://app.example.com/dashboard" }
 ]}
 ```
@@ -67,25 +134,15 @@ When the daemon is not running:
 
 ---
 
-## Workflow commands
-
-| Command | Description |
-|---|---|
-| `run <name\|file.rb> [--params file] [--key value ...]` | Run a named workflow or workflow file |
-| `workflows` | List available workflows |
-| `describe <name>` | Show workflow params and steps |
-
----
-
 ## `browserd` flags
 
 | Flag | Default | Description |
 |---|---|---|
 | `--headed` | headless | Start with a visible browser window |
-| `--name <id>` | `default` | Name this daemon instance (for multi-agent isolation) |
+| `--name <id>` | auto | Name this daemon instance; if omitted and the default slot is taken, auto-picks `d1`, `d2`, ... |
 | `--log-level <level>` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 
-`browserd` always writes logs to `~/.browserctl/browserd.log` (or `~/.browserctl/<name>.log` for a named instance) in addition to stderr. The log path is printed to stderr on startup so it's visible even when backgrounding with `&`:
+`browserd` always writes logs to `~/.browserctl/browserd.log` (or `~/.browserctl/<name>.log` for a named instance). The log path is printed to stderr on startup:
 
 ```
 browserd starting — log: /Users/you/.browserctl/browserd.log
@@ -97,10 +154,11 @@ To follow live log output:
 tail -f ~/.browserctl/browserd.log
 ```
 
-If a daemon is already running when `browserd` starts, it aborts with a clear message rather than clobbering the live session:
+When the default slot is already taken, `browserd` auto-indexes rather than aborting:
 
 ```
-browserd already running (PID 12345). Use 'browserctl shutdown' first.
+browserd: default slot taken — starting as 'd1'
+  to connect: browserctl --daemon d1 <command>
 ```
 
 ---
@@ -109,13 +167,16 @@ browserd already running (PID 12345). Use 'browserctl shutdown' first.
 
 | Flag | Description |
 |---|---|
-| `--daemon <name>` | Target a specific named daemon instance |
+| `--daemon <name>` | Connect to a specific named or auto-indexed daemon (e.g. `d1`, `work`) |
+| `--version, -v` | Print the version and exit |
+
+If `--daemon` is omitted, `browserctl` connects to the default socket (`browserd.sock`). If that socket is absent, it falls back to the first responsive auto-indexed daemon and prints which one it connected to.
 
 ---
 
 ## Snapshot format
 
-`browserctl snap <page>` returns a JSON array of interactable elements:
+`browserctl snapshot <page>` returns a JSON array of interactable elements:
 
 ```json
 [
@@ -142,25 +203,26 @@ browserd already running (PID 12345). Use 'browserctl shutdown' first.
 
 Use `--ref <id>` with `fill` and `click` to interact without writing selectors. Use `--format html` for full page HTML.
 
-`goto` and `snap` responses include `"challenge": true` when a Cloudflare interstitial is detected. See [Handling Challenges](../guides/handling-challenges.md).
-
 ---
 
 ## Workflow DSL reference
 
 | Method | Description |
 |---|---|
-| `desc "text"` | Human-readable description shown by `browserctl workflows` |
+| `desc "text"` | Human-readable description shown by `workflow list` |
 | `param :name, required:, secret:, default:` | Declare an input parameter |
 | `step "label" { }` | Add a step — runs in order, halts workflow on failure |
 | `step "label", retry_count: N, timeout: S { }` | Step with retry and/or timeout |
 | `compose "workflow"` | Inline all steps from another workflow at this point |
-| `open_page(page_name, url: nil)` | Open a named page, optionally navigating to a URL |
-| `close_page(page_name)` | Close a named page |
+| `open_page(name, url: nil)` | Open a named page, optionally navigating to a URL |
+| `close_page(name)` | Close a named page |
 | `page(:name)` | Return a `PageProxy` for the named page |
-| `invoke "workflow", **overrides` | Call another workflow by name (runs as a unit, not inlined) |
+| `save_session(name)` | Save the current browser state to a named session |
+| `load_session(name)` | Restore a saved session into the running daemon |
+| `list_sessions` | Return all saved session metadata |
+| `invoke "workflow", **overrides` | Call another workflow by name |
 | `assert condition, "message"` | Raise `WorkflowError` if condition is false |
-| `store :key, value` | Store a value for use in later steps (within this run only) |
+| `store :key, value` | Store a value for use in later steps |
 | `fetch :key` | Retrieve a value stored by an earlier step |
 
 ---
@@ -171,16 +233,19 @@ Methods available on `page(:name)` inside a workflow:
 
 | Method | Description |
 |---|---|
-| `goto(url)` | Navigate to URL |
+| `navigate(url)` | Navigate to a URL |
 | `fill(selector, value)` | Fill an input by CSS selector |
 | `click(selector)` | Click an element by CSS selector |
-| `watch(selector, timeout: 30)` | Poll until selector appears (default 30s) — use for async content |
-| `wait_for(selector, timeout: 10)` | Wait up to N seconds for selector to appear (short-form gate, default 10s) |
+| `wait(selector, timeout: 30)` | Wait until selector appears (default 30s) |
 | `url` | Return the current page URL |
 | `evaluate(expression)` | Evaluate a JS expression and return the result |
-| `snapshot(**opts)` | Return a DOM snapshot (same as `browserctl snap`) |
-| `screenshot(**opts)` | Take a screenshot (same as `browserctl shot`) |
+| `snapshot(**opts)` | Return a DOM snapshot |
+| `screenshot(**opts)` | Take a screenshot |
+| `storage_get(key, store: "local")` | Read a localStorage or sessionStorage key |
+| `storage_set(key, value, store: "local")` | Write a localStorage or sessionStorage key |
+| `delete_cookies` | Delete all cookies for the page |
+| `devtools` | Return the Chrome DevTools URL for this page |
 
-Prefer `watch` for async content that may take several seconds to appear; use `wait_for` as a quick gate for DOM already expected to be present.
+All methods raise `WorkflowError` on a daemon error, which fails the current step.
 
 For the full workflow authoring guide, see [Writing Workflows](../guides/writing-workflows.md).

--- a/docs/reference/style-guide.md
+++ b/docs/reference/style-guide.md
@@ -13,63 +13,89 @@ browserctl has three distinct naming surfaces. Each has its own convention, and 
 `snake_case` always. These are the keys in `COMMAND_MAP` and what flows over the Unix socket.
 
 ```
-open_page   close_page   list_pages
-goto        snapshot      screenshot
-fill        click         evaluate
-wait_for    url           ping
-shutdown    pause         resume
-inspect     cookies       set_cookie
-clear_cookies             import_cookies
-store       fetch
+page_open    page_close   page_list    page_focus
+navigate     snapshot     screenshot
+fill         click        evaluate
+wait         url          ping
+shutdown     pause        resume
+devtools     cookies      set_cookie
+delete_cookies            import_cookies
+storage_get  storage_set  storage_export
+storage_import            storage_delete
+session_save session_load session_list
+session_delete
+store        fetch
 ```
 
-Never abbreviate on the wire (`snapshot`, not `snap`). The wire protocol is the Fixed zone — once locked, these names never change.
+Never abbreviate on the wire (`snapshot`, not `snap`; `navigate`, not `goto`). The wire protocol is the Fixed zone — these names cannot change without a `PROTOCOL_VERSION` bump.
 
 ### CLI commands (`bin/browserctl`)
 
-Lowercase, hyphen-separated for multi-word names. Single-word commands are their natural verb or noun.
+v0.6 uses **noun-verb subcommand groups** for related commands and **full English words** for standalone verbs. No abbreviations; no aliases.
 
-Short-form aliases are allowed **and intentional** — document them explicitly, do not treat them as bugs.
+| CLI command | Wire command | Notes |
+|---|---|---|
+| `page open` | `page_open` | subcommand group |
+| `page close` | `page_close` | subcommand group |
+| `page list` | `page_list` | subcommand group |
+| `page focus` | `page_focus` | subcommand group (headed mode only) |
+| `navigate` | `navigate` | standalone verb |
+| `snapshot` | `snapshot` | full word (no `snap` alias) |
+| `screenshot` | `screenshot` | full word (no `shot` alias) |
+| `evaluate` | `evaluate` | full word (no `eval` alias) |
+| `fill` | `fill` | standalone |
+| `click` | `click` | standalone |
+| `url` | `url` | standalone |
+| `wait` | `wait` | standalone |
+| `pause` | `pause` | standalone |
+| `resume` | `resume` | standalone |
+| `devtools` | `devtools` | standalone |
+| `cookie list` | `cookies` | subcommand group |
+| `cookie set` | `set_cookie` | subcommand group |
+| `cookie delete` | `delete_cookies` | subcommand group |
+| `cookie export` | client-side | reads `cookies`, writes file |
+| `cookie import` | `import_cookies` | subcommand group |
+| `storage get` | `storage_get` | subcommand group |
+| `storage set` | `storage_set` | subcommand group |
+| `storage export` | `storage_export` | subcommand group |
+| `storage import` | `storage_import` | subcommand group |
+| `storage delete` | `storage_delete` | subcommand group |
+| `session save` | `session_save` | subcommand group |
+| `session load` | `session_load` | subcommand group |
+| `session list` | `session_list` | subcommand group |
+| `session delete` | `session_delete` | subcommand group |
+| `session export` | client-side | zips session directory |
+| `session import` | client-side | unzips session archive |
+| `daemon ping` | `ping` | subcommand group |
+| `daemon status` | client-side | reads `ping` + `page_list` + `url` per page |
+| `daemon start` | client-side | spawns `browserd` subprocess |
+| `daemon stop` | `shutdown` | subcommand group |
+| `daemon list` | client-side | scans sockets, pings each |
+| `workflow run` | client-side | runs a workflow file or name |
+| `workflow list` | client-side | lists registered workflows |
+| `workflow describe` | client-side | shows params + steps |
 
-| Canonical CLI name | Wire command | Notes |
-|--------------------|--------------|-------|
-| `open` | `open_page` | concise alias |
-| `close` | `close_page` | concise alias |
-| `pages` | `list_pages` | concise alias |
-| `goto` | `goto` | — |
-| `snap` | `snapshot` | short-form alias; `--format elements` is the default |
-| `shot` | `screenshot` | short-form alias |
-| `fill` | `fill` | — |
-| `click` | `click` | — |
-| `eval` | `evaluate` | short-form alias |
-| `url` | `url` | — |
-| `watch` | `watch` | 30s default, returns selector echo |
-| `pause` | `pause` | — |
-| `resume` | `resume` | — |
-| `inspect` | `inspect` | — |
-| `cookies` | `cookies` | — |
-| `set-cookie` | `set_cookie` | hyphen (not `set_cookie`) |
-| `clear-cookies` | `clear_cookies` | hyphen (not `clear_cookies`) |
-| `export-cookies` | client-side | hyphen ✓ |
-| `import-cookies` | `import_cookies` | hyphen ✓ |
-| `ping` | `ping` | — |
-| `status` | client-side | reads `ping` + `list_pages` + `url` per page |
-| `shutdown` | `shutdown` | — |
-
-**Rule:** multi-word CLI commands are always hyphenated. Underscores are forbidden in CLI command names.
+**Rules:**
+- Subcommand groups follow `<noun> <verb>` order.
+- Standalone verbs (not grouped) are full English words with no abbreviation alias.
+- No hyphenated names — use spaces (subcommands) or underscores (wire).
 
 ### Ruby SDK (`Browserctl::Client` methods)
 
-`snake_case` always. Full names preferred over abbreviations. The sole exception is `inspect_page` (avoids shadowing `Kernel#inspect`).
+`snake_case` always. Full names preferred over abbreviations. Method names follow the wire command names.
 
 ```ruby
-open_page    close_page   list_pages
-goto         snapshot     screenshot
+page_open    page_close   page_list    page_focus
+navigate     snapshot     screenshot
 fill         click        evaluate
-wait_for     watch        url
-pause        resume       inspect_page
-cookies      set_cookie   clear_cookies
+wait         url
+pause        resume       devtools
+cookies      set_cookie   delete_cookies
 export_cookies            import_cookies
+storage_get  storage_set  storage_export
+storage_import            storage_delete
+session_save session_load session_list
+session_delete
 store        fetch
 ping         shutdown
 ```
@@ -85,7 +111,7 @@ ping         shutdown
 | Spec files | mirror source path, `_spec.rb` suffix | `spec/unit/snapshot_spec.rb` |
 | Docs | `kebab-case.md` | `api-stability.md` |
 
-One command handler = one file. Do not group paired commands (e.g. `pause_resume.rb`) in a single file.
+One command handler = one file. Do not group paired commands in a single file.
 
 ---
 

--- a/docs/vs-agent-browser.md
+++ b/docs/vs-agent-browser.md
@@ -49,7 +49,7 @@ agent-browser has no equivalent pause/resume primitive.
 
 Knowing *when* to pause is as important as being able to pause. browserctl ships with built-in detection for known blockers:
 
-- **Cloudflare challenges** — `snapshot` and `goto` responses include a `challenge: true` field when a Cloudflare interstitial is detected
+- **Cloudflare challenges** — `snapshot` and `navigate` responses include a `challenge: true` field when a Cloudflare interstitial is detected
 
 The detection layer is designed to grow. The same pattern that detects Cloudflare can be extended to detect:
 - Bot-detection pages (DataDome, PerimeterX, Arkose)
@@ -73,11 +73,10 @@ Browserctl.workflow :checkout_smoke do
   param :password, required: true, secret: true
 
   step "login" do
-    page(:main).goto("https://shop.example.com/login")
-    snap = page(:main).snapshot
-    page(:main).fill(snap.ref(:email_field), email)
-    page(:main).fill(snap.ref(:password_field), password)
-    page(:main).click(snap.ref(:submit))
+    page(:main).navigate("https://shop.example.com/login")
+    page(:main).fill("input[name=email]", email)
+    page(:main).fill("input[name=password]", password)
+    page(:main).click("button[type=submit]")
   end
 end
 ```
@@ -98,7 +97,7 @@ agent-browser wraps `snapshot` output in nonce-delimited content boundaries, pre
 
 ### Live viewport streaming
 
-agent-browser provides a WebSocket-based dashboard with a live browser viewport, useful for pair-browsing and debugging agent sessions in real time. browserctl has no live preview — inspection is via `browserctl inspect` which opens Chrome DevTools, not a streaming view.
+agent-browser provides a WebSocket-based dashboard with a live browser viewport, useful for pair-browsing and debugging agent sessions in real time. browserctl has no live preview — inspection is via `browserctl devtools <page>` which opens Chrome DevTools, not a streaming view.
 
 ---
 

--- a/examples/cloudflare_hitl.rb
+++ b/examples/cloudflare_hitl.rb
@@ -7,7 +7,7 @@
 # pauses automation so a human can solve it in the live browser, then resumes.
 #
 # Run:
-#   browserctl run examples/cloudflare_hitl.rb --url https://example.com
+#   browserctl workflow run examples/cloudflare_hitl.rb --url https://example.com
 #
 # Note: modern Cloudflare often passes a real headed Chrome without challenge.
 # The pause/resume branch fires only when the challenge page is actually served
@@ -22,11 +22,11 @@ Browserctl.workflow "cloudflare_hitl" do
   param :selector, default: "body"
 
   step "open page" do
-    client.open_page("main")
+    open_page(:main)
   end
 
   step "navigate to target URL" do
-    res = client.goto("main", url)
+    res = client.navigate("main", url)
 
     if res[:challenge]
       $stdout.puts ""
@@ -54,12 +54,12 @@ Browserctl.workflow "cloudflare_hitl" do
   end
 
   step "wait for content and snapshot" do
-    page(:main).wait_for(selector, timeout: 15)
+    page(:main).wait(selector, timeout: 15)
     result = page(:main).snapshot(format: "elements")
     $stdout.puts "  Snapshot: #{result[:snapshot]&.length || 0} elements captured"
   end
 
   step "close page" do
-    client.close_page("main")
+    close_page(:main)
   end
 end

--- a/examples/smoke/params_file.rb
+++ b/examples/smoke/params_file.rb
@@ -29,6 +29,7 @@ Browserctl.workflow "smoke/params_file" do
   end
 
   step "assert login succeeded" do
+    page(:main).wait(".flash.success", timeout: 10)
     assert page(:main).url.include?("/secure"), "expected redirect to /secure — params may not have loaded"
     puts "  [ok] reached secure area — params file loaded correctly"
   end

--- a/examples/smoke/params_file.rb
+++ b/examples/smoke/params_file.rb
@@ -4,7 +4,7 @@
 # Smoke test for --params file loading (Task 7.5).
 #
 # Run with:
-#   browserctl run examples/smoke/params_file.rb --params examples/smoke/params_file.yml
+#   browserctl workflow run examples/smoke/params_file.rb --params examples/smoke/params_file.yml
 #
 # The workflow logs in using credentials from the params file and asserts
 # the secure area is reached — proving the params were loaded and available.
@@ -17,7 +17,7 @@ Browserctl.workflow "smoke/params_file" do
   param :base_url, default: "https://the-internet.herokuapp.com"
 
   step "open login page" do
-    client.open_page("main", url: "#{base_url}/login")
+    open_page(:main, url: "#{base_url}/login")
   end
 
   step "fill credentials from params file" do

--- a/examples/smoke/store_fetch.rb
+++ b/examples/smoke/store_fetch.rb
@@ -12,12 +12,12 @@ Browserctl.workflow "smoke/store_fetch" do
   param :base_url, default: "https://the-internet.herokuapp.com"
 
   step "open dynamic loading page" do
-    client.open_page("main", url: "#{base_url}/dynamic_loading/1")
+    open_page(:main, url: "#{base_url}/dynamic_loading/1")
   end
 
   step "click start and capture loaded text" do
     page(:main).click("div#start button")
-    page(:main).wait_for("div#finish", timeout: 10)
+    page(:main).wait("div#finish", timeout: 10)
     text = client.evaluate("main", "document.querySelector('div#finish h4')?.innerText?.trim()")[:result]
     assert text && !text.empty?, "expected loaded text, got: #{text.inspect}"
     store(:loaded_text, text)

--- a/examples/smoke/store_fetch.rb
+++ b/examples/smoke/store_fetch.rb
@@ -32,8 +32,8 @@ Browserctl.workflow "smoke/store_fetch" do
 
   step "confirm fetch raises for unknown key" do
     fetch(:nonexistent_key)
-    assert false, "expected KeyError was not raised"
-  rescue KeyError => e
-    puts "  [ok] KeyError raised as expected: #{e.message}"
+    assert false, "expected WorkflowError was not raised"
+  rescue Browserctl::WorkflowError => e
+    puts "  [ok] WorkflowError raised as expected: #{e.message}"
   end
 end

--- a/examples/test_automation_practices/checkboxes.rb
+++ b/examples/test_automation_practices/checkboxes.rb
@@ -7,7 +7,7 @@ Browserctl.workflow "test_automation_practices/checkboxes" do
   param :screenshot_path, default: File.expand_path(".browserctl/screenshots/test_automation_practices_checkboxes.png")
 
   step "open checkboxes page" do
-    client.open_page("main", url: "#{base_url}/#/checkboxes")
+    open_page(:main, url: "#{base_url}/#/checkboxes")
   end
 
   step "read initial state — checkbox 2 pre-checked" do

--- a/examples/test_automation_practices/dynamic_elements.rb
+++ b/examples/test_automation_practices/dynamic_elements.rb
@@ -8,7 +8,7 @@ Browserctl.workflow "test_automation_practices/dynamic_elements" do
         default: File.expand_path(".browserctl/screenshots/test_automation_practices_dynamic_elements.png")
 
   step "open dynamic elements page" do
-    client.open_page("main", url: "#{base_url}/#/dynamic-elements")
+    open_page(:main, url: "#{base_url}/#/dynamic-elements")
   end
 
   step "assert no dynamic items exist before reload" do
@@ -19,7 +19,7 @@ Browserctl.workflow "test_automation_practices/dynamic_elements" do
   step "click reload and wait for items" do
     page(:main).click("[data-test='reload-button']")
     # loading indicator appears first; wait for it to clear and items to render
-    page(:main).watch("[data-test='dynamic-item-0']", timeout: 15)
+    page(:main).wait("[data-test='dynamic-item-0']", timeout: 15)
   end
 
   step "verify all three dynamic items are present" do
@@ -33,7 +33,7 @@ Browserctl.workflow "test_automation_practices/dynamic_elements" do
 
   step "toggle hidden content on" do
     page(:main).click("[data-test='toggle-hidden-button']")
-    page(:main).wait_for("[data-test='hidden-content']", timeout: 5)
+    page(:main).wait("[data-test='hidden-content']", timeout: 5)
     visible = client.evaluate("main", "!!document.querySelector('[data-test=\"hidden-content\"]')")[:result]
     assert visible, "expected hidden content to appear after toggle"
   end

--- a/examples/test_automation_practices/key_press.rb
+++ b/examples/test_automation_practices/key_press.rb
@@ -7,7 +7,7 @@ Browserctl.workflow "test_automation_practices/key_press" do
   param :screenshot_path, default: File.expand_path(".browserctl/screenshots/test_automation_practices_key_press.png")
 
   step "open key press page" do
-    client.open_page("main", url: "#{base_url}/#/key-press")
+    open_page(:main, url: "#{base_url}/#/key-press")
   end
 
   step "dispatch key events and verify last-key display" do

--- a/examples/test_automation_practices/login.rb
+++ b/examples/test_automation_practices/login.rb
@@ -9,7 +9,7 @@ Browserctl.workflow "test_automation_practices/login" do
   param :screenshot_path, default: File.expand_path(".browserctl/screenshots/test_automation_practices_login.png")
 
   step "open auth page" do
-    client.open_page("main", url: "#{base_url}/#/auth")
+    open_page(:main, url: "#{base_url}/#/auth")
   end
 
   step "fill and submit credentials" do
@@ -19,7 +19,7 @@ Browserctl.workflow "test_automation_practices/login" do
   end
 
   step "verify successful login" do
-    page(:main).wait_for("[data-test='auth-success']", timeout: 10)
+    page(:main).wait("[data-test='auth-success']", timeout: 10)
     msg = client.evaluate("main", "document.querySelector('[data-test=\"auth-success\"]')?.innerText?.trim()")[:result]
     assert msg&.length&.positive?, "expected a success message, got: #{msg.inspect}"
     page(:main).screenshot(path: screenshot_path)
@@ -27,7 +27,7 @@ Browserctl.workflow "test_automation_practices/login" do
 
   step "logout and verify form reappears" do
     page(:main).click("[data-test='logout-button']")
-    page(:main).wait_for("[data-test='login-button']", timeout: 5)
+    page(:main).wait("[data-test='login-button']", timeout: 5)
     visible = client.evaluate("main", "!!document.querySelector('[data-test=\"login-button\"]')")[:result]
     assert visible, "expected login form to reappear after logout"
   end

--- a/examples/test_automation_practices/login_negative.rb
+++ b/examples/test_automation_practices/login_negative.rb
@@ -8,7 +8,7 @@ Browserctl.workflow "test_automation_practices/login_negative" do
         default: File.expand_path(".browserctl/screenshots/test_automation_practices_login_negative.png")
 
   step "open auth page" do
-    client.open_page("main", url: "#{base_url}/#/auth")
+    open_page(:main, url: "#{base_url}/#/auth")
   end
 
   step "submit wrong credentials" do
@@ -18,7 +18,7 @@ Browserctl.workflow "test_automation_practices/login_negative" do
   end
 
   step "verify error is shown and success is absent" do
-    page(:main).wait_for("[data-test='auth-error']", timeout: 10)
+    page(:main).wait("[data-test='auth-error']", timeout: 10)
     error = client.evaluate("main", "document.querySelector('[data-test=\"auth-error\"]')?.innerText?.trim()")[:result]
     assert error&.length&.positive?, "expected an error message, got: #{error.inspect}"
     no_success = client.evaluate("main", "!document.querySelector('[data-test=\"auth-success\"]')")[:result]

--- a/examples/test_automation_practices/notifications.rb
+++ b/examples/test_automation_practices/notifications.rb
@@ -14,8 +14,8 @@ Browserctl.workflow "test_automation_practices/notifications" do
         default: File.expand_path(".browserctl/screenshots/test_automation_practices_notifications.png")
 
   step "open notifications page and record baseline" do
-    client.open_page("main", url: "#{base_url}/#/notifications")
-    page(:main).wait_for("[data-test='notification-container']", timeout: 5)
+    open_page(:main, url: "#{base_url}/#/notifications")
+    page(:main).wait("[data-test='notification-container']", timeout: 5)
     # Let any delayed on-load notifications finish appearing before we snapshot the baseline
     sleep 1
     store(:baseline, client.evaluate("main", NOTIFICATION_ITEMS_JS)[:result])
@@ -24,7 +24,7 @@ Browserctl.workflow "test_automation_practices/notifications" do
   step "trigger success notification and verify count increased by 1" do
     base = fetch(:baseline)
     page(:main).click("[data-test='add-success']")
-    page(:main).wait_for("[data-test^='notification-']:not([data-test='notification-container'])", timeout: 5)
+    page(:main).wait("[data-test^='notification-']:not([data-test='notification-container'])", timeout: 5)
     count = client.evaluate("main", NOTIFICATION_ITEMS_JS)[:result]
     assert count == base + 1, "expected #{base + 1} notifications after success, got: #{count}"
   end
@@ -49,7 +49,7 @@ Browserctl.workflow "test_automation_practices/notifications" do
     base = fetch(:baseline)
     page(:main).click("[data-test='add-error']")
     page(:main).click("[data-test='add-info']")
-    page(:main).wait_for("[data-test^='notification-']:not([data-test='notification-container'])", timeout: 5)
+    page(:main).wait("[data-test^='notification-']:not([data-test='notification-container'])", timeout: 5)
     count = client.evaluate("main", NOTIFICATION_ITEMS_JS)[:result]
     assert count == base + 2, "expected #{base + 2} notifications (error + info), got: #{count}"
     page(:main).screenshot(path: screenshot_path)

--- a/examples/the_internet/add_remove_elements.rb
+++ b/examples/the_internet/add_remove_elements.rb
@@ -7,7 +7,7 @@ Browserctl.workflow "the_internet/add_remove_elements" do
   param :screenshot_path, default: File.expand_path(".browserctl/screenshots/the_internet_add_remove_elements.png")
 
   step "open add/remove elements page" do
-    client.open_page("main", url: "#{base_url}/add_remove_elements/")
+    open_page(:main, url: "#{base_url}/add_remove_elements/")
   end
 
   step "add three elements" do

--- a/examples/the_internet/checkboxes.rb
+++ b/examples/the_internet/checkboxes.rb
@@ -7,7 +7,7 @@ Browserctl.workflow "the_internet/checkboxes" do
   param :screenshot_path, default: File.expand_path(".browserctl/screenshots/the_internet_checkboxes.png")
 
   step "open checkboxes page" do
-    client.open_page("main", url: "#{base_url}/checkboxes")
+    open_page(:main, url: "#{base_url}/checkboxes")
   end
 
   step "read initial state" do

--- a/examples/the_internet/dropdown.rb
+++ b/examples/the_internet/dropdown.rb
@@ -7,7 +7,7 @@ Browserctl.workflow "the_internet/dropdown" do
   param :screenshot_path, default: File.expand_path(".browserctl/screenshots/the_internet_dropdown.png")
 
   step "open dropdown page" do
-    client.open_page("main", url: "#{base_url}/dropdown")
+    open_page(:main, url: "#{base_url}/dropdown")
   end
 
   step "assert default is unselected" do

--- a/examples/the_internet/dynamic_loading.rb
+++ b/examples/the_internet/dynamic_loading.rb
@@ -7,7 +7,7 @@ Browserctl.workflow "the_internet/dynamic_loading" do
   param :screenshot_path, default: File.expand_path(".browserctl/screenshots/the_internet_dynamic_loading.png")
 
   step "open dynamic loading page" do
-    client.open_page("main", url: "#{base_url}/dynamic_loading/1")
+    open_page(:main, url: "#{base_url}/dynamic_loading/1")
   end
 
   step "assert finish text is hidden before start" do
@@ -17,7 +17,7 @@ Browserctl.workflow "the_internet/dynamic_loading" do
 
   step "click Start and wait for content" do
     page(:main).click("#start button")
-    page(:main).wait_for("#finish h4", timeout: 10)
+    page(:main).wait("#finish h4", timeout: 10)
   end
 
   step "assert finish text is correct" do

--- a/examples/the_internet/login.rb
+++ b/examples/the_internet/login.rb
@@ -9,7 +9,7 @@ Browserctl.workflow "the_internet/login" do
   param :screenshot_path, default: File.expand_path(".browserctl/screenshots/the_internet_login.png")
 
   step "open login page" do
-    client.open_page("main", url: "#{base_url}/login")
+    open_page(:main, url: "#{base_url}/login")
   end
 
   step "fill and submit credentials" do

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -30,6 +30,7 @@ module Browserctl
       "page_open" => :cmd_page_open,
       "page_close" => :cmd_page_close,
       "page_list" => :cmd_page_list,
+      "page_focus" => :cmd_page_focus,
       "navigate" => :cmd_navigate,
       "wait" => :cmd_wait,
       "snapshot" => :cmd_snapshot,

--- a/lib/browserctl/server/handlers/page_lifecycle.rb
+++ b/lib/browserctl/server/handlers/page_lifecycle.rb
@@ -23,6 +23,13 @@ module Browserctl
         def cmd_page_list(_req)
           { pages: @global_mutex.synchronize { @pages.keys } }
         end
+
+        def cmd_page_focus(req)
+          with_page(req[:name]) do |session|
+            session.page.activate
+            { ok: true }
+          end
+        end
       end
     end
   end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "webrick"
+require "tmpdir"
+require "json"
+require "fileutils"
+require "browserctl/session"
+
+RSpec.describe "session commands", :integration do
+  def start_html_server
+    log    = WEBrick::Log.new(File::NULL)
+    server = WEBrick::HTTPServer.new(Port: 0, Logger: log, AccessLog: [])
+    server.mount_proc("/") do |_, res|
+      res.body = "<html><body>session test</body></html>"
+      res["Content-Type"] = "text/html"
+    end
+    Thread.new { server.start }
+    [server, server.config[:Port]]
+  end
+
+  before(:all) do
+    @client = start_daemon
+    @server, @port = start_html_server
+  end
+
+  after(:all) do
+    stop_daemon
+    @server.shutdown
+  end
+
+  def session_dir(name)
+    File.join(Browserctl::Session::BASE_DIR, name)
+  end
+
+  let(:session_name) { "test_#{Process.pid}_#{rand(100_000)}" }
+
+  after do
+    FileUtils.rm_rf(session_dir(session_name))
+    begin
+      @client.page_close("sp")
+    rescue StandardError
+      nil
+    end
+  end
+
+  describe "session_save" do
+    it "returns error when no pages are open" do
+      res = @client.session_save(session_name)
+      expect(res[:error]).to match(/no open pages/)
+    end
+
+    it "returns page and cookie counts" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.set_cookie("sp", "save_test", "cval", "localhost")
+
+      res = @client.session_save(session_name)
+      expect(res[:ok]).to be true
+      expect(res[:pages]).to eq(1)
+      expect(res[:cookies]).to be >= 1
+    end
+
+    it "writes metadata.json, cookies.json, and local_storage.json to disk" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.session_save(session_name)
+
+      dir = session_dir(session_name)
+      expect(File.exist?(File.join(dir, "metadata.json"))).to be true
+      expect(File.exist?(File.join(dir, "cookies.json"))).to be true
+      expect(File.exist?(File.join(dir, "local_storage.json"))).to be true
+    end
+
+    it "captures localStorage for the page's origin" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.storage_set("sp", "saved_key", "saved_val")
+      @client.session_save(session_name)
+
+      ls = JSON.parse(File.read(File.join(session_dir(session_name), "local_storage.json")))
+      values = ls.values.first
+      expect(values["saved_key"]).to eq("saved_val")
+    end
+
+    it "records the saved page's name and URL in metadata.json" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.session_save(session_name)
+
+      meta = JSON.parse(File.read(File.join(session_dir(session_name), "metadata.json")), symbolize_names: true)
+      expect(meta[:name]).to eq(session_name)
+      expect(meta[:pages]).to have_key(:sp)
+      expect(meta[:pages][:sp][:url]).to start_with("http://localhost:#{@port}")
+    end
+  end
+
+  describe "session_list" do
+    it "includes the saved session by name" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.session_save(session_name)
+
+      res = @client.session_list
+      expect(res[:ok]).to be true
+      names = res[:sessions].map { |s| s[:name] }
+      expect(names).to include(session_name)
+    end
+  end
+
+  describe "session_delete" do
+    it "removes the session directory from disk" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.session_save(session_name)
+      expect(Dir.exist?(session_dir(session_name))).to be true
+
+      @client.session_delete(session_name)
+      expect(Dir.exist?(session_dir(session_name))).to be false
+    end
+  end
+
+  describe "session_load" do
+    it "reopens saved pages at their saved URLs" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.session_save(session_name)
+      @client.page_close("sp")
+      expect(@client.page_list[:pages]).not_to include("sp")
+
+      @client.session_load(session_name)
+
+      expect(@client.page_list[:pages]).to include("sp")
+      expect(@client.url("sp")[:url]).to start_with("http://localhost:#{@port}")
+    end
+
+    it "restores cookies into the shared cookie jar" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.set_cookie("sp", "restore_me", "cookie_value", "localhost")
+      @client.session_save(session_name)
+      @client.delete_cookies("sp")
+      expect(@client.cookies("sp")[:cookies].map { |c| c[:name] }).not_to include("restore_me")
+
+      @client.page_close("sp")
+      @client.session_load(session_name)
+
+      cookie_names = @client.cookies("sp")[:cookies].map { |c| c[:name] }
+      expect(cookie_names).to include("restore_me")
+    end
+
+    it "restores localStorage for the page's origin" do
+      @client.page_open("sp", url: "http://localhost:#{@port}/")
+      @client.storage_set("sp", "load_key", "load_val")
+      @client.session_save(session_name)
+      @client.storage_delete("sp")
+      expect(@client.storage_get("sp", "load_key")[:value]).to be_nil
+
+      @client.page_close("sp")
+      @client.session_load(session_name)
+
+      expect(@client.storage_get("sp", "load_key")[:value]).to eq("load_val")
+    end
+
+    it "returns error when the session does not exist" do
+      res = @client.session_load("no_such_session_xyz_abc_123")
+      expect(res[:error]).to match(/not found/)
+    end
+  end
+end

--- a/spec/integration/storage_spec.rb
+++ b/spec/integration/storage_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "webrick"
+require "tmpdir"
+require "json"
+
+RSpec.describe "storage commands", :integration do
+  def start_html_server
+    log    = WEBrick::Log.new(File::NULL)
+    server = WEBrick::HTTPServer.new(Port: 0, Logger: log, AccessLog: [])
+    server.mount_proc("/") do |_, res|
+      res.body = "<html><body>storage test</body></html>"
+      res["Content-Type"] = "text/html"
+    end
+    Thread.new { server.start }
+    [server, server.config[:Port]]
+  end
+
+  before(:all) do
+    @client = start_daemon
+    @server, @port = start_html_server
+    @client.page_open("store", url: "http://localhost:#{@port}/")
+  end
+
+  after(:all) do
+    stop_daemon
+    @server.shutdown
+  end
+
+  after do
+    @client.storage_delete("store")
+  rescue StandardError
+    nil
+  end
+
+  describe "storage_set and storage_get" do
+    it "roundtrips a localStorage key" do
+      @client.storage_set("store", "theme", "dark")
+      res = @client.storage_get("store", "theme")
+      expect(res[:ok]).to be true
+      expect(res[:value]).to eq("dark")
+    end
+
+    it "returns nil for a key that has not been set" do
+      res = @client.storage_get("store", "nonexistent_xyz")
+      expect(res[:ok]).to be true
+      expect(res[:value]).to be_nil
+    end
+
+    it "roundtrips a sessionStorage key" do
+      @client.storage_set("store", "sess_key", "sess_val", store: "session")
+      res = @client.storage_get("store", "sess_key", store: "session")
+      expect(res[:ok]).to be true
+      expect(res[:value]).to eq("sess_val")
+    end
+
+    it "returns error for an unknown store name" do
+      res = @client.storage_get("store", "k", store: "invalid_store")
+      expect(res[:error]).to match(/unknown store/)
+    end
+  end
+
+  describe "storage_export" do
+    it "writes a JSON file containing the page's localStorage keys" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "export.json")
+        @client.storage_set("store", "color", "blue")
+        @client.storage_set("store", "count", "42")
+
+        res = @client.storage_export("store", path)
+        expect(res[:ok]).to be true
+        expect(res[:key_count]).to be >= 2
+
+        data = JSON.parse(File.read(path))
+        expect(data).to be_a(Hash)
+        values = data.values.first
+        expect(values["color"]).to eq("blue")
+        expect(values["count"]).to eq("42")
+      end
+    end
+
+    it "returns the file path in the response" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "out.json")
+        res = @client.storage_export("store", path)
+        expect(res[:path]).to eq(path)
+      end
+    end
+  end
+
+  describe "storage_import" do
+    it "seeds keys from a JSON file into the page's localStorage" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "import.json")
+        File.write(path, JSON.generate({
+                                         "http://localhost:#{@port}" => { "imported_key" => "imported_val", "another" => "xyz" }
+                                       }))
+
+        res = @client.storage_import("store", path)
+        expect(res[:ok]).to be true
+        expect(res[:key_count]).to eq(2)
+
+        expect(@client.storage_get("store", "imported_key")[:value]).to eq("imported_val")
+        expect(@client.storage_get("store", "another")[:value]).to eq("xyz")
+      end
+    end
+
+    it "returns error when the file does not exist" do
+      res = @client.storage_import("store", "/tmp/no_such_storage_file_xyz_abc.json")
+      expect(res[:error]).to match(/file not found/)
+    end
+  end
+
+  describe "storage_delete" do
+    it "clears all localStorage keys" do
+      @client.storage_set("store", "to_clear", "yes")
+      @client.storage_set("store", "also_clear", "yes")
+
+      @client.storage_delete("store")
+
+      expect(@client.storage_get("store", "to_clear")[:value]).to be_nil
+      expect(@client.storage_get("store", "also_clear")[:value]).to be_nil
+    end
+
+    it "clears only localStorage when stores: local is specified" do
+      @client.storage_set("store", "local_key", "lv")
+      @client.storage_set("store", "sess_key", "sv", store: "session")
+
+      @client.storage_delete("store", stores: "local")
+
+      expect(@client.storage_get("store", "local_key")[:value]).to be_nil
+      expect(@client.storage_get("store", "sess_key", store: "session")[:value]).to eq("sv")
+    end
+
+    it "clears only sessionStorage when stores: session is specified" do
+      @client.storage_set("store", "local_k", "lv")
+      @client.storage_set("store", "sess_k", "sv", store: "session")
+
+      @client.storage_delete("store", stores: "session")
+
+      expect(@client.storage_get("store", "local_k")[:value]).to eq("lv")
+      expect(@client.storage_get("store", "sess_k", store: "session")[:value]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Wire `page_focus`** into `COMMAND_MAP` and implement `cmd_page_focus` via Ferrum's `page.activate` — completes the v0.6 `page` subcommand group (`open`, `close`, `list`, `focus`)
- **Add integration specs** for session and storage commands (`spec/integration/session_spec.rb`, `spec/integration/storage_spec.rb`)
- **Fix six copy-paste-breaking doc errors** introduced by the v0.6 rename/redesign

## Doc fixes

| File | Error | Fix |
|---|---|---|
| `guides/handling-challenges.md` | `browserctl cookies main` (pre-v0.6 name) | → `cookie list main` |
| `product.md` | `browserctl record my-bug` (missing subcommand) | → `record start my-bug` + `record stop` |
| `vs-agent-browser.md` | `browserctl inspect` (renamed in v0.6) | → `devtools <page>` |
| `product.md` + `vs-agent-browser.md` | `snap.ref(:email_field)` (invented API) | → CSS selectors |
| `product.md` | `screenshot(out:)` | → `screenshot(path:)` (matches guide) |
| `concepts/hitl.md` | "planned for v0.6" (shipped) | → v0.7 |
| `concepts/snapshots-and-refs.md` | `snap --diff` prose alias | → `snapshot --diff` |

## Test plan

- [ ] `browserctl page focus <name>` works in headed mode against a live daemon
- [ ] `browserctl page focus <name>` returns a clean error when page name doesn't exist
- [ ] Run `bundle exec rspec spec/integration/` against a live daemon
- [ ] Spot-check each corrected code snippet in the docs is copy-pasteable