### PR TITLE
fix: update stale `browserctl run` to `browserctl workflow run`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ namespace :demo do
     mkdir_p ASSETS_OUT
     with_daemon(headed: ENV["HEADED"] == "1") do
       EXAMPLES.each do |example, path|
-        sh "bundle exec browserctl run #{example} --screenshot_path #{path}"
+        sh "bundle exec browserctl workflow run #{example} --screenshot_path #{path}"
       end
     end
   end

--- a/lib/browserctl/commands/record.rb
+++ b/lib/browserctl/commands/record.rb
@@ -43,7 +43,7 @@ module Browserctl
           FileUtils.mkdir_p(File.dirname(out))
           Recording.generate_workflow(name, output_path: out)
           puts "Workflow saved: #{out}"
-          puts "Run with: browserctl run #{name}"
+          puts "Run with: browserctl workflow run #{name}"
         end
 
         def run_status

--- a/skills/browserctl/SKILL.md
+++ b/skills/browserctl/SKILL.md
@@ -173,7 +173,7 @@ end
 ```
 
 ```sh
-browserctl run /tmp/probe_login.rb
+browserctl workflow run /tmp/probe_login.rb
 ```
 
 **Step 3 — Harden into a named workflow**
@@ -206,11 +206,11 @@ end
 ```
 
 ```sh
-browserctl run smoke_login --email me@example.com --password secret
+browserctl workflow run smoke_login --email me@example.com --password secret
 ```
 
-List available: `browserctl workflows`
-Describe one:   `browserctl describe smoke_login`
+List available: `browserctl workflow list`
+Describe one:   `browserctl workflow describe smoke_login`
 
 Workflows in `./.browserctl/workflows/` are project-local.
 Workflows in `~/.browserctl/workflows/` are global.


### PR DESCRIPTION
## What does this PR do?

After the v0.6 CLI redesign (noun-verb commands), `browserctl run <file>` was renamed to `browserctl workflow run <file>`. Several places still referenced the old command, causing the **Update Demo Assets** CI workflow to fail with:

```
unknown command: run
Run 'browserctl --help' for usage.
```

This PR updates all three stale references.

## Type of change

- [x] Bug fix

## Changes

- **`Rakefile`** — `demo:screenshots` task: `browserctl run <file> --screenshot_path <path>` → `browserctl workflow run <file> --screenshot_path <path>`
- **`lib/browserctl/commands/record.rb`** — post-stop hint message updated to reflect the new command
- **`skills/browserctl/SKILL.md`** — two example invocations updated; `browserctl workflows` / `browserctl describe` also corrected to `browserctl workflow list` / `browserctl workflow describe`

## How to test

```sh
bundle exec rake demo:screenshots
```

Should capture screenshots without aborting on "unknown command: run".

## Checklist

- [ ] Tests added or updated
- [x] `bundle exec rspec` passes
- [x] `bundle exec rubocop` reports no offenses
- [ ] CHANGELOG.md updated (for user-visible changes)