### PR TITLE
fix: v0.8.2 UX polish — describe secret_ref, fallback hint, cross-platform encrypt guidance

### DIFF
--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -109,7 +109,11 @@ module Browserctl
     end
 
     def format_params(defn)
-      defn.param_defs.transform_values { |p| { required: p.required, secret: p.secret, default: p.default } }
+      defn.param_defs.transform_values do |p|
+        entry = { required: p.required, secret: p.secret, default: p.default }
+        entry[:secret_ref] = p.secret_ref if p.secret_ref
+        entry
+      end
     end
   end
 end

--- a/lib/browserctl/secret_resolver_registry.rb
+++ b/lib/browserctl/secret_resolver_registry.rb
@@ -16,9 +16,13 @@ module Browserctl
       scheme, reference = secret_ref.split("://", 2)
       resolver = @mutex.synchronize { @registry[scheme] }
       raise SecretResolverError, "unknown secret resolver scheme '#{scheme}'" unless resolver
+
       unless resolver.available?
-        raise SecretResolverError,
-              "'#{scheme}://' resolver is not available in this environment"
+        msg = "'#{scheme}://' resolver is not available in this environment"
+        if scheme == "keychain"
+          msg += "\n  Use env://YOUR_VAR_NAME to source secrets from environment variables instead."
+        end
+        raise SecretResolverError, msg
       end
 
       resolver.resolve(reference)

--- a/lib/browserctl/session.rb
+++ b/lib/browserctl/session.rb
@@ -39,7 +39,12 @@ module Browserctl
     def self.prepare_encryption(session_name, metadata, encrypt)
       return [nil, metadata] unless encrypt
 
-      raise Browserctl::Error, "session encryption requires macOS Keychain (darwin only)" unless keychain_available?
+      unless keychain_available?
+        raise Browserctl::Error,
+              "session encryption requires macOS Keychain (darwin only)\n  " \
+              "For Linux/CI, omit --encrypt and rely on 0o600 file permissions,\n  " \
+              "or use BROWSERCTL_EXPORT_PASSPHRASE with session export --encrypt for portable archives."
+      end
 
       key = SecureRandom.bytes(32)
       keychain_store(session_name, key)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -4,6 +4,7 @@ require "timeout"
 require_relative "client"
 require_relative "errors"
 require_relative "secret_resolvers"
+require_relative "session"
 
 module Browserctl
   ParamDef = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
@@ -76,8 +77,11 @@ module Browserctl
       invoke(fallback.to_s)
       res2 = @client.session_load(session_name)
       if res2[:error]
-        raise WorkflowError,
-              "session '#{session_name}' still unavailable after running fallback '#{fallback}'"
+        msg = "session '#{session_name}' still unavailable after running fallback '#{fallback}'"
+        unless Session.exist?(session_name)
+          msg += "\n  Hint: '#{fallback}' did not call save_session(\"#{session_name}\") — add it as the last step."
+        end
+        raise WorkflowError, msg
       end
 
       res2

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -95,4 +95,35 @@ RSpec.describe Browserctl::Runner do
         .to raise_error(RuntimeError, /not found/)
     end
   end
+
+  describe "#describe_workflow" do
+    before do
+      Browserctl.workflow("describe_test") do
+        desc "test workflow"
+        param :email, required: true
+        param :password, secret_ref: "keychain://MyApp/admin"
+        param :api_token, secret_ref: "env://API_TOKEN"
+        param :note, default: "hello"
+        step("step one") { nil }
+      end
+    end
+
+    after do
+      Browserctl.instance_variable_get(:@registry_mutex).synchronize do
+        Browserctl.instance_variable_get(:@registry).delete("describe_test")
+      end
+    end
+
+    it "includes secret_ref in param output when declared" do
+      result = runner.describe_workflow("describe_test")
+      expect(result[:params][:password][:secret_ref]).to eq("keychain://MyApp/admin")
+      expect(result[:params][:api_token][:secret_ref]).to eq("env://API_TOKEN")
+    end
+
+    it "omits secret_ref key for plain params" do
+      result = runner.describe_workflow("describe_test")
+      expect(result[:params][:email]).not_to have_key(:secret_ref)
+      expect(result[:params][:note]).not_to have_key(:secret_ref)
+    end
+  end
 end

