### PR TITLE
fix: README & CONTRIBUTING polish + Rakefile v0.6 CI fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to browserctl
 
-Thank you for taking the time to contribute! This guide covers everything you need to get started.
+This guide covers the workflow for contributing code, docs, and bug reports to browserctl.
 
 ## Table of Contents
 
@@ -16,7 +16,7 @@ Thank you for taking the time to contribute! This guide covers everything you ne
 
 ## Development Setup
 
-**Requirements:** Ruby >= 3.3, Chrome or Chromium on `PATH`
+**Requirements:** Ruby >= 3.3, Chrome or Chromium installed
 
 ```bash
 git clone https://github.com/patrick204nqh/browserctl
@@ -24,7 +24,7 @@ cd browserctl
 bin/setup
 ```
 
-`bin/setup` installs gem dependencies and checks for Chrome/Chromium.
+`bin/setup` installs gem dependencies and checks for Chrome/Chromium. It also installs [lefthook](https://github.com/evilmartians/lefthook) Git hooks — pre-commit runs RuboCop, pre-push runs the test suite.
 
 ---
 
@@ -83,6 +83,7 @@ Configuration lives in `.rubocop.yml`. Please keep new code consistent with the 
 **Branch naming conventions:**
 - `fix/<short-description>` — bug fixes
 - `feat/<short-description>` — new features
+- `docs/<short-description>` — documentation changes
 - `chore/<short-description>` — maintenance, refactoring, deps
 
 ---
@@ -104,7 +105,7 @@ release-please opens (or updates) a Release PR
         ↓
 maintainer reviews and merges the Release PR
         ↓
-release-please creates a GitHub Release + tag (e.g. v0.2.0)
+release-please creates a GitHub Release + tag (e.g. v0.6.0)
         ↓
 release workflow triggers → gem built and pushed to RubyGems
 ```
@@ -143,7 +144,7 @@ This project follows [Semantic Versioning](https://semver.org). release-please d
 Open an issue at [github.com/patrick204nqh/browserctl/issues](https://github.com/patrick204nqh/browserctl/issues). Include:
 
 - Ruby version (`ruby --version`)
-- Chrome/Chromium version (`google-chrome --version`)
+- Chrome/Chromium version (`google-chrome --version` on Linux; `open -a "Google Chrome" --args --version` on macOS)
 - OS and version
 - Steps to reproduce
 - Expected vs. actual behavior

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ gem install browserctl
 browserd &
 
 # 3. Open a named page
-browserctl page open main --url https://the-internet.herokuapp.com/login
+browserctl page open main --url https://moatazeldebsy.github.io/test-automation-practices/#/auth
 
 # 4. Snapshot — returns JSON with a ref ID per interactable element
 browserctl snapshot main
-# → [{"ref":"e1","tag":"input","attrs":{"id":"username"}}, {"ref":"e2",...}, {"ref":"e3","tag":"button","text":"Login",...}]
+# → [{"ref":"e1","tag":"input","attrs":{"data-test":"username-input"}}, {"ref":"e2",...}, {"ref":"e3","tag":"button","text":"Login",...}]
 
 # 5. Interact using the ref IDs from the snapshot
-browserctl fill main --ref e1 --value tomsmith
-browserctl fill main --ref e2 --value SuperSecretPassword!
+browserctl fill main --ref e1 --value admin
+browserctl fill main --ref e2 --value admin
 browserctl click main --ref e3
 
 # 6. Observe

--- a/README.md
+++ b/README.md
@@ -50,14 +50,7 @@ browserctl daemon stop
 </td>
 </tr></table>
 
-> Demo assets are regenerated automatically on every push to `main` that touches `demo/` or the login example. To regenerate locally:
->
-> ```bash
-> rake demo               # full pipeline: screenshots + browser GIF + terminal GIF
-> rake demo:screenshots   # smoke test screenshots only
-> rake demo:browser_gif   # browser animation only  (requires: ffmpeg)
-> rake demo:terminal      # terminal GIF only        (requires: vhs)
-> ```
+> Demo assets are regenerated automatically on every push to `main` that touches `demo/` or the login example. See [Development](#development) to regenerate locally.
 
 ---
 
@@ -210,9 +203,10 @@ bin/setup              # brew bundle (macOS) + bundle install + Chrome check
 bundle exec rspec      # run tests
 bundle exec rubocop    # lint
 
-rake demo              # regenerate screenshots + terminal GIF
-rake demo:screenshots  # screenshots only (no VHS required)
-rake demo:terminal     # terminal GIF only
+rake demo               # full pipeline: screenshots + browser GIF + terminal GIF
+rake demo:screenshots   # smoke test screenshots only
+rake demo:browser_gif   # browser animation only  (requires: ffmpeg)
+rake demo:terminal      # terminal GIF only        (requires: vhs)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">browserctl</h1>
 
 <p align="center">
-  A persistent browser daemon for AI agents and iterative dev workflows — the session stays alive between commands.
+  A browser daemon that keeps sessions alive between commands — for AI agents and iterative dev workflows.
 </p>
 
 <p align="center">
@@ -20,10 +20,10 @@ Every browser automation tool restarts the browser when your script ends. That m
 
 ```bash
 browserd &                                               # start the daemon (headless)
-browserctl page open login --url https://example.com/login
-browserctl snapshot login                                # AI-friendly JSON snapshot with ref IDs
-browserctl fill login --ref e1 --value me@example.com   # interact by ref, no selectors needed
-browserctl click login --ref e2
+browserctl page open main --url https://example.com/login
+browserctl snapshot main                                 # AI-friendly JSON snapshot with ref IDs
+browserctl fill main --ref e1 --value me@example.com    # interact by ref, no selectors needed
+browserctl click main --ref e2
 browserctl daemon stop
 ```
 
@@ -50,8 +50,6 @@ browserctl daemon stop
 </td>
 </tr></table>
 
-> Demo assets are regenerated automatically on every push to `main` that touches `demo/` or the login example. See [Development](#development) to regenerate locally.
-
 ---
 
 ## Quick Start
@@ -64,18 +62,19 @@ gem install browserctl
 browserd &
 
 # 3. Open a named page
-browserctl page open main --url https://moatazeldebsy.github.io/test-automation-practices/#/auth
+browserctl page open main --url https://the-internet.herokuapp.com/login
 
-# 4. Snapshot the page — get AI-friendly JSON with ref IDs
+# 4. Snapshot — returns JSON with a ref ID per interactable element
 browserctl snapshot main
+# → [{"ref":"e1","tag":"input","attrs":{"id":"username"}}, {"ref":"e2",...}, {"ref":"e3","tag":"button","text":"Login",...}]
 
-# 5. Interact using refs
-browserctl fill  main --ref e1 --value admin
-browserctl fill  main --ref e2 --value admin
+# 5. Interact using the ref IDs from the snapshot
+browserctl fill main --ref e1 --value tomsmith
+browserctl fill main --ref e2 --value SuperSecretPassword!
 browserctl click main --ref e3
 
 # 6. Observe
-browserctl url  main
+browserctl url main
 browserctl snapshot main --diff   # only what changed
 
 # 7. Done
@@ -100,7 +99,7 @@ browserctl daemon stop
 
 Most automation tools are stateless — every script spins up a fresh browser and tears it down. browserctl doesn't.
 
-| | browserctl | Playwright / Selenium |
+| Capability | browserctl | Playwright / Selenium |
 |---|---|---|
 | Session persists across commands | ✓ | ✗ (per-script lifecycle) |
 | Named page handles | ✓ | ✗ |
@@ -118,7 +117,7 @@ Most automation tools are stateless — every script spins up a fresh browser an
 
 ## Installation
 
-**Requirements:** Ruby >= 3.3 · Chrome or Chromium on your `PATH`
+**Requirements:** Ruby >= 3.3 · Chrome or Chromium installed
 
 ```bash
 gem install browserctl
@@ -158,7 +157,7 @@ browserctl ships as a Claude Code plugin. Install it once and Claude automatical
 }
 ```
 
-Once installed, Claude Code loads the `browserctl` skill automatically — no `/invoke` needed.
+Once installed, the `browserctl` skill loads automatically.
 
 ---
 
@@ -208,6 +207,8 @@ rake demo:screenshots   # smoke test screenshots only
 rake demo:browser_gif   # browser animation only  (requires: ffmpeg)
 rake demo:terminal      # terminal GIF only        (requires: vhs)
 ```
