### PR TITLE
feat(v0.8): secret resolver plugin system + load_session fallback

### DIFF
--- a/lib/browserctl.rb
+++ b/lib/browserctl.rb
@@ -3,6 +3,7 @@
 require_relative "browserctl/version"
 require_relative "browserctl/constants"
 require_relative "browserctl/errors"
+require_relative "browserctl/secret_resolvers"
 require_relative "browserctl/workflow"
 require_relative "browserctl/runner"
 require_relative "browserctl/client"

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -22,4 +22,7 @@ module Browserctl
   class DomainNotAllowed < Error; def self.default_code = "domain_not_allowed" end
   class TimeoutError     < Error; def self.default_code = "timeout"            end
   class KeyNotFound      < Error; def self.default_code = "key_not_found"      end
+
+  class WorkflowError < StandardError; end
+  class SecretResolverError < WorkflowError; end
 end

--- a/lib/browserctl/secret_resolver_registry.rb
+++ b/lib/browserctl/secret_resolver_registry.rb
@@ -16,7 +16,10 @@ module Browserctl
       scheme, reference = secret_ref.split("://", 2)
       resolver = @mutex.synchronize { @registry[scheme] }
       raise SecretResolverError, "unknown secret resolver scheme '#{scheme}'" unless resolver
-      raise SecretResolverError, "'#{scheme}://' resolver is not available in this environment" unless resolver.available?
+      unless resolver.available?
+        raise SecretResolverError,
+              "'#{scheme}://' resolver is not available in this environment"
+      end
 
       resolver.resolve(reference)
     rescue SecretResolverError

--- a/lib/browserctl/secret_resolver_registry.rb
+++ b/lib/browserctl/secret_resolver_registry.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "errors"
+
+module Browserctl
+  class SecretResolverRegistry
+    @mutex    = Mutex.new
+    @registry = {}
+
+    def self.register(resolver_class)
+      instance = resolver_class.new
+      @mutex.synchronize { @registry[resolver_class.scheme] = instance }
+    end
+
+    def self.resolve(secret_ref)
+      scheme, reference = secret_ref.split("://", 2)
+      resolver = @mutex.synchronize { @registry[scheme] }
+      raise SecretResolverError, "unknown secret resolver scheme '#{scheme}'" unless resolver
+      raise SecretResolverError, "'#{scheme}://' resolver is not available in this environment" unless resolver.available?
+
+      resolver.resolve(reference)
+    rescue SecretResolverError
+      raise
+    rescue StandardError => e
+      raise SecretResolverError, "secret resolution failed for #{secret_ref.inspect}: #{e.message}"
+    end
+
+    def self.registered?(scheme)
+      @mutex.synchronize { @registry.key?(scheme) }
+    end
+
+    def self.reset!
+      @mutex.synchronize { @registry.clear }
+    end
+  end
+end

--- a/lib/browserctl/secret_resolvers.rb
+++ b/lib/browserctl/secret_resolvers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "secret_resolver_registry"
+require_relative "secret_resolvers/base"
+require_relative "secret_resolvers/env"
+require_relative "secret_resolvers/macos_keychain"
+require_relative "secret_resolvers/one_password"
+
+Browserctl::SecretResolverRegistry.register(Browserctl::SecretResolvers::Env)
+Browserctl::SecretResolverRegistry.register(Browserctl::SecretResolvers::MacOSKeychain)
+Browserctl::SecretResolverRegistry.register(Browserctl::SecretResolvers::OnePassword)
+
+user_resolvers = File.expand_path("~/.browserctl/resolvers.rb")
+load user_resolvers if File.exist?(user_resolvers)

--- a/lib/browserctl/secret_resolvers/base.rb
+++ b/lib/browserctl/secret_resolvers/base.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module SecretResolvers
+    class Base
+      def self.scheme
+        raise NotImplementedError, "#{name}.scheme not implemented"
+      end
+
+      def available? = true
+
+      def resolve(_reference)
+        raise NotImplementedError, "#{self.class.name}#resolve not implemented"
+      end
+    end
+  end
+end

