### PR TITLE
fix: fill test gaps and tighten DX for v0.8.1 encryption

### DIFF
--- a/docs/concepts/sessions-and-pages.md
+++ b/docs/concepts/sessions-and-pages.md
@@ -65,11 +65,12 @@ No re-authentication. No cookie injection. The session is just alive.
 
 ## Saving and restoring sessions
 
-In-memory state is lost when the daemon stops. `session save` captures everything — open pages, cookies, and localStorage — to a plain JSON bundle on disk. `session load` restores it into a running daemon, including re-opening every saved page at its saved URL.
+In-memory state is lost when the daemon stops. `session save` captures everything — open pages, cookies, and localStorage — to disk. `session load` restores it into a running daemon, including re-opening every saved page at its saved URL.
 
 ```bash
 # After logging in and navigating to the right state:
-browserctl session save github_work
+browserctl session save github_work           # plaintext (0o600 perms)
+browserctl session save github_work --encrypt # AES-256-GCM, key in macOS Keychain
 
 # Next time, on a fresh daemon:
 browserd &
@@ -77,20 +78,24 @@ browserctl session load github_work
 # → pages are back, cookies are restored, localStorage is seeded
 ```
 
-Session files live in `~/.browserctl/sessions/<name>/` as readable JSON:
+Plaintext sessions live in `~/.browserctl/sessions/<name>/` as `0o600` JSON files. Encrypted sessions store `.enc` blobs instead — the decryption key is kept in macOS Keychain and retrieved transparently on load:
 
 ```
 ~/.browserctl/sessions/github_work/
-  metadata.json       # page names + URLs + timestamps
-  cookies.json        # all cookies from the shared daemon jar
-  local_storage.json  # localStorage by origin
+  metadata.json            # page names + URLs + timestamps (always plaintext)
+  cookies.json             # plaintext, or…
+  cookies.json.enc         # …AES-256-GCM blob when --encrypt was used
+  local_storage.json(.enc)
+  session_storage.json(.enc)
 ```
 
-To share a session or move it to another machine, export it as a zip:
+To share a session or move it to another machine, export it as a zip. Add `--encrypt` to protect the archive with a passphrase (prompted on export; detected automatically on import):
 
 ```bash
 browserctl session export github_work ~/sessions/github_work.zip
-browserctl session import ~/sessions/github_work.zip
+browserctl session export github_work ~/sessions/github_work.zip --encrypt
+
+browserctl session import ~/sessions/github_work.zip  # detects encryption automatically
 ```
 
 List and manage sessions:

--- a/docs/guides/writing-workflows.md
+++ b/docs/guides/writing-workflows.md
@@ -228,6 +228,54 @@ The value is resolved at workflow runtime — never stored in the workflow file,
 
 `keychain://` requires macOS with the `security` command. `op://` requires the [1Password CLI](https://developer.1password.com/docs/cli/) (`op`) to be installed and signed in. Both resolvers raise `SecretResolverError` with a clear message if the item is not found or the tool is unavailable.
 
+**How to store the secret (one-time setup):**
+
+`env://` — export the variable in your shell before running the workflow:
+
+```sh
+export GMAIL_PASSWORD="hunter2"
+browserctl workflow run my_workflow.rb
+```
+
+Or add it to your shell profile (`~/.zshrc`, `~/.bashrc`) or a project-local `.envrc` (loaded by [direnv](https://direnv.net)) so it's available without exporting each time:
+
+```sh
+# .envrc  (project root, git-ignored)
+export GMAIL_PASSWORD="hunter2"
+```
+
+`keychain://` — store the password once with the macOS `security` CLI. The reference format is `keychain://service/account`, where **service** is any label you choose and **account** is the username or identifier:
+
+```sh
+# store
+security add-generic-password -s "MyApp" -a "admin" -w "hunter2"
+
+# verify it round-trips
+security find-generic-password -s "MyApp" -a "admin" -w
+```
+
+Then in your workflow:
+
+```ruby
+param :password, secret_ref: "keychain://MyApp/admin"
+```
+
+At runtime browserctl calls `security find-generic-password` transparently — no prompt, no value in the workflow file.
+
+`op://` — the reference is the native 1Password CLI format. Sign in once, then point `secret_ref:` at the item:
+
+```sh
+# sign in (one-time per session)
+op signin
+
+# verify the reference resolves
+op read "op://Personal/Gmail/password"
+```
+
+```ruby
+param :password, secret_ref: "op://Personal/Gmail/password"
+```
+
 **Adding a resolver for another secret manager:**
 
 Create `~/.browserctl/resolvers.rb` (loaded automatically at daemon startup):

--- a/docs/guides/writing-workflows.md
+++ b/docs/guides/writing-workflows.md
@@ -247,7 +247,10 @@ export GMAIL_PASSWORD="hunter2"
 `keychain://` — store the password once with the macOS `security` CLI. The reference format is `keychain://service/account`, where **service** is any label you choose and **account** is the username or identifier:
 
 ```sh
-# store
+# store (omit -w to be prompted — avoids the password landing in shell history)
+security add-generic-password -s "MyApp" -a "admin"
+
+# or pass it inline (convenient, but the value appears in ~/.zsh_history)
 security add-generic-password -s "MyApp" -a "admin" -w "hunter2"
 
 # verify it round-trips

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -140,16 +140,16 @@ browserctl ask "Enter 2FA code:"
 
 ## Session
 
-A session bundles everything needed to resume a browser state: all open pages (names + URLs), all cookies, and localStorage for each origin. Session files are plain JSON stored in `~/.browserctl/sessions/<name>/`.
+A session bundles everything needed to resume a browser state: all open pages (names + URLs), all cookies, and localStorage for each origin. Session files live in `~/.browserctl/sessions/<name>/`. By default they are plain JSON with `0o600` permissions; `--encrypt` stores them as AES-256-GCM blobs with the key in macOS Keychain.
 
 | Command | Description |
 |---|---|
-| `session save <name>` | Save the current browser state to a named session |
+| `session save <name> [--encrypt]` | Save the current browser state; `--encrypt` stores sensitive files as AES-256-GCM blobs (macOS only) |
 | `session load <name>` | Restore a saved session into the running daemon |
 | `session list` | List all saved sessions |
 | `session delete <name>` | Delete a saved session |
-| `session export <name> <path>` | Zip a saved session to a portable archive |
-| `session import <path>` | Unzip a session archive into the sessions directory |
+| `session export <name> <path> [--encrypt]` | Zip a session to a portable archive; `--encrypt` prompts for a passphrase and uses PBKDF2+AES-256-GCM |
+| `session import <path>` | Unzip a session archive; automatically detects and decrypts an encrypted archive |
 
 ---
 
@@ -276,14 +276,15 @@ Use `--ref <id>` with `fill` and `click` to interact without writing selectors. 
 |---|---|
 | `desc "text"` | Human-readable description shown by `workflow list` |
 | `param :name, required:, secret:, default:` | Declare an input parameter |
+| `param :name, secret_ref: "scheme://ref"` | Declare a param sourced from a secret manager at runtime; always masked from recordings |
 | `step "label" { }` | Add a step — runs in order, halts workflow on failure |
 | `step "label", retry_count: N, timeout: S { }` | Step with retry and/or timeout |
 | `compose "workflow"` | Inline all steps from another workflow at this point |
 | `open_page(name, url: nil)` | Open a named page, optionally navigating to a URL |
 | `close_page(name)` | Close a named page |
 | `page(:name)` | Return a `PageProxy` for the named page |
-| `save_session(name)` | Save the current browser state to a named session |
-| `load_session(name)` | Restore a saved session into the running daemon |
+| `save_session(name, encrypt: false)` | Save the current browser state; `encrypt: true` uses macOS Keychain (darwin only) |
+| `load_session(name, fallback: nil)` | Restore a saved session; `fallback:` names a workflow to run and retry if the session is missing |
 | `list_sessions` | Return all saved session metadata |
 | `invoke "workflow", **overrides` | Call another workflow by name |
 | `assert condition, "message"` | Raise `WorkflowError` if condition is false |

--- a/lib/browserctl/commands/session.rb
+++ b/lib/browserctl/commands/session.rb
@@ -67,7 +67,7 @@ module Browserctl
         dest = File.expand_path(dest)
 
         if encrypt
-          passphrase = prompt_passphrase
+          passphrase = prompt_passphrase(confirm: true)
           encrypt_export(session_dir, name, dest, passphrase)
         else
           pid = Process.spawn("zip", "-r", dest, name, chdir: File.join(Browserctl::BROWSERCTL_DIR, "sessions"))
@@ -98,15 +98,21 @@ module Browserctl
 
       # --- private helpers ---
 
-      def self.prompt_passphrase
-        if ENV["BROWSERCTL_EXPORT_PASSPHRASE"]
-          ENV["BROWSERCTL_EXPORT_PASSPHRASE"]
-        else
-          $stderr.print "Passphrase: "
-          pass = $stdin.noecho(&:gets).to_s.chomp
+      def self.prompt_passphrase(confirm: false)
+        return ENV["BROWSERCTL_EXPORT_PASSPHRASE"] if ENV["BROWSERCTL_EXPORT_PASSPHRASE"]
+
+        $stderr.print "Passphrase: "
+        pass = $stdin.noecho(&:gets).to_s.chomp
+        $stderr.puts
+
+        if confirm
+          $stderr.print "Confirm passphrase: "
+          confirm_pass = $stdin.noecho(&:gets).to_s.chomp
           $stderr.puts
-          pass
+          abort "Passphrases do not match." unless pass == confirm_pass
         end
+
+        pass
       end
       private_class_method :prompt_passphrase
 

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -60,8 +60,8 @@ module Browserctl
       res
     end
 
-    def save_session(session_name)
-      res = @client.session_save(session_name)
+    def save_session(session_name, encrypt: false)
+      res = @client.session_save(session_name, encrypt: encrypt)
       raise WorkflowError, res[:error] if res[:error]
 
       res

--- a/rakelib/smoke.rake
+++ b/rakelib/smoke.rake
@@ -15,7 +15,6 @@ SMOKE_FILES = %w[
 desc "Run all smoke workflows. HEADED=1 for a visible browser."
 task :smoke do
   ENV["BCTL_SMOKE_SECRET"] = "smoke-secret-ok"
-  ENV.delete("BCTL_SMOKE_MISSING_VAR")
 
   with_daemon(headed: ENV["HEADED"] == "1") do
     SMOKE_FILES.each do |file|

--- a/rakelib/smoke.rake
+++ b/rakelib/smoke.rake
@@ -9,10 +9,13 @@ SMOKE_FILES = %w[
   rakelib/smoke/session.rb
   rakelib/smoke/session_encrypted.rb
   rakelib/smoke/store_fetch.rb
+  rakelib/smoke/secret_resolvers.rb
 ].freeze
 
 desc "Run all smoke workflows. HEADED=1 for a visible browser."
 task :smoke do
+  ENV["BCTL_SMOKE_SECRET"] = "smoke-secret-ok"
+
   with_daemon(headed: ENV["HEADED"] == "1") do
     SMOKE_FILES.each do |file|
       puts "\n── #{file} ──"

--- a/rakelib/smoke.rake
+++ b/rakelib/smoke.rake
@@ -15,6 +15,7 @@ SMOKE_FILES = %w[
 desc "Run all smoke workflows. HEADED=1 for a visible browser."
 task :smoke do
   ENV["BCTL_SMOKE_SECRET"] = "smoke-secret-ok"
+  ENV.delete("BCTL_SMOKE_MISSING_VAR")
 
   with_daemon(headed: ENV["HEADED"] == "1") do
     SMOKE_FILES.each do |file|

--- a/rakelib/smoke.rake
+++ b/rakelib/smoke.rake
@@ -7,6 +7,7 @@ SMOKE_FILES = %w[
   rakelib/smoke/upload_dialog.rb
   rakelib/smoke/cookies_storage.rb
   rakelib/smoke/session.rb
+  rakelib/smoke/session_encrypted.rb
   rakelib/smoke/store_fetch.rb
 ].freeze
 

--- a/rakelib/smoke/secret_resolvers.rb
+++ b/rakelib/smoke/secret_resolvers.rb
@@ -22,7 +22,8 @@ Browserctl.workflow "smoke/secret_resolvers" do
   end
 
   step "assert missing env var raises SecretResolverError" do
-    Browserctl::SecretResolverRegistry.resolve("env://BCTL_SMOKE_MISSING_VAR")
+    missing = "BCTL_SMOKE_MISSING_#{SecureRandom.hex(8)}"
+    Browserctl::SecretResolverRegistry.resolve("env://#{missing}")
     assert false, "expected SecretResolverError was not raised"
   rescue Browserctl::SecretResolverError => e
     puts "  [ok] SecretResolverError raised as expected: #{e.message}"

--- a/rakelib/smoke/secret_resolvers.rb
+++ b/rakelib/smoke/secret_resolvers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#
+# Smoke test: secret resolver plugin system.
+#
+# Uses env:// (the only built-in resolver with no external tool dependency)
+# to verify the full path: param declaration → registry dispatch → value
+# available inside a step.
+#
+# Requires BCTL_SMOKE_SECRET to be set in the environment.
+# The rake task sets it automatically.
+
+Browserctl.workflow "smoke/secret_resolvers" do
+  desc "Smoke: env:// secret resolver resolves param at runtime"
+
+  param :secret_value, secret_ref: "env://BCTL_SMOKE_SECRET"
+
+  step "assert secret was resolved" do
+    assert secret_value == "smoke-secret-ok",
+           "expected 'smoke-secret-ok', got: #{secret_value.inspect}"
+    puts "  [ok] env:// resolver returned correct value"
+  end
+
+  step "assert missing env var raises SecretResolverError" do
+    Browserctl::SecretResolverRegistry.resolve("env://BCTL_SMOKE_MISSING_VAR")
+    assert false, "expected SecretResolverError was not raised"
+  rescue Browserctl::SecretResolverError => e
+    puts "  [ok] SecretResolverError raised as expected: #{e.message}"
+  end
+end

--- a/rakelib/smoke/session_encrypted.rb
+++ b/rakelib/smoke/session_encrypted.rb
@@ -10,17 +10,15 @@
 # Run with:
 #   browserctl workflow run rakelib/smoke/session_encrypted.rb
 
+unless RUBY_PLATFORM.include?("darwin")
+  puts "  [skip] smoke/session_encrypted: macOS Keychain required — skipping on #{RUBY_PLATFORM}"
+  return
+end
+
 SESSION_NAME = "smoke-enc-#{Process.pid}".freeze
 
 Browserctl.workflow "smoke/session_encrypted" do
   desc "Smoke: encrypted session save, load, delete"
-
-  step "guard — skip on non-darwin" do
-    unless RUBY_PLATFORM.include?("darwin")
-      puts "  [skip] session encryption requires macOS Keychain — skipping on #{RUBY_PLATFORM}"
-      throw :abort
-    end
-  end
 
   step "setup — open page with state" do
     open_page(:sess, url: "https://example.com")

--- a/rakelib/smoke/session_encrypted.rb
+++ b/rakelib/smoke/session_encrypted.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#
+# Smoke test: encrypted session save/load/delete.
+#
+# Verifies that `save_session(name, encrypt: true)` writes .enc files and
+# that a subsequent load restores the page correctly. Requires macOS Keychain
+# (darwin only) — the workflow aborts gracefully on other platforms.
+#
+# Run with:
+#   browserctl workflow run rakelib/smoke/session_encrypted.rb
+
+SESSION_NAME = "smoke-enc-#{Process.pid}".freeze
+
+Browserctl.workflow "smoke/session_encrypted" do
+  desc "Smoke: encrypted session save, load, delete"
+
+  step "guard — skip on non-darwin" do
+    unless RUBY_PLATFORM.include?("darwin")
+      puts "  [skip] session encryption requires macOS Keychain — skipping on #{RUBY_PLATFORM}"
+      throw :abort
+    end
+  end
+
+  step "setup — open page with state" do
+    open_page(:sess, url: "https://example.com")
+    puts "  [ok] page :sess opened"
+  end
+
+  step "session save --encrypt" do
+    save_session(SESSION_NAME, encrypt: true)
+    puts "  [ok] encrypted session saved as #{SESSION_NAME.inspect}"
+  end
+
+  step "verify .enc files on disk (no plaintext)" do
+    sessions_dir = File.join(Browserctl::BROWSERCTL_DIR, "sessions", SESSION_NAME)
+    assert Dir.exist?(sessions_dir), "session dir missing: #{sessions_dir}"
+    assert File.exist?(File.join(sessions_dir, "cookies.json.enc")), "cookies.json.enc missing"
+    assert !File.exist?(File.join(sessions_dir, "cookies.json")), "plaintext cookies.json should not exist"
+    puts "  [ok] .enc files present, no plaintext"
+  end
+
+  step "close page before loading session" do
+    close_page(:sess)
+    pages = client.page_list[:pages]
+    assert !pages.include?("sess"), "expected :sess closed"
+    puts "  [ok] page :sess closed"
+  end
+
+  step "session load — restores page from encrypted session" do
+    load_session(SESSION_NAME)
+    pages = client.page_list[:pages]
+    assert pages.include?("sess"), "expected :sess restored, got: #{pages.inspect}"
+    puts "  [ok] encrypted session loaded — pages: #{pages.inspect}"
+  end
+
+  step "session delete" do
+    client.session_delete(SESSION_NAME)
+    sessions = list_sessions
+    names = sessions.map { |s| s[:name] }
+    assert !names.include?(SESSION_NAME), "expected #{SESSION_NAME.inspect} deleted"
+    puts "  [ok] session deleted"
+  end
+
+  step "teardown" do
+    client.page_close("sess")
+  rescue StandardError
+    nil
+  end
+end

--- a/skills/browserctl/SKILL.md
+++ b/skills/browserctl/SKILL.md
@@ -122,12 +122,14 @@ browserctl storage delete login                                                 
 browserctl storage delete login --store session                                  # clear sessionStorage only
 
 # Session (save/restore full browser state: pages + cookies + localStorage)
-browserctl session save   myapp                          # snapshot current state
+browserctl session save   myapp                          # snapshot current state (plaintext, 0o600)
+browserctl session save   myapp --encrypt                # AES-256-GCM at rest, key in macOS Keychain
 browserctl session load   myapp                          # restore into running daemon
 browserctl session list                                  # list saved sessions
 browserctl session delete myapp                          # delete a saved session
 browserctl session export myapp /tmp/myapp.zip           # zip to portable archive
-browserctl session import /tmp/myapp.zip                 # unzip into sessions directory
+browserctl session export myapp /tmp/myapp.zip --encrypt # passphrase-protected zip (PBKDF2+AES-256-GCM)
+browserctl session import /tmp/myapp.zip                 # unzip; detects and decrypts automatically
 
 # Page management
 browserctl page list
@@ -366,7 +368,7 @@ end
 | `open_page(name, url: nil)` | Open a named page, optionally navigating to a URL |
 | `close_page(name)` | Close a named page |
 | `page(:name)` | Return a `PageProxy` for the named page |
-| `save_session(name)` | Snapshot current browser state (pages + cookies + localStorage) to a named session |
+| `save_session(name, encrypt: false)` | Snapshot current browser state to a named session; `encrypt: true` stores sensitive files as AES-256-GCM blobs with the key in macOS Keychain (darwin only) |
 | `load_session(name)` | Restore a saved session into the running daemon |
 | `load_session(name, fallback: "workflow_name")` | Restore session; if load fails, invoke the named fallback workflow then retry once. Use this instead of hand-rolling detect-expiry logic. |
 | `list_sessions` | Return all saved session metadata |

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,14 @@ require "browserctl/client"
 Browserctl.logger = Logger.new(File::NULL)
 
 module BrowserctlHelpers
+  def with_env(vars)
+    old = vars.keys.to_h { |k| [k, ENV.fetch(k, nil)] }
+    vars.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+    yield
+  ensure
+    old.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+
   def start_daemon(headed: false, name: nil)
     socket = Browserctl.socket_path(name)
     pid_f  = Browserctl.pid_path(name)

--- a/spec/unit/session_encryption_spec.rb
+++ b/spec/unit/session_encryption_spec.rb
@@ -159,6 +159,21 @@ RSpec.describe "Session encryption" do
         dir = Browserctl::Session.path("enc_test")
         expect(File.exist?(File.join(dir, "session_storage.json.enc"))).to be false
       end
+
+      it "writes .enc files with mode 0600" do
+        Browserctl::Session.save("enc_test",
+                                 metadata: metadata,
+                                 cookies: cookies,
+                                 local_storage: local_storage,
+                                 session_storage: session_storage,
+                                 encrypt: true)
+
+        dir = Browserctl::Session.path("enc_test")
+        %w[cookies.json.enc local_storage.json.enc session_storage.json.enc].each do |f|
+          mode = File.stat(File.join(dir, f)).mode & 0o777
+          expect(mode).to eq(0o600), "expected #{f} to be 0600, got #{mode.to_s(8)}"
+        end
+      end
     end
   end
 
@@ -217,6 +232,21 @@ RSpec.describe "Session encryption" do
       end
     end
 
+    context "when an .enc file is missing (corrupted session)" do
+      before do
+        enc_meta = metadata.merge(encrypted: true)
+        dir = File.join(@tmpdir, "corrupt_test")
+        FileUtils.mkdir_p(dir)
+        File.write(File.join(dir, "metadata.json"), JSON.generate(enc_meta))
+        # deliberately omit cookies.json.enc
+        allow(Browserctl::Session).to receive(:keychain_fetch).with("corrupt_test").and_return(key)
+      end
+
+      it "raises an error when a required .enc file is absent" do
+        expect { Browserctl::Session.load("corrupt_test") }.to raise_error(StandardError)
+      end
+    end
+
     context "when metadata has no encrypted field (plaintext session)" do
       before do
         Browserctl::Session.save("plain_test",
@@ -231,6 +261,48 @@ RSpec.describe "Session encryption" do
         expect(data[:cookies].first[:name]).to eq("auth")
         expect(data[:local_storage]["https://example.com"]["token"]).to eq("abc")
         expect(data[:metadata][:encrypted]).to be_nil
+      end
+    end
+  end
+
+  # --- prompt_passphrase confirm: true ---
+
+  describe "Browserctl::Commands::Session prompt_passphrase" do
+    around(&:run)
+
+    context "when BROWSERCTL_EXPORT_PASSPHRASE is set" do
+      around do |ex|
+        prev = ENV.delete("BROWSERCTL_EXPORT_PASSPHRASE")
+        ENV["BROWSERCTL_EXPORT_PASSPHRASE"] = "env-pass"
+        ex.run
+      ensure
+        ENV["BROWSERCTL_EXPORT_PASSPHRASE"] = prev
+      end
+
+      it "returns env var without prompting, regardless of confirm:" do
+        result = Browserctl::Commands::Session.send(:prompt_passphrase, confirm: true)
+        expect(result).to eq("env-pass")
+      end
+    end
+
+    context "when reading from stdin" do
+      before do
+        ENV.delete("BROWSERCTL_EXPORT_PASSPHRASE")
+        allow($stderr).to receive(:print)
+        allow($stderr).to receive(:puts)
+        allow($stdin).to receive(:noecho) { |&blk| blk.call($stdin) }
+      end
+
+      it "aborts when confirm passphrase does not match" do
+        allow($stdin).to receive(:gets).and_return("first\n", "second\n")
+        expect { Browserctl::Commands::Session.send(:prompt_passphrase, confirm: true) }
+          .to raise_error(SystemExit)
+      end
+
+      it "returns the passphrase when both entries match" do
+        allow($stdin).to receive(:gets).and_return("match\n", "match\n")
+        result = Browserctl::Commands::Session.send(:prompt_passphrase, confirm: true)
+        expect(result).to eq("match")
       end
     end
   end

--- a/spec/unit/session_encryption_spec.rb
+++ b/spec/unit/session_encryption_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "spec_helper"
 require "tmpdir"
 require "json"
 require "browserctl/session"
@@ -271,23 +272,18 @@ RSpec.describe "Session encryption" do
     around(&:run)
 
     context "when BROWSERCTL_EXPORT_PASSPHRASE is set" do
-      around do |ex|
-        prev = ENV.delete("BROWSERCTL_EXPORT_PASSPHRASE")
-        ENV["BROWSERCTL_EXPORT_PASSPHRASE"] = "env-pass"
-        ex.run
-      ensure
-        ENV["BROWSERCTL_EXPORT_PASSPHRASE"] = prev
-      end
-
       it "returns env var without prompting, regardless of confirm:" do
-        result = Browserctl::Commands::Session.send(:prompt_passphrase, confirm: true)
-        expect(result).to eq("env-pass")
+        with_env("BROWSERCTL_EXPORT_PASSPHRASE" => "env-pass") do
+          result = Browserctl::Commands::Session.send(:prompt_passphrase, confirm: true)
+          expect(result).to eq("env-pass")
+        end
       end
     end
 
     context "when reading from stdin" do
+      around { |ex| with_env("BROWSERCTL_EXPORT_PASSPHRASE" => nil) { ex.run } }
+
       before do
-        ENV.delete("BROWSERCTL_EXPORT_PASSPHRASE")
         allow($stderr).to receive(:print)
         allow($stderr).to receive(:puts)
         allow($stdin).to receive(:noecho) { |&blk| blk.call($stdin) }


### PR DESCRIPTION
## Summary

Follow-up to #57 (v0.8.1 session encryption) — closes the gaps identified in the post-merge coverage audit.

**Test gaps filled:**
- `.enc` files are written with mode `0600` (was asserted for plaintext, not encrypted)
- `Session.load` raises when a required `.enc` file is absent (corrupted session guard)
- `prompt_passphrase(confirm: true)` — mismatch aborts, match returns passphrase, env var bypasses both prompts

**DX improvements:**
- `save_session(name, encrypt: true)` now available in the workflow DSL — engineers no longer have to drop to `client.session_save` for encrypted saves
- `session export --encrypt` now requires passphrase confirmation; `session import` keeps single-prompt (nothing to confirm on the read side)
- `rakelib/smoke/session_encrypted.rb` — full encrypted session lifecycle smoke workflow (darwin-only guard skips gracefully on Linux/CI)

## Test plan

- [x] `spec/unit/session_encryption_spec.rb` — 31 examples, all green
- [x] Full unit suite: 245 examples, 0 failures
- [x] RuboCop: 0 offenses