+
+> Demo assets are regenerated automatically on every push to `main` that touches `demo/` or the login example.
 
 ---
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,14 +15,14 @@ EXAMPLES = {
 }.freeze
 
 def shutdown_daemon
-  system("bundle exec browserctl shutdown", out: File::NULL, err: File::NULL)
+  system("bundle exec browserctl daemon stop", out: File::NULL, err: File::NULL)
 rescue StandardError
   nil
 end
 
 def daemon_ready?
   30.times.any? do
-    break true if system("bundle exec browserctl ping", out: File::NULL, err: File::NULL)
+    break true if system("bundle exec browserctl daemon ping", out: File::NULL, err: File::NULL)
 
     sleep 0.5
     false


### PR DESCRIPTION
## Summary

- **Rakefile** — `browserctl ping/shutdown` → `daemon ping/daemon stop` (fixes the assets CI job that was timing out)
- **README** — tighten subtitle, consistent page name in hero, switch Quick Start to stable URL with snapshot output context, fix Chrome PATH requirement, add table header, move demo regen note to Development, drop `/invoke` jargon
- **CONTRIBUTING** — drop generic opener, fix Chrome PATH requirement, document lefthook hooks, add `docs/` branch prefix, fix macOS Chrome version command, update stale release example version

## Test plan

- [ ] Assets CI job passes after Rakefile fix
- [ ] Quick Start commands are copy-pasteable against the-internet.herokuapp.com
- [ ] Review README renders correctly on GitHub
- [ ] Review CONTRIBUTING renders correctly on GitHub