--- a/lib/browserctl/secret_resolvers/env.rb
+++ b/lib/browserctl/secret_resolvers/env.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module SecretResolvers
+    class Env < Base
+      def self.scheme = "env"
+
+      def resolve(reference)
+        ENV.fetch(reference) { raise SecretResolverError, "env var '#{reference}' is not set" }
+      end
+    end
+  end
+end

--- a/lib/browserctl/secret_resolvers/macos_keychain.rb
+++ b/lib/browserctl/secret_resolvers/macos_keychain.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module Browserctl
+  module SecretResolvers
+    class MacOSKeychain < Base
+      def self.scheme = "keychain"
+
+      def available?
+        RUBY_PLATFORM.include?("darwin") && system("which security > /dev/null 2>&1")
+      end
+
+      def resolve(reference)
+        service, account = reference.split("/", 2)
+        raise SecretResolverError, "keychain reference must be 'service/account', got: #{reference.inspect}" if account.nil?
+
+        result, status = Open3.capture2("security", "find-generic-password",
+                                        "-a", account, "-s", service, "-w")
+        raise SecretResolverError, "keychain item not found: #{reference}" unless status.success?
+
+        result.chomp
+      end
+    end
+  end
+end

--- a/lib/browserctl/secret_resolvers/macos_keychain.rb
+++ b/lib/browserctl/secret_resolvers/macos_keychain.rb
@@ -13,7 +13,10 @@ module Browserctl
 
       def resolve(reference)
         service, account = reference.split("/", 2)
-        raise SecretResolverError, "keychain reference must be 'service/account', got: #{reference.inspect}" if account.nil?
+        if account.nil?
+          raise SecretResolverError,
+                "keychain reference must be 'service/account', got: #{reference.inspect}"
+        end
 
         result, status = Open3.capture2("security", "find-generic-password",
                                         "-a", account, "-s", service, "-w")

--- a/lib/browserctl/secret_resolvers/one_password.rb
+++ b/lib/browserctl/secret_resolvers/one_password.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module Browserctl
+  module SecretResolvers
+    class OnePassword < Base
+      def self.scheme = "op"
+
+      def available?
+        system("which op > /dev/null 2>&1")
+      end
+
+      def resolve(reference)
+        result, status = Open3.capture2("op", "read", "op://#{reference}")
+        raise SecretResolverError, "1Password item not found: op://#{reference}" unless status.success?
+
+        result.chomp
+      end
+    end
+  end
+end

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -75,7 +75,10 @@ module Browserctl
 
       invoke(fallback.to_s)
       res2 = @client.session_load(session_name)
-      raise WorkflowError, "session '#{session_name}' still unavailable after running fallback '#{fallback}'" if res2[:error]
+      if res2[:error]
+        raise WorkflowError,
+              "session '#{session_name}' still unavailable after running fallback '#{fallback}'"
+      end
 
       res2
     end
@@ -180,7 +183,8 @@ module Browserctl
 
     def param(name, required: false, secret: false, default: nil, secret_ref: nil)
       secret = true if secret_ref
-      @param_defs[name] = ParamDef.new(name: name, required: required, secret: secret, default: default, secret_ref: secret_ref)
+      @param_defs[name] =
+        ParamDef.new(name: name, required: required, secret: secret, default: default, secret_ref: secret_ref)
     end
 
     def step(label, retry_count: 0, timeout: nil, &block)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -2,11 +2,11 @@
 
 require "timeout"
 require_relative "client"
+require_relative "errors"
+require_relative "secret_resolvers"
 
 module Browserctl
-  class WorkflowError < StandardError; end
-
-  ParamDef = Struct.new(:name, :required, :secret, :default, keyword_init: true)
+  ParamDef = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
   StepResult = Struct.new(:name, :ok, :error, keyword_init: true)
   StepDef = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
 
@@ -67,11 +67,17 @@ module Browserctl
       res
     end
 
-    def load_session(session_name)
+    def load_session(session_name, fallback: nil)
       res = @client.session_load(session_name)
-      raise WorkflowError, res[:error] if res[:error]
+      return res unless res[:error]
 
