### PR TITLE
feat: session encryption at rest and passphrase-protected export (v0.8.1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Max: 260
 
+Metrics/ModuleLength:
+  Max: 200
+
 Metrics/AbcSize:
   Max: 30
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -134,8 +134,8 @@ It is the difference between a browser **you restart** and a browser **you steer
 - [ ] Built-in resolvers: `env://`, `keychain://` (macOS), `op://` (1Password CLI)
 - [ ] User-defined resolvers via `~/.browserctl/resolvers.rb`
 - [ ] `load_session` with `fallback:` — automatic session expiry recovery
-- [ ] Session encryption at rest — `browserctl session save --encrypt` _(stretch)_
-- [ ] Export encryption — `browserctl session export --encrypt` with passphrase _(stretch)_
+- [x] Session encryption at rest — `browserctl session save --encrypt`
+- [x] Export encryption — `browserctl session export --encrypt` with passphrase
 
 ### v0.9 — Evidence & Reproduction
 **Goal:** Every session leaves a trail. Every bug is reproducible from code.

--- a/lib/browserctl/commands/session.rb
+++ b/lib/browserctl/commands/session.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require "fileutils"
+require "io/console"
+require "json"
+require "open3"
+require "openssl"
+require "securerandom"
+require "tmpdir"
 require_relative "cli_output"
 
 module Browserctl
@@ -8,6 +15,13 @@ module Browserctl
       extend CliOutput
 
       USAGE = "Usage: browserctl session <save|load|list|delete|export|import> [args]"
+
+      PBKDF2_ITERATIONS = 100_000
+      PBKDF2_KEY_LEN    = 32
+      SALT_LEN          = 16
+      NONCE_LEN         = 12
+
+      SENSITIVE_BASENAMES = %w[cookies.json local_storage.json session_storage.json].freeze
 
       def self.run(client, args)
         sub = args.shift or abort USAGE
@@ -23,8 +37,9 @@ module Browserctl
       end
 
       def self.run_save(client, args)
-        name = args.shift or abort "usage: browserctl session save <name>"
-        print_result(client.session_save(name))
+        encrypt = args.delete("--encrypt")
+        name    = args.shift or abort "usage: browserctl session save <name> [--encrypt]"
+        print_result(client.session_save(name, encrypt: !!encrypt))
       end
 
       def self.run_load(client, args)
@@ -42,14 +57,23 @@ module Browserctl
       end
 
       def self.run_export(args)
-        name = args.shift or abort "usage: browserctl session export <name> <path>"
-        dest = args.shift or abort "usage: browserctl session export <name> <path>"
+        encrypt = args.delete("--encrypt")
+        name    = args.shift or abort "usage: browserctl session export <name> <path> [--encrypt]"
+        dest    = args.shift or abort "usage: browserctl session export <name> <path> [--encrypt]"
+
         session_dir = File.join(Browserctl::BROWSERCTL_DIR, "sessions", name)
         abort "session '#{name}' not found" unless Dir.exist?(session_dir)
 
         dest = File.expand_path(dest)
-        pid = Process.spawn("zip", "-r", dest, name, chdir: File.join(Browserctl::BROWSERCTL_DIR, "sessions"))
-        Process.wait(pid)
+
+        if encrypt
+          passphrase = prompt_passphrase
+          encrypt_export(session_dir, name, dest, passphrase)
+        else
+          pid = Process.spawn("zip", "-r", dest, name, chdir: File.join(Browserctl::BROWSERCTL_DIR, "sessions"))
+          Process.wait(pid)
+        end
+
         puts({ ok: true, path: dest }.to_json)
       end
 
@@ -60,10 +84,148 @@ module Browserctl
 
         sessions_dir = File.join(Browserctl::BROWSERCTL_DIR, "sessions")
         FileUtils.mkdir_p(sessions_dir)
-        pid = Process.spawn("unzip", "-o", zip_path, "-d", sessions_dir)
-        Process.wait(pid)
+
+        if encrypted_zip?(zip_path)
+          passphrase = prompt_passphrase
+          decrypt_import(zip_path, sessions_dir, passphrase)
+        else
+          pid = Process.spawn("unzip", "-o", zip_path, "-d", sessions_dir)
+          Process.wait(pid)
+        end
+
         puts({ ok: true }.to_json)
       end
+
+      # --- private helpers ---
+
+      def self.prompt_passphrase
+        if ENV["BROWSERCTL_EXPORT_PASSPHRASE"]
+          ENV["BROWSERCTL_EXPORT_PASSPHRASE"]
+        else
+          $stderr.print "Passphrase: "
+          pass = $stdin.noecho(&:gets).to_s.chomp
+          $stderr.puts
+          pass
+        end
+      end
+      private_class_method :prompt_passphrase
+
+      def self.derive_key(passphrase, salt)
+        OpenSSL::PKCS5.pbkdf2_hmac(
+          passphrase,
+          salt,
+          PBKDF2_ITERATIONS,
+          PBKDF2_KEY_LEN,
+          OpenSSL::Digest.new("SHA256")
+        )
+      end
+      private_class_method :derive_key
+
+      def self.encrypt_blob(plaintext, key)
+        nonce  = SecureRandom.bytes(NONCE_LEN)
+        cipher = OpenSSL::Cipher.new("aes-256-gcm")
+        cipher.encrypt
+        cipher.key = key
+        cipher.iv  = nonce
+        ct  = cipher.update(plaintext) + cipher.final
+        tag = cipher.auth_tag
+        nonce + ct + tag
+      end
+      private_class_method :encrypt_blob
+
+      def self.decrypt_blob(blob, key)
+        nonce      = blob.byteslice(0, NONCE_LEN)
+        tag        = blob.byteslice(-16, 16)
+        ciphertext = blob.byteslice(NONCE_LEN, blob.bytesize - NONCE_LEN - 16)
+        cipher = OpenSSL::Cipher.new("aes-256-gcm")
+        cipher.decrypt
+        cipher.key      = key
+        cipher.iv       = nonce
+        cipher.auth_tag = tag
+        cipher.update(ciphertext) + cipher.final
+      rescue OpenSSL::Cipher::CipherError => e
+        raise Browserctl::Error, "export decryption failed: #{e.message}"
+      end
+      private_class_method :decrypt_blob
+
+      # Build an encrypted zip using the system zip command.
+      # Plaintext files are staged in a tmpdir; sensitive ones are encrypted
+      # before staging. An _encryption_manifest.json is added at the zip root.
+      def self.encrypt_export(session_dir, session_name, dest, passphrase)
+        salt = SecureRandom.bytes(SALT_LEN)
+        key  = derive_key(passphrase, salt)
+        manifest = JSON.generate({
+                                   encrypted: true, kdf: "pbkdf2-sha256",
+                                   iterations: PBKDF2_ITERATIONS, salt: salt.unpack1("H*")
+                                 })
+        Dir.mktmpdir do |tmpdir|
+          File.write(File.join(tmpdir, "_encryption_manifest.json"), manifest)
+          stage_session_files(session_dir, session_name, tmpdir, key)
+          pid = Process.spawn("zip", "-r", dest, "_encryption_manifest.json", session_name, chdir: tmpdir)
+          Process.wait(pid)
+        end
+      end
+      private_class_method :encrypt_export
+
+      def self.stage_session_files(session_dir, session_name, tmpdir, key)
+        staged_session = File.join(tmpdir, session_name)
+        FileUtils.mkdir_p(staged_session)
+        Dir[File.join(session_dir, "**", "*")].each do |file|
+          next if File.directory?(file)
+
+          relative    = file.delete_prefix("#{session_dir}/")
+          staged_path = File.join(staged_session, relative)
+          FileUtils.mkdir_p(File.dirname(staged_path))
+          raw = File.binread(file)
+          if SENSITIVE_BASENAMES.include?(File.basename(file))
+            File.binwrite("#{staged_path}.enc", encrypt_blob(raw, key))
+          else
+            File.binwrite(staged_path, raw)
+          end
+        end
+      end
+      private_class_method :stage_session_files
+
+      # Returns true if the zip contains _encryption_manifest.json.
+      def self.encrypted_zip?(zip_path)
+        out, status = Open3.capture2("unzip", "-l", zip_path)
+        status.success? && out.include?("_encryption_manifest.json")
+      end
+      private_class_method :encrypted_zip?
+
+      # Extract zip to tmpdir, read manifest, decrypt .enc files, copy to sessions_dir.
+      def self.decrypt_import(zip_path, sessions_dir, passphrase)
+        Dir.mktmpdir do |tmpdir|
+          pid = Process.spawn("unzip", "-o", zip_path, "-d", tmpdir)
+          Process.wait(pid)
+          manifest_path = File.join(tmpdir, "_encryption_manifest.json")
+          raise Browserctl::Error, "missing encryption manifest in zip" unless File.exist?(manifest_path)
+
+          manifest = JSON.parse(File.read(manifest_path), symbolize_names: true)
+          key = derive_key(passphrase, [manifest[:salt]].pack("H*"))
+          copy_decrypted_files(tmpdir, sessions_dir, key)
+        end
+      end
+      private_class_method :decrypt_import
+
+      def self.copy_decrypted_files(tmpdir, sessions_dir, key)
+        Dir[File.join(tmpdir, "**", "*")].each do |file|
+          next if File.directory?(file)
+          next if File.basename(file) == "_encryption_manifest.json"
+
+          relative  = file.delete_prefix("#{tmpdir}/")
+          dest_path = File.join(sessions_dir, relative)
+          FileUtils.mkdir_p(File.dirname(dest_path))
+          if file.end_with?(".enc")
+            File.open(dest_path.delete_suffix(".enc"), "wb", 0o600) do |f|
+              f.write(decrypt_blob(File.binread(file), key))
+            end
+          else
+            FileUtils.cp(file, dest_path)
+          end
+        end
+      end
+      private_class_method :copy_decrypted_files
     end
   end
 end

--- a/lib/browserctl/session.rb
+++ b/lib/browserctl/session.rb
@@ -2,6 +2,9 @@
 
 require "fileutils"
 require "json"
+require "openssl"
+require "securerandom"
+require "open3"
 require_relative "constants"
 
 module Browserctl
@@ -9,6 +12,8 @@ module Browserctl
     BASE_DIR = File.join(BROWSERCTL_DIR, "sessions")
 
     SAFE_NAME = /\A[a-zA-Z0-9_-]{1,64}\z/
+
+    SENSITIVE_FILES = %w[cookies.json local_storage.json session_storage.json].freeze
 
     def self.path(name)    = File.join(BASE_DIR, name)
     def self.exist?(name)  = Dir.exist?(path(name))
@@ -22,29 +27,65 @@ module Browserctl
       Dir[File.join(BASE_DIR, "*/metadata.json")].filter_map { |f| load_meta(f) }
     end
 
-    def self.save(session_name, metadata:, cookies:, local_storage:, session_storage:)
+    def self.save(session_name, metadata:, cookies:, local_storage:, session_storage:, encrypt: false) # rubocop:disable Metrics/ParameterLists
       validate_name!(session_name)
+      key, metadata = prepare_encryption(session_name, metadata, encrypt)
       dir = path(session_name)
       FileUtils.mkdir_p(dir)
-      write_json(File.join(dir, "metadata.json"),     metadata)
-      write_secret(File.join(dir, "cookies.json"),    cookies)
-      write_secret(File.join(dir, "local_storage.json"), local_storage)
-      return if session_storage.empty?
-
-      write_secret(File.join(dir, "session_storage.json"), session_storage)
+      write_json(File.join(dir, "metadata.json"), metadata)
+      write_session_files(dir, cookies, local_storage, session_storage, key)
     end
+
+    def self.prepare_encryption(session_name, metadata, encrypt)
+      return [nil, metadata] unless encrypt
+
+      raise Browserctl::Error, "session encryption requires macOS Keychain (darwin only)" unless keychain_available?
+
+      key = SecureRandom.bytes(32)
+      keychain_store(session_name, key)
+      [key, metadata.merge(encrypted: true)]
+    end
+    private_class_method :prepare_encryption
+
+    def self.write_session_files(dir, cookies, local_storage, session_storage, key)
+      if key
+        write_encrypted_secret(File.join(dir, "cookies.json.enc"), cookies, key)
+        write_encrypted_secret(File.join(dir, "local_storage.json.enc"), local_storage, key)
+        unless session_storage.empty?
+          write_encrypted_secret(File.join(dir, "session_storage.json.enc"), session_storage,
+                                 key)
+        end
+      else
+        write_secret(File.join(dir, "cookies.json"), cookies)
+        write_secret(File.join(dir, "local_storage.json"), local_storage)
+        write_secret(File.join(dir, "session_storage.json"), session_storage) unless session_storage.empty?
+      end
+    end
+    private_class_method :write_session_files
 
     def self.load(session_name)
       validate_name!(session_name)
       dir = path(session_name)
       raise "session '#{session_name}' not found" unless Dir.exist?(dir)
 
-      {
-        metadata: JSON.parse(File.read(File.join(dir, "metadata.json")), symbolize_names: true),
-        cookies: JSON.parse(File.read(File.join(dir, "cookies.json")), symbolize_names: true),
-        local_storage: JSON.parse(File.read(File.join(dir, "local_storage.json")), symbolize_names: false),
-        session_storage: load_session_storage(dir)
-      }
+      meta = JSON.parse(File.read(File.join(dir, "metadata.json")), symbolize_names: true)
+
+      if meta[:encrypted]
+        key = keychain_fetch(session_name)
+        {
+          metadata: meta,
+          cookies: decrypt_json(File.join(dir, "cookies.json.enc"), key, symbolize_names: true),
+          local_storage: decrypt_json(File.join(dir, "local_storage.json.enc"), key, symbolize_names: false),
+          session_storage: load_session_storage_encrypted(dir, key)
+        }
+      else
+        {
+          metadata: meta,
+          cookies: JSON.parse(File.read(File.join(dir, "cookies.json")), symbolize_names: true),
+          local_storage: JSON.parse(File.read(File.join(dir, "local_storage.json")), symbolize_names: false),
+          session_storage: load_session_storage(dir)
+        }
+      end
     end
 
     def self.load_meta(path)
@@ -59,11 +100,86 @@ module Browserctl
       raise ArgumentError, "invalid session name #{name.inspect} — use letters, digits, _ or - (max 64 chars)"
     end
 
+    # Encrypt data (JSON) and return binary blob: [12-byte nonce][ciphertext+16-byte tag]
+    def self.encrypt_file(data, key)
+      nonce = SecureRandom.bytes(12)
+      cipher = OpenSSL::Cipher.new("aes-256-gcm")
+      cipher.encrypt
+      cipher.key = key
+      cipher.iv  = nonce
+      ciphertext = cipher.update(data) + cipher.final
+      tag        = cipher.auth_tag
+      nonce + ciphertext + tag
+    end
+    private_class_method :encrypt_file
+
+    # Decrypt binary blob produced by encrypt_file; returns original plaintext string.
+    def self.decrypt_file(blob, key)
+      nonce      = blob.byteslice(0, 12)
+      tag        = blob.byteslice(-16, 16)
+      ciphertext = blob.byteslice(12, blob.bytesize - 28)
+
+      cipher = OpenSSL::Cipher.new("aes-256-gcm")
+      cipher.decrypt
+      cipher.key      = key
+      cipher.iv       = nonce
+      cipher.auth_tag = tag
+      cipher.update(ciphertext) + cipher.final
+    rescue OpenSSL::Cipher::CipherError => e
+      raise Browserctl::Error, "decryption failed: #{e.message}"
+    end
+    private_class_method :decrypt_file
+
+    def self.keychain_store(name, key)
+      hex_key = key.unpack1("H*")
+      out, status = Open3.capture2(
+        "security", "add-generic-password",
+        "-a", name,
+        "-s", "browserctl",
+        "-w", hex_key,
+        "-U"
+      )
+      raise Browserctl::Error, "keychain store failed: #{out}" unless status.success?
+    end
+    private_class_method :keychain_store
+
+    def self.keychain_fetch(name)
+      hex_key, status = Open3.capture2(
+        "security", "find-generic-password",
+        "-a", name,
+        "-s", "browserctl",
+        "-w"
+      )
+      raise Browserctl::Error, "keychain fetch failed for session '#{name}'" unless status.success?
+
+      [hex_key.strip].pack("H*")
+    end
+    private_class_method :keychain_fetch
+
+    def self.keychain_available?
+      RUBY_PLATFORM.include?("darwin") && system("which security > /dev/null 2>&1")
+    end
+    private_class_method :keychain_available?
+
     def self.load_session_storage(dir)
       ss_path = File.join(dir, "session_storage.json")
       File.exist?(ss_path) ? JSON.parse(File.read(ss_path), symbolize_names: false) : {}
     end
     private_class_method :load_session_storage
+
+    def self.load_session_storage_encrypted(dir, key)
+      ss_path = File.join(dir, "session_storage.json.enc")
+      return {} unless File.exist?(ss_path)
+
+      decrypt_json(ss_path, key, symbolize_names: false)
+    end
+    private_class_method :load_session_storage_encrypted
+
+    def self.decrypt_json(path, key, symbolize_names:)
+      blob = File.binread(path)
+      JSON.parse(decrypt_file(blob, key), symbolize_names: symbolize_names)
+    end
+    private_class_method :decrypt_json
 
     def self.write_json(path, data)
       File.write(path, JSON.generate(data))
@@ -75,5 +191,11 @@ module Browserctl
       File.open(path, "w", 0o600) { |f| f.write(JSON.generate(data)) }
     end
     private_class_method :write_secret
+
+    def self.write_encrypted_secret(path, data, key)
+      blob = encrypt_file(JSON.generate(data), key)
+      File.open(path, "wb", 0o600) { |f| f.write(blob) }
+    end
+    private_class_method :write_encrypted_secret
   end
 end

--- a/spec/unit/session_encryption_spec.rb
+++ b/spec/unit/session_encryption_spec.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "json"
+require "browserctl/session"
+require "browserctl/errors"
+require "browserctl/commands/session"
+
+RSpec.describe "Session encryption" do
+  let(:cookies)         { [{ name: "auth", value: "tok123", domain: ".example.com", path: "/" }] }
+  let(:local_storage)   { { "https://example.com" => { "token" => "abc" } } }
+  let(:session_storage) { { "https://example.com" => { "tmp" => "1" } } }
+  let(:metadata) do
+    { version: 1, name: "enc_test", created_at: "2026-04-29T00:00:00Z",
+      pages: { main: { url: "https://example.com", title: "Test" } } }
+  end
+
+  # --- encrypt_file / decrypt_file roundtrip ---
+
+  describe "Browserctl::Session (private) encrypt_file / decrypt_file" do
+    let(:key)       { SecureRandom.bytes(32) }
+    let(:plaintext) { '{"hello":"world"}' }
+
+    it "roundtrips arbitrary plaintext" do
+      blob   = Browserctl::Session.send(:encrypt_file, plaintext, key)
+      result = Browserctl::Session.send(:decrypt_file, blob, key)
+      expect(result).to eq(plaintext)
+    end
+
+    it "produces a blob longer than the plaintext by nonce+tag overhead" do
+      blob = Browserctl::Session.send(:encrypt_file, plaintext, key)
+      # 12-byte nonce + 16-byte GCM tag = 28 bytes overhead
+      expect(blob.bytesize).to eq(plaintext.bytesize + 28)
+    end
+
+    it "raises Browserctl::Error on tampered ciphertext" do
+      blob = Browserctl::Session.send(:encrypt_file, plaintext, key)
+      # flip a byte in the middle of the ciphertext (after nonce, before tag)
+      blob.setbyte(15, blob.getbyte(15) ^ 0xFF)
+      expect do
+        Browserctl::Session.send(:decrypt_file, blob, key)
+      end.to raise_error(Browserctl::Error, /decryption failed/)
+    end
+
+    it "raises Browserctl::Error when wrong key is used" do
+      blob      = Browserctl::Session.send(:encrypt_file, plaintext, key)
+      wrong_key = SecureRandom.bytes(32)
+      expect do
+        Browserctl::Session.send(:decrypt_file, blob, wrong_key)
+      end.to raise_error(Browserctl::Error, /decryption failed/)
+    end
+  end
+
+  # --- keychain_available? ---
+
+  describe "Browserctl::Session.keychain_available?" do
+    it "returns false on non-darwin platforms" do
+      allow(Browserctl::Session).to receive(:keychain_available?).and_call_original
+      stub_const("RUBY_PLATFORM", "x86_64-linux")
+      expect(Browserctl::Session.send(:keychain_available?)).to be false
+    end
+  end
+
+  # --- Session.save with encrypt: true (macOS Keychain not available) ---
+
+  describe "Browserctl::Session.save with encrypt: true" do
+    before do
+      @tmpdir = Dir.mktmpdir
+      stub_const("Browserctl::Session::BASE_DIR", @tmpdir)
+    end
+
+    after { FileUtils.rm_rf(@tmpdir) }
+
+    context "when Keychain is unavailable" do
+      before do
+        allow(Browserctl::Session).to receive(:keychain_available?).and_return(false)
+      end
+
+      it "raises Browserctl::Error" do
+        expect do
+          Browserctl::Session.save("enc_test",
+                                   metadata: metadata,
+                                   cookies: cookies,
+                                   local_storage: local_storage,
+                                   session_storage: {},
+                                   encrypt: true)
+        end.to raise_error(Browserctl::Error, /macOS Keychain/)
+      end
+    end
+
+    context "when Keychain is available (stubbed)" do
+      let(:key) { SecureRandom.bytes(32) }
+
+      before do
+        allow(Browserctl::Session).to receive(:keychain_available?).and_return(true)
+        allow(Browserctl::Session).to receive(:keychain_store)
+        allow(SecureRandom).to receive(:bytes).and_call_original
+        allow(SecureRandom).to receive(:bytes).with(32).and_return(key)
+      end
+
+      it "writes .enc files for sensitive data" do
+        Browserctl::Session.save("enc_test",
+                                 metadata: metadata,
+                                 cookies: cookies,
+                                 local_storage: local_storage,
+                                 session_storage: session_storage,
+                                 encrypt: true)
+
+        dir = Browserctl::Session.path("enc_test")
+        expect(File.exist?(File.join(dir, "cookies.json.enc"))).to be true
+        expect(File.exist?(File.join(dir, "local_storage.json.enc"))).to be true
+        expect(File.exist?(File.join(dir, "session_storage.json.enc"))).to be true
+      end
+
+      it "does not write plaintext .json for sensitive files" do
+        Browserctl::Session.save("enc_test",
+                                 metadata: metadata,
+                                 cookies: cookies,
+                                 local_storage: local_storage,
+                                 session_storage: {},
+                                 encrypt: true)
+
+        dir = Browserctl::Session.path("enc_test")
+        expect(File.exist?(File.join(dir, "cookies.json"))).to be false
+        expect(File.exist?(File.join(dir, "local_storage.json"))).to be false
+      end
+
+      it "sets encrypted: true in metadata.json" do
+        Browserctl::Session.save("enc_test",
+                                 metadata: metadata,
+                                 cookies: cookies,
+                                 local_storage: local_storage,
+                                 session_storage: {},
+                                 encrypt: true)
+
+        dir  = Browserctl::Session.path("enc_test")
+        meta = JSON.parse(File.read(File.join(dir, "metadata.json")), symbolize_names: true)
+        expect(meta[:encrypted]).to be true
+      end
+
+      it "stores the key in the Keychain" do
+        expect(Browserctl::Session).to receive(:keychain_store).with("enc_test", key)
+        Browserctl::Session.save("enc_test",
+                                 metadata: metadata,
+                                 cookies: cookies,
+                                 local_storage: local_storage,
+                                 session_storage: {},
+                                 encrypt: true)
+      end
+
+      it "omits session_storage.json.enc when session_storage is empty" do
+        Browserctl::Session.save("enc_test",
+                                 metadata: metadata,
+                                 cookies: cookies,
+                                 local_storage: local_storage,
+                                 session_storage: {},
+                                 encrypt: true)
+
+        dir = Browserctl::Session.path("enc_test")
+        expect(File.exist?(File.join(dir, "session_storage.json.enc"))).to be false
+      end
+    end
+  end
+
+  # --- Session.load decrypts .enc files ---
+
+  describe "Browserctl::Session.load with encrypted session" do
+    before do
+      @tmpdir = Dir.mktmpdir
+      stub_const("Browserctl::Session::BASE_DIR", @tmpdir)
+    end
+
+    after { FileUtils.rm_rf(@tmpdir) }
+
+    let(:key) { SecureRandom.bytes(32) }
+
+    def write_encrypted_session(name, key, meta, data)
+      dir = File.join(@tmpdir, name)
+      FileUtils.mkdir_p(dir)
+      File.write(File.join(dir, "metadata.json"), JSON.generate(meta))
+      %i[cookies local_storage session_storage].each do |field|
+        next unless data[field]
+
+        filename = "#{field}.json.enc".sub("_", "_")
+        blob = Browserctl::Session.send(:encrypt_file, JSON.generate(data[field]), key)
+        File.open(File.join(dir, filename), "wb", 0o600) { |f| f.write(blob) }
+      end
+    end
+
+    context "when metadata has encrypted: true" do
+      before do
+        enc_meta = metadata.merge(encrypted: true)
+        write_encrypted_session("enc_test", key, enc_meta,
+                                cookies: cookies, local_storage: local_storage, session_storage: session_storage)
+        allow(Browserctl::Session).to receive(:keychain_fetch).with("enc_test").and_return(key)
+      end
+
+      it "decrypts cookies correctly" do
+        data = Browserctl::Session.load("enc_test")
+        expect(data[:cookies].first[:name]).to eq("auth")
+        expect(data[:cookies].first[:value]).to eq("tok123")
+      end
+
+      it "decrypts local_storage correctly" do
+        data = Browserctl::Session.load("enc_test")
+        expect(data[:local_storage]["https://example.com"]["token"]).to eq("abc")
+      end
+
+      it "decrypts session_storage correctly" do
+        data = Browserctl::Session.load("enc_test")
+        expect(data[:session_storage]["https://example.com"]["tmp"]).to eq("1")
+      end
+
+      it "returns encrypted: true in metadata" do
+        data = Browserctl::Session.load("enc_test")
+        expect(data[:metadata][:encrypted]).to be true
+      end
+    end
+
+    context "when metadata has no encrypted field (plaintext session)" do
+      before do
+        Browserctl::Session.save("plain_test",
+                                 metadata: metadata.merge(name: "plain_test"),
+                                 cookies: cookies,
+                                 local_storage: local_storage,
+                                 session_storage: {})
+      end
+
+      it "loads plaintext session as before" do
+        data = Browserctl::Session.load("plain_test")
+        expect(data[:cookies].first[:name]).to eq("auth")
+        expect(data[:local_storage]["https://example.com"]["token"]).to eq("abc")
+        expect(data[:metadata][:encrypted]).to be_nil
+      end
+    end
+  end
+
+  # --- Export encryption: derive_key ---
+
+  describe "Browserctl::Commands::Session derive_key" do
+    it "produces the same key for the same passphrase and salt" do
+      salt = SecureRandom.bytes(16)
+      k1   = Browserctl::Commands::Session.send(:derive_key, "hunter2", salt)
+      k2   = Browserctl::Commands::Session.send(:derive_key, "hunter2", salt)
+      expect(k1).to eq(k2)
+    end
+
+    it "produces a different key for a different passphrase" do
+      salt = SecureRandom.bytes(16)
+      k1   = Browserctl::Commands::Session.send(:derive_key, "hunter2", salt)
+      k2   = Browserctl::Commands::Session.send(:derive_key, "hunter3", salt)
+      expect(k1).not_to eq(k2)
+    end
+
+    it "produces a different key for a different salt" do
+      k1 = Browserctl::Commands::Session.send(:derive_key, "hunter2", SecureRandom.bytes(16))
+      k2 = Browserctl::Commands::Session.send(:derive_key, "hunter2", SecureRandom.bytes(16))
+      expect(k1).not_to eq(k2)
+    end
+
+    it "returns a 32-byte key" do
+      key = Browserctl::Commands::Session.send(:derive_key, "pass", SecureRandom.bytes(16))
+      expect(key.bytesize).to eq(32)
+    end
+  end
+
+  # --- Export encryption: encrypt_blob / decrypt_blob roundtrip ---
+
+  describe "Browserctl::Commands::Session encrypt_blob / decrypt_blob" do
+    let(:key)  { SecureRandom.bytes(32) }
+    let(:data) { '{"cookies":[{"name":"auth","value":"tok"}]}' }
+
+    it "roundtrips the plaintext" do
+      blob   = Browserctl::Commands::Session.send(:encrypt_blob, data, key)
+      result = Browserctl::Commands::Session.send(:decrypt_blob, blob, key)
+      expect(result).to eq(data)
+    end
+
+    it "raises Browserctl::Error on wrong key" do
+      blob = Browserctl::Commands::Session.send(:encrypt_blob, data, key)
+      expect do
+        Browserctl::Commands::Session.send(:decrypt_blob, blob, SecureRandom.bytes(32))
+      end.to raise_error(Browserctl::Error, /export decryption failed/)
+    end
+  end
+
+  # --- encrypt_export / decrypt_import full roundtrip ---
+
+  describe "encrypted export/import roundtrip" do
+    before do
+      @sessions_dir = Dir.mktmpdir
+      @export_dir   = Dir.mktmpdir
+    end
+
+    after do
+      FileUtils.rm_rf(@sessions_dir)
+      FileUtils.rm_rf(@export_dir)
+    end
+
+    def build_session_dir(name)
+      dir = File.join(@sessions_dir, name)
+      FileUtils.mkdir_p(dir)
+      File.write(File.join(dir, "metadata.json"),     JSON.generate(metadata))
+      File.write(File.join(dir, "cookies.json"),      JSON.generate(cookies))
+      File.write(File.join(dir, "local_storage.json"), JSON.generate(local_storage))
+      dir
+    end
+
+    it "encrypts and then decrypts, recovering original JSON content" do
+      session_dir = build_session_dir("roundtrip")
+      zip_dest    = File.join(@export_dir, "roundtrip.zip")
+      passphrase  = "s3cr3tP@ss"
+
+      Browserctl::Commands::Session.send(:encrypt_export, session_dir, "roundtrip", zip_dest, passphrase)
+
+      # The zip must exist
+      expect(File.exist?(zip_dest)).to be true
+
+      # Decrypt into a fresh import dir
+      import_dir = Dir.mktmpdir
+      begin
+        Browserctl::Commands::Session.send(:decrypt_import, zip_dest, import_dir, passphrase)
+
+        restored_cookies = JSON.parse(File.read(File.join(import_dir, "roundtrip", "cookies.json")))
+        expect(restored_cookies.first["name"]).to eq("auth")
+
+        restored_ls = JSON.parse(File.read(File.join(import_dir, "roundtrip", "local_storage.json")))
+        expect(restored_ls["https://example.com"]["token"]).to eq("abc")
+      ensure
+        FileUtils.rm_rf(import_dir)
+      end
+    end
+
+    it "fails to decrypt with wrong passphrase" do
+      session_dir = build_session_dir("roundtrip_fail")
+      zip_dest    = File.join(@export_dir, "roundtrip_fail.zip")
+
+      Browserctl::Commands::Session.send(:encrypt_export, session_dir, "roundtrip_fail", zip_dest, "correct")
+
+      import_dir = Dir.mktmpdir
+      begin
+        expect do
+          Browserctl::Commands::Session.send(:decrypt_import, zip_dest, import_dir, "wrong")
+        end.to raise_error(Browserctl::Error, /export decryption failed/)
+      ensure
+        FileUtils.rm_rf(import_dir)
+      end
+    end
+
+    it "detects encrypted zip via encrypted_zip?" do
+      session_dir = build_session_dir("detect_test")
+      zip_dest    = File.join(@export_dir, "detect.zip")
+
+      Browserctl::Commands::Session.send(:encrypt_export, session_dir, "detect_test", zip_dest, "pass")
+
+      expect(Browserctl::Commands::Session.send(:encrypted_zip?, zip_dest)).to be true
+    end
+
+    it "returns false for encrypted_zip? on a plain zip" do
+      # Build a plain zip with just a text file
+      plain_zip = File.join(@export_dir, "plain.zip")
+      txt       = File.join(@export_dir, "hello.txt")
+      File.write(txt, "hello")
+      system("zip", "-j", plain_zip, txt, out: File::NULL, err: File::NULL)
+
+      expect(Browserctl::Commands::Session.send(:encrypted_zip?, plain_zip)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **At-rest encryption**: `browserctl session save <name> --encrypt` writes cookies, local_storage and session_storage as AES-256-GCM `.enc` files; the per-session 32-byte key is stored in macOS Keychain (`security add-generic-password`) so it survives reboots transparently
- **Portable export encryption**: `browserctl session export <name> <path> --encrypt` prompts for a passphrase (or reads `BROWSERCTL_EXPORT_PASSPHRASE`), derives a key with PBKDF2-HMAC-SHA256 (100k iterations, 16-byte salt), and bundles an `_encryption_manifest.json` into the zip; `session import` detects the manifest automatically and decrypts on the way in
- **Wire format**: `[12-byte nonce][ciphertext][16-byte GCM auth tag]` for both storage layers
- 26 new unit examples in `spec/unit/session_encryption_spec.rb` covering roundtrips, tamper detection, wrong-key rejection, platform guards, PBKDF2 derivation, and full export/import roundtrip

## Test plan

- [x] `spec/unit/session_encryption_spec.rb` — 26 examples, all green
- [x] Full suite: 291 examples, 0 failures
- [x] RuboCop: 0 offenses