--- a/spec/unit/secret_resolver_registry_spec.rb
+++ b/spec/unit/secret_resolver_registry_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe Browserctl::SecretResolverRegistry do
         .to raise_error(Browserctl::SecretResolverError, %r{'unavail://' resolver is not available})
     end
 
+    it "includes env:// hint when keychain:// resolver is unavailable" do
+      keychain_class = Class.new(Browserctl::SecretResolvers::Base) do
+        def self.scheme = "keychain"
+        def available? = false
+        def resolve(_reference) = "nope"
+      end
+      described_class.register(keychain_class)
+      expect { described_class.resolve("keychain://MyApp/admin") }
+        .to raise_error(Browserctl::SecretResolverError, %r{Use env://YOUR_VAR_NAME})
+    end
+
     it "wraps non-SecretResolverError in SecretResolverError" do
       described_class.register(raising_resolver_class)
       expect { described_class.resolve("raises://something") }

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -229,14 +229,38 @@ RSpec.describe "WorkflowContext#load_session with fallback:" do
     expect(result).to eq({ ok: true, session: "data" })
   end
 
-  it "raises WorkflowError with clear message when fallback cannot recover" do
+  it "raises WorkflowError with hint when fallback ran but never called save_session" do
     allow(client).to receive(:session_load).with("my-session").and_return({ error: "not found" })
+    allow(Browserctl::Session).to receive(:exist?).with("my-session").and_return(false)
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    allow(ctx).to receive(:invoke).with("setup_workflow")
+
+    error = nil
+    begin
+      ctx.load_session("my-session", fallback: :setup_workflow)
+    rescue Browserctl::WorkflowError => e
+      error = e
+    end
+
+    expect(error).not_to be_nil
+    expect(error.message).to match(/still unavailable after running fallback 'setup_workflow'/)
+    expect(error.message).to match(/Hint: 'setup_workflow' did not call save_session\("my-session"\)/)
+  end
+
+  it "raises WorkflowError without hint when session dir exists but load still fails" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ error: "decryption failed" })
+    allow(Browserctl::Session).to receive(:exist?).with("my-session").and_return(true)
     ctx = Browserctl::WorkflowContext.new({}, client)
     allow(ctx).to receive(:invoke).with("setup_workflow")
 
     expect { ctx.load_session("my-session", fallback: :setup_workflow) }
-      .to raise_error(Browserctl::WorkflowError,
-                      "session 'my-session' still unavailable after running fallback 'setup_workflow'")
+      .to raise_error(Browserctl::WorkflowError, /still unavailable after running fallback 'setup_workflow'/)
+
+    begin
+      ctx.load_session("my-session", fallback: :setup_workflow)
+    rescue Browserctl::WorkflowError => e
+      expect(e.message).not_to include("Hint:")
+    end
   end
 
   it "raises WorkflowError without fallback as today" do


### PR DESCRIPTION
## Summary

Closes #61, #62, #63 — all three v0.8.2 milestone issues.

- **#61** `workflow describe` now includes `secret_ref:` URI in param output so engineers can see what secret infrastructure a workflow requires without reading source
- **#62** `load_session` fallback error appends a `Hint:` about missing `save_session` call when the session directory was never created by the fallback workflow
- **#63** `--encrypt` error on non-darwin and `keychain://` unavailability error both now suggest `env://` as the cross-platform alternative

## Changes

| File | Change |
|------|--------|
| `lib/browserctl/runner.rb` | `format_params` includes `secret_ref:` key when declared |
| `lib/browserctl/workflow.rb` | `load_session` checks `Session.exist?` after fallback fails; appends hint when absent |
| `lib/browserctl/session.rb` | `prepare_encryption` error message extended with Linux/CI guidance |
| `lib/browserctl/secret_resolver_registry.rb` | unavailability error for `keychain://` suggests `env://` |

## Test plan

- [x] `bundle exec rspec` — 300 examples, 0 failures (51 pending — Chrome unavailable in CI)
- [x] New test: `describe_workflow` exposes `secret_ref` and omits key for plain params
- [x] New test: `load_session` fallback emits hint when session dir absent; no hint when dir exists
- [x] New test: `keychain://` unavailable error includes `env://` hint