-      res
+      raise WorkflowError, res[:error] unless fallback
+
+      invoke(fallback.to_s)
+      res2 = @client.session_load(session_name)
+      raise WorkflowError, "session '#{session_name}' still unavailable after running fallback '#{fallback}'" if res2[:error]
+
+      res2
     end
 
     def list_sessions
@@ -172,8 +178,9 @@ module Browserctl
       @description = text
     end
 
-    def param(name, required: false, secret: false, default: nil)
-      @param_defs[name] = ParamDef.new(name: name, required: required, secret: secret, default: default)
+    def param(name, required: false, secret: false, default: nil, secret_ref: nil)
+      secret = true if secret_ref
+      @param_defs[name] = ParamDef.new(name: name, required: required, secret: secret, default: default, secret_ref: secret_ref)
     end
 
     def step(label, retry_count: 0, timeout: nil, &block)
@@ -223,7 +230,11 @@ module Browserctl
 
     def resolve_params(provided)
       @param_defs.each_with_object({}) do |(name, defn), out|
-        val = provided[name] || defn.default
+        val = if defn.secret_ref
+                SecretResolverRegistry.resolve(defn.secret_ref)
+              else
+                provided[name] || defn.default
+              end
         raise WorkflowError, "required param '#{name}' missing" if defn.required && val.nil?
 
         out[name] = val

--- a/spec/unit/secret_resolver_registry_spec.rb
+++ b/spec/unit/secret_resolver_registry_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Browserctl::SecretResolverRegistry do
   let(:raising_resolver_class) do
     Class.new(Browserctl::SecretResolvers::Base) do
       def self.scheme = "raises"
-      def resolve(_reference) = raise(RuntimeError, "unexpected failure")
+      def resolve(_reference) = raise("unexpected failure")
     end
   end
 
@@ -49,13 +49,13 @@ RSpec.describe Browserctl::SecretResolverRegistry do
     it "raises SecretResolverError when available? returns false" do
       described_class.register(unavailable_resolver_class)
       expect { described_class.resolve("unavail://foo") }
-        .to raise_error(Browserctl::SecretResolverError, /'unavail:\/\/' resolver is not available/)
+        .to raise_error(Browserctl::SecretResolverError, %r{'unavail://' resolver is not available})
     end
 
     it "wraps non-SecretResolverError in SecretResolverError" do
       described_class.register(raising_resolver_class)
       expect { described_class.resolve("raises://something") }
-        .to raise_error(Browserctl::SecretResolverError, /secret resolution failed for "raises:\/\/something"/)
+        .to raise_error(Browserctl::SecretResolverError, %r{secret resolution failed for "raises://something"})
     end
   end
 end

--- a/spec/unit/secret_resolver_registry_spec.rb
+++ b/spec/unit/secret_resolver_registry_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Browserctl::SecretResolverRegistry do
+  before { described_class.reset! }
+  after  { described_class.reset! }
+
+  let(:resolver_class) do
+    Class.new(Browserctl::SecretResolvers::Base) do
+      def self.scheme = "test"
+      def resolve(reference) = "resolved:#{reference}"
+    end
+  end
+
+  let(:unavailable_resolver_class) do
+    Class.new(Browserctl::SecretResolvers::Base) do
+      def self.scheme = "unavail"
+      def available? = false
+      def resolve(_reference) = "should not reach"
+    end
+  end
+
+  let(:raising_resolver_class) do
+    Class.new(Browserctl::SecretResolvers::Base) do
+      def self.scheme = "raises"
+      def resolve(_reference) = raise(RuntimeError, "unexpected failure")
+    end
+  end
+
+  describe ".register" do
+    it "stores resolver by scheme" do
+      described_class.register(resolver_class)
+      expect(described_class.registered?("test")).to be true
+    end
+  end
+
+  describe ".resolve" do
+    it "dispatches to the right resolver" do
+      described_class.register(resolver_class)
+      expect(described_class.resolve("test://my-var")).to eq("resolved:my-var")
+    end
+
+    it "raises SecretResolverError for unknown scheme" do
+      expect { described_class.resolve("unknown://foo") }
+        .to raise_error(Browserctl::SecretResolverError, /unknown secret resolver scheme 'unknown'/)
+    end
+
+    it "raises SecretResolverError when available? returns false" do
+      described_class.register(unavailable_resolver_class)
+      expect { described_class.resolve("unavail://foo") }
+        .to raise_error(Browserctl::SecretResolverError, /'unavail:\/\/' resolver is not available/)
+    end
+
+    it "wraps non-SecretResolverError in SecretResolverError" do
+      described_class.register(raising_resolver_class)
+      expect { described_class.resolve("raises://something") }
+        .to raise_error(Browserctl::SecretResolverError, /secret resolution failed for "raises:\/\/something"/)
+    end
+  end
+end

