### PR TITLE
docs: fix v0.8 roadmap checkboxes, stale HITL reference, and secrets discoverability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Mental models before mechanics.
 | [Sessions and Pages](concepts/sessions-and-pages.md) | Why a daemon beats a script, and what named pages give you |
 | [Snapshots and Refs](concepts/snapshots-and-refs.md) | The compact JSON snapshot format and ref-based interaction |
 | [Human-in-the-Loop](concepts/hitl.md) | Pause/resume, challenge detection, the extensible blocker model |
+| [Secrets and Credentials](guides/writing-workflows.md#sourcing-secrets-with-secret_ref) | Secret resolver system — env://, keychain://, op://, and custom resolvers |
 
 ---
 

--- a/docs/concepts/hitl.md
+++ b/docs/concepts/hitl.md
@@ -67,7 +67,7 @@ Cloudflare is just the first detector. The detection layer is designed to grow �
 
 The philosophy is: **surface the signal, let the workflow decide.** browserctl doesn't try to auto-solve challenges (fragile, constantly broken by vendor updates, often illegal). It identifies that the situation requires attention and hands it off cleanly.
 
-A `register_detector` plugin API is planned for v0.7 — third-party detectors will be registerable without modifying the core. For now, additional detection logic can be added via the plugin system using `register_command`.
+A `register_detector` plugin API is planned for a future release — third-party detectors will be registerable without modifying the core. For now, additional detection logic can be added via the plugin system using `register_command`.
 
 ---
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -130,10 +130,10 @@ It is the difference between a browser **you restart** and a browser **you steer
 ### v0.8 — Credentials & Session Durability
 **Goal:** Production-grade workflows without infrastructure boilerplate.
 
-- [ ] Secret resolver plugin system — `param :password, secret_ref: "op://vault/item/field"`
-- [ ] Built-in resolvers: `env://`, `keychain://` (macOS), `op://` (1Password CLI)
-- [ ] User-defined resolvers via `~/.browserctl/resolvers.rb`
-- [ ] `load_session` with `fallback:` — automatic session expiry recovery
+- [x] Secret resolver plugin system — `param :password, secret_ref: "op://vault/item/field"`
+- [x] Built-in resolvers: `env://`, `keychain://` (macOS), `op://` (1Password CLI)
+- [x] User-defined resolvers via `~/.browserctl/resolvers.rb`
+- [x] `load_session` with `fallback:` — automatic session expiry recovery
 - [x] Session encryption at rest — `browserctl session save --encrypt`
 - [x] Export encryption — `browserctl session export --encrypt` with passphrase
 


### PR DESCRIPTION
## Summary

- **`docs/vision.md`** — marks the 4 remaining v0.8 items as `[x]` (secret resolver plugin system, built-in resolvers, user-defined resolvers, `load_session` fallback); all shipped in v0.8.0
- **`docs/concepts/hitl.md`** — removes stale "planned for v0.7" reference for `register_detector`; replaces with "planned for a future release"
- **`docs/README.md`** — adds Secrets and Credentials entry to the Concepts table so the v0.8 secret resolver system is discoverable from the docs index

## Test plan

- [ ] `docs/vision.md` v0.8 section — all items show `[x]`
- [ ] `docs/concepts/hitl.md` extensible detection section — no stale version reference
- [ ] `docs/README.md` Concepts table — Secrets and Credentials row present, links to `secret_ref:` section