--- a/spec/unit/secret_resolvers/env_spec.rb
+++ b/spec/unit/secret_resolvers/env_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Browserctl::SecretResolvers::Env do
+  subject(:resolver) { described_class.new }
+
+  describe "#available?" do
+    it "returns true" do
+      expect(resolver.available?).to be true
+    end
+  end
+
+  describe "#resolve" do
+    it "resolves an existing env var" do
+      ENV["BCTL_TEST_VAR"] = "secret_value"
+      expect(resolver.resolve("BCTL_TEST_VAR")).to eq("secret_value")
+    ensure
+      ENV.delete("BCTL_TEST_VAR")
+    end
+
+    it "raises SecretResolverError when var is not set" do
+      ENV.delete("BCTL_MISSING_VAR")
+      expect { resolver.resolve("BCTL_MISSING_VAR") }
+        .to raise_error(Browserctl::SecretResolverError, /env var 'BCTL_MISSING_VAR' is not set/)
+    end
+  end
+end

--- a/spec/unit/secret_resolvers/macos_keychain_spec.rb
+++ b/spec/unit/secret_resolvers/macos_keychain_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Browserctl::SecretResolvers::MacOSKeychain do
+  subject(:resolver) { described_class.new }
+
+  describe "#available?" do
+    it "returns false on non-darwin" do
+      stub_const("RUBY_PLATFORM", "x86_64-linux")
+      expect(resolver.available?).to be false
+    end
+  end
+
+  describe "#resolve" do
+    it "raises SecretResolverError on malformed reference (no /)" do
+      expect { resolver.resolve("no-slash") }
+        .to raise_error(Browserctl::SecretResolverError, /keychain reference must be 'service\/account'/)
+    end
+
+    context "when security command fails" do
+      it "raises SecretResolverError" do
+        status = instance_double(Process::Status, success?: false)
+        allow(Open3).to receive(:capture2).and_return(["", status])
+
+        expect { resolver.resolve("my-service/my-account") }
+          .to raise_error(Browserctl::SecretResolverError, /keychain item not found: my-service\/my-account/)
+      end
+    end
+
+    context "when security command succeeds" do
+      it "returns the value with trailing newline chomped" do
+        status = instance_double(Process::Status, success?: true)
+        allow(Open3).to receive(:capture2).and_return(["my-password\n", status])
+
+        expect(resolver.resolve("my-service/my-account")).to eq("my-password")
+      end
+    end
+  end
+end

--- a/spec/unit/secret_resolvers/macos_keychain_spec.rb
+++ b/spec/unit/secret_resolvers/macos_keychain_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Browserctl::SecretResolvers::MacOSKeychain do
   describe "#resolve" do
     it "raises SecretResolverError on malformed reference (no /)" do
       expect { resolver.resolve("no-slash") }
-        .to raise_error(Browserctl::SecretResolverError, /keychain reference must be 'service\/account'/)
+        .to raise_error(Browserctl::SecretResolverError, %r{keychain reference must be 'service/account'})
     end
 
     context "when security command fails" do
@@ -24,7 +24,7 @@ RSpec.describe Browserctl::SecretResolvers::MacOSKeychain do
         allow(Open3).to receive(:capture2).and_return(["", status])
 
         expect { resolver.resolve("my-service/my-account") }
-          .to raise_error(Browserctl::SecretResolverError, /keychain item not found: my-service\/my-account/)
+          .to raise_error(Browserctl::SecretResolverError, %r{keychain item not found: my-service/my-account})
       end
     end
 

--- a/spec/unit/secret_resolvers/one_password_spec.rb
+++ b/spec/unit/secret_resolvers/one_password_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Browserctl::SecretResolvers::OnePassword do
+  subject(:resolver) { described_class.new }
+
+  describe "#available?" do
+    it "returns false when op is not in PATH" do
+      allow(resolver).to receive(:system).with("which op > /dev/null 2>&1").and_return(false)
+      expect(resolver.available?).to be false
+    end
+  end
+
+  describe "#resolve" do
+    context "when op command fails" do
+      it "raises SecretResolverError" do
+        status = instance_double(Process::Status, success?: false)
+        allow(Open3).to receive(:capture2).and_return(["", status])
+
+        expect { resolver.resolve("vault/item/field") }
+          .to raise_error(Browserctl::SecretResolverError, /1Password item not found: op:\/\/vault\/item\/field/)
+      end
+    end
+
+    context "when op command succeeds" do
+      it "returns the value and chomps trailing newline" do
+        status = instance_double(Process::Status, success?: true)
+        allow(Open3).to receive(:capture2).and_return(["super-secret\n", status])
+
+        expect(resolver.resolve("vault/item/field")).to eq("super-secret")
+      end
+    end
+  end
+end

--- a/spec/unit/secret_resolvers/one_password_spec.rb
+++ b/spec/unit/secret_resolvers/one_password_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Browserctl::SecretResolvers::OnePassword do
         allow(Open3).to receive(:capture2).and_return(["", status])
 
         expect { resolver.resolve("vault/item/field") }
-          .to raise_error(Browserctl::SecretResolverError, /1Password item not found: op:\/\/vault\/item\/field/)
+          .to raise_error(Browserctl::SecretResolverError, %r{1Password item not found: op://vault/item/field})
       end
     end
 

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -173,6 +173,81 @@ RSpec.describe "WorkflowContext#ask" do
   end
 end
 
+RSpec.describe "secret_ref param resolution" do
+  let(:client) { instance_double(Browserctl::Client) }
+
+  before { Browserctl::SecretResolverRegistry.reset! }
+  after  { Browserctl::SecretResolverRegistry.reset! }
+
+  let(:fake_resolver_class) do
+    Class.new(Browserctl::SecretResolvers::Base) do
+      def self.scheme = "fakescheme"
+      def resolve(reference) = "resolved-#{reference}"
+    end
+  end
+
+  it "resolves secret_ref via SecretResolverRegistry at param resolution time" do
+    Browserctl::SecretResolverRegistry.register(fake_resolver_class)
+    received = nil
+    defn = Browserctl::WorkflowDefinition.new("test")
+    defn.param(:api_key, secret_ref: "fakescheme://MY_KEY")
+    defn.step("s") { received = api_key }
+
+    defn.call({}, client)
+    expect(received).to eq("resolved-MY_KEY")
+  end
+
+  it "forces secret: true on ParamDef when secret_ref is present, regardless of explicit secret: false" do
+    defn = Browserctl::WorkflowDefinition.new("test")
+    defn.param(:token, secret_ref: "fakescheme://TOKEN", secret: false)
+    expect(defn.param_defs[:token].secret).to be true
+  end
+end
+
+RSpec.describe "WorkflowContext#load_session with fallback:" do
+  let(:client) { instance_double(Browserctl::Client) }
+
+  it "returns session result when load succeeds on first attempt" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ ok: true, session: "data" })
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    result = ctx.load_session("my-session", fallback: :setup_workflow)
+    expect(result).to eq({ ok: true, session: "data" })
+  end
+
+  it "invokes fallback workflow and retries when session load fails" do
+    call_count = 0
+    allow(client).to receive(:session_load).with("my-session") do
+      call_count += 1
+      call_count == 1 ? { error: "not found" } : { ok: true, session: "data" }
+    end
+
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    allow(ctx).to receive(:invoke).with("setup_workflow")
+
+    result = ctx.load_session("my-session", fallback: :setup_workflow)
+    expect(ctx).to have_received(:invoke).with("setup_workflow").once
+    expect(result).to eq({ ok: true, session: "data" })
+  end
+
+  it "raises WorkflowError with clear message when fallback cannot recover" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ error: "not found" })
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    allow(ctx).to receive(:invoke).with("setup_workflow")
+
+    expect { ctx.load_session("my-session", fallback: :setup_workflow) }
+      .to raise_error(Browserctl::WorkflowError,
+                      "session 'my-session' still unavailable after running fallback 'setup_workflow'")
+  end
+
+  it "raises WorkflowError without fallback as today" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ error: "not found" })
+    ctx = Browserctl::WorkflowContext.new({}, client)
+
+    expect { ctx.load_session("my-session") }
+      .to raise_error(Browserctl::WorkflowError, "not found")
+  end
+end
+
 RSpec.describe Browserctl::WorkflowContext do
   let(:client) { instance_double(Browserctl::Client) }
 


### PR DESCRIPTION
## Summary

- **Secret Resolver Plugin System** — `param :password, secret_ref: "op://vault/item/field"` sources secrets from external managers at runtime; built-in resolvers for `env://`, `keychain://` (macOS), and `op://` (1Password CLI); third-party resolvers register via `~/.browserctl/resolvers.rb`
- **`load_session` with `fallback:`** — `load_session("gmail_prod", fallback: "login_gmail")` auto-invokes a recovery workflow on session load failure and retries once; raises with a clear message if the fallback can't recover
- **`SecretResolverError < WorkflowError`** — new typed error flows through existing step error machinery unchanged
- **`WorkflowError` moved to `errors.rb`** — consolidates all error definitions in one place

## API surface

```ruby
# Secret resolution at param declaration time
param :password,  secret_ref: "keychain://MyApp/admin"   # macOS Keychain
param :api_token, secret_ref: "op://Personal/Gmail/token" # 1Password (native URI)
param :ci_key,    secret_ref: "env://CI_SECRET_TOKEN"      # env var (explicit)

# Session expiry recovery without boilerplate
load_session("gmail_prod", fallback: "login_gmail")
# → if load fails: invoke("login_gmail"), retry once, raise if still failing
```

`secret_ref:` always implies `secret: true` (masking from recordings). No opt-out.

## Test plan

- [x] `SecretResolverRegistry` — register, dispatch, unknown scheme, unavailable resolver, error wrapping
- [x] `Env` resolver — present var, missing var
- [x] `MacOSKeychain` resolver — `available?` gated by platform, malformed reference, success/failure (Open3 stubbed)
- [x] `OnePassword` resolver — `available?` gated by `op` in PATH, success/failure (Open3 stubbed)
- [x] `WorkflowDefinition#param` — `secret_ref` forces `secret: true`; resolution dispatches to registry
- [x] `WorkflowContext#load_session` — success path, fallback invoked on failure, error when fallback can't recover, no-fallback raises as before
- [x] 265 examples, 0 failures (51 pending = integration tests requiring Chrome)

## Files changed

| File | Change |
|---|---|
| `lib/browserctl/secret_resolvers/base.rb` | New — resolver interface |
| `lib/browserctl/secret_resolvers/env.rb` | New — `env://` built-in |
| `lib/browserctl/secret_resolvers/macos_keychain.rb` | New — `keychain://` built-in |
| `lib/browserctl/secret_resolvers/one_password.rb` | New — `op://` built-in |
| `lib/browserctl/secret_resolver_registry.rb` | New — thread-safe registry |
| `lib/browserctl/secret_resolvers.rb` | New — loader + auto-registration |
| `lib/browserctl/errors.rb` | `WorkflowError` + `SecretResolverError` added |
| `lib/browserctl/workflow.rb` | `ParamDef` + `secret_ref`, `param`, `resolve_params`, `load_session` updated |
| `lib/browserctl.rb` | `secret_resolvers` required before `workflow` |
| `spec/unit/secret_resolver_registry_spec.rb` | New |
| `spec/unit/secret_resolvers/{env,macos_keychain,one_password}_spec.rb` | New |
| `spec/unit/workflow_spec.rb` | 4 new describe blocks added |