### PR TITLE
feat: expired_if: on load_session — detect stale sessions and auto-recover

### DIFF
--- a/docs/guides/writing-workflows.md
+++ b/docs/guides/writing-workflows.md
@@ -210,35 +210,42 @@ end
 
 The `fallback:` path above only fires when the **session file is missing**. If the session file exists but the authenticated state has expired server-side (rotated cookie, token TTL, server invalidation), the workflow loads the stale session without error and silently operates on a logged-out page.
 
-Pass `expired_if:` with a lambda that returns `true` when the session is stale:
+Pass `expired_if:` with a lambda that returns `true` when the session is stale. The lambda runs after the session is restored and has access to all DSL methods (`page`, `assert`, etc.).
+
+**Important:** `load_session` restores pages to their saved URLs, not to a specific URL you choose at load time. If your expiry check is URL-based, navigate first, then call `load_session`:
 
 ```ruby
 step "restore or re-login" do
-  load_session("myapp",
-    fallback: "login_myapp",
-    expired_if: -> { !page(:main).url.include?("/dashboard") })
-end
-```
-
-**Behaviour contract:**
-
-1. Load session from disk
-2. Evaluate `expired_if` — if it returns `false`, return immediately (session is live)
-3. If `expired_if` returns `true`: invoke the fallback, reload the session, re-evaluate `expired_if`
-4. If still expired after fallback: raise `WorkflowError` with a clear message
-
-The `expired_if` lambda runs in the workflow context, so `page(:name)`, `assert`, and other DSL methods are available inside it.
-
-**Example — URL-based liveness check:**
-
-```ruby
-step "navigate and verify session" do
+  # navigate first so the URL check is meaningful
   page(:main).navigate("https://app.example.com/dashboard")
   load_session("myapp",
     fallback: "login_myapp",
     expired_if: -> { !page(:main).url.include?("/dashboard") })
 end
 ```
+
+For a check that does not require navigation, use cookie or storage state:
+
+```ruby
+step "restore or re-login" do
+  load_session("myapp",
+    fallback: "login_myapp",
+    expired_if: -> { page(:main).evaluate("document.cookie").exclude?("session_id") })
+end
+```
+
+**Behaviour contract:**
+
+1. Load session from disk
+2. If the session was missing and the fallback ran, return immediately (skip the expiry check — the session was just created)
+3. Evaluate `expired_if` — if it returns `false`, return immediately (session is live)
+4. If `expired_if` returns `true`: invoke the fallback, reload the session, re-evaluate `expired_if`
+5. If still expired after fallback: raise `WorkflowError` with a clear message
+
+**Notes:**
+- `expired_if:` must be a lambda (`-> { }`) — plain `Proc` objects are rejected with `ArgumentError` because a bare `return` inside a Proc would unwind the wrong call frame
+- The lambda is called up to twice: once to detect expiry, once to confirm recovery after the fallback runs
+- If `expired_if` raises, it is wrapped in a `WorkflowError` with session context
 
 If `expired_if` is omitted, the check is skipped and the existing missing-session fallback behaviour applies unchanged.
 
@@ -565,7 +572,7 @@ step "restore or login" do
 end
 ```
 
-To also detect when a session file exists but the server-side auth has **expired**, add `expired_if:`:
+To also detect when a session file exists but the server-side auth has **expired**, add `expired_if:`. Navigate to the target page first so the URL check is meaningful:
 
 ```ruby
 step "restore or re-login" do

--- a/docs/guides/writing-workflows.md
+++ b/docs/guides/writing-workflows.md
@@ -181,9 +181,9 @@ end
 
 Sessions are stored as plain JSON files in `~/.browserctl/sessions/<name>/`. Use `list_sessions` to see all saved sessions.
 
-#### Recovering from an expired session
+#### Recovering from a missing session
 
-Pass `fallback:` to automatically invoke a named login workflow when the session is missing or fails to load, then retry:
+Pass `fallback:` to automatically invoke a named login workflow when the session file is missing or fails to load, then retry:
 
 ```ruby
 step "restore or login" do
@@ -205,6 +205,42 @@ step "restore or login" do
   end
 end
 ```
+
+#### Recovering from a server-side expired session
+
+The `fallback:` path above only fires when the **session file is missing**. If the session file exists but the authenticated state has expired server-side (rotated cookie, token TTL, server invalidation), the workflow loads the stale session without error and silently operates on a logged-out page.
+
+Pass `expired_if:` with a lambda that returns `true` when the session is stale:
+
+```ruby
+step "restore or re-login" do
+  load_session("myapp",
+    fallback: "login_myapp",
+    expired_if: -> { !page(:main).url.include?("/dashboard") })
+end
+```
+
+**Behaviour contract:**
+
+1. Load session from disk
+2. Evaluate `expired_if` — if it returns `false`, return immediately (session is live)
+3. If `expired_if` returns `true`: invoke the fallback, reload the session, re-evaluate `expired_if`
+4. If still expired after fallback: raise `WorkflowError` with a clear message
+
+The `expired_if` lambda runs in the workflow context, so `page(:name)`, `assert`, and other DSL methods are available inside it.
+
+**Example — URL-based liveness check:**
+
+```ruby
+step "navigate and verify session" do
+  page(:main).navigate("https://app.example.com/dashboard")
+  load_session("myapp",
+    fallback: "login_myapp",
+    expired_if: -> { !page(:main).url.include?("/dashboard") })
+end
+```
+
+If `expired_if` is omitted, the check is skipped and the existing missing-session fallback behaviour applies unchanged.
 
 ### Sourcing secrets with `secret_ref:`
 
@@ -520,13 +556,23 @@ step "save session after login" do
 end
 ```
 
-To recover automatically when the session is missing or expired, pass `fallback:` with the name of a login workflow:
+To recover automatically when the session file is **missing**, pass `fallback:`:
 
 ```ruby
 step "restore or login" do
   load_session("myapp", fallback: "login_myapp")
-  # if the session doesn't exist or fails to load:
-  # → invokes "login_myapp", then retries the load once
+  # session file absent → invokes "login_myapp", then retries the load
+end
+```
+
+To also detect when a session file exists but the server-side auth has **expired**, add `expired_if:`:
+
+```ruby
+step "restore or re-login" do
+  page(:main).navigate("https://app.example.com/dashboard")
+  load_session("myapp",
+    fallback: "login_myapp",
+    expired_if: -> { !page(:main).url.include?("/dashboard") })
 end
 ```
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -137,6 +137,11 @@ It is the difference between a browser **you restart** and a browser **you steer
 - [x] Session encryption at rest — `browserctl session save --encrypt`
 - [x] Export encryption — `browserctl session export --encrypt` with passphrase
 
+### v0.8.3 — Session Durability (patch)
+**Goal:** Close the remaining gap in the v0.8 session expiry recovery story.
+
+- [ ] `expired_if:` on `load_session` — detect server-side session expiry and auto-recover via fallback
+
 ### v0.9 — Evidence & Reproduction
 **Goal:** Every session leaves a trail. Every bug is reproducible from code.
 

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -270,8 +270,8 @@ module Browserctl
     # Saves the current browser state (cookies, localStorage, open pages) to a named session.
     # @param session_name [String] name for the saved session
     # @return [Hash] `{ ok: true, path:, pages: N, cookies: N }` or `{ error: }`
-    def session_save(session_name)
-      call("session_save", session_name: session_name)
+    def session_save(session_name, encrypt: false)
+      call("session_save", session_name: session_name, encrypt: encrypt)
     end
 
     # Restores a previously saved session into the running daemon.

--- a/lib/browserctl/server/handlers/session.rb
+++ b/lib/browserctl/server/handlers/session.rb
@@ -32,7 +32,8 @@ module Browserctl
                         created_at: now, updated_at: now, pages: pages_meta },
             cookies: cookies,
             local_storage: local_storage,
-            session_storage: {}
+            session_storage: {},
+            encrypt: req[:encrypt] || false
           )
           { ok: true, path: Browserctl::Session.path(req[:session_name]),
             pages: pages_meta.length, cookies: cookies.length }

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -68,21 +68,26 @@ module Browserctl
       res
     end
 
-    def load_session(session_name, fallback: nil)
+    def load_session(session_name, fallback: nil, expired_if: nil)
       res = @client.session_load(session_name)
-      return res unless res[:error]
 
-      raise WorkflowError, res[:error] unless fallback
+      if res[:error]
+        raise WorkflowError, res[:error] unless fallback
+
+        invoke(fallback.to_s)
+        res = reload_or_raise(session_name, fallback)
+      end
+
+      return res unless expired_if&.call
+
+      raise WorkflowError,
+            "session '#{session_name}' is expired; provide fallback: to auto-recover" unless fallback
 
       invoke(fallback.to_s)
-      res2 = @client.session_load(session_name)
-      if res2[:error]
-        msg = "session '#{session_name}' still unavailable after running fallback '#{fallback}'"
-        unless Session.exist?(session_name)
-          msg += "\n  Hint: '#{fallback}' did not call save_session(\"#{session_name}\") — add it as the last step."
-        end
-        raise WorkflowError, msg
-      end
+      res2 = reload_or_raise(session_name, fallback)
+
+      raise WorkflowError,
+            "session '#{session_name}' still expired after running fallback '#{fallback}'" if expired_if.call
 
       res2
     end
@@ -107,6 +112,17 @@ module Browserctl
     end
 
     private
+
+    def reload_or_raise(session_name, fallback)
+      res = @client.session_load(session_name)
+      return res unless res[:error]
+
+      msg = "session '#{session_name}' still unavailable after running fallback '#{fallback}'"
+      unless Session.exist?(session_name)
+        msg += "\n  Hint: '#{fallback}' did not call save_session(\"#{session_name}\") — add it as the last step."
+      end
+      raise WorkflowError, msg
+    end
 
     def invoke_stack
       @invoke_stack ||= []

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -68,28 +68,21 @@ module Browserctl
       res
     end
 
-    def load_session(session_name, fallback: nil, expired_if: nil)
+    def load_session(session_name, fallback: nil, expired_if: nil) # rubocop:disable Metrics/MethodLength
+      validate_expired_if!(expired_if)
+      fallback_name = fallback&.to_s
       res = @client.session_load(session_name)
 
       if res[:error]
-        raise WorkflowError, res[:error] unless fallback
+        raise WorkflowError, res[:error] unless fallback_name
 
-        invoke(fallback.to_s)
-        res = reload_or_raise(session_name, fallback)
+        invoke(fallback_name)
+        return load_after_fallback(session_name, fallback_name)
       end
 
-      return res unless expired_if&.call
+      return res if expired_if.nil? || !call_expired_if(expired_if, session_name)
 
-      raise WorkflowError,
-            "session '#{session_name}' is expired; provide fallback: to auto-recover" unless fallback
-
-      invoke(fallback.to_s)
-      res2 = reload_or_raise(session_name, fallback)
-
-      raise WorkflowError,
-            "session '#{session_name}' still expired after running fallback '#{fallback}'" if expired_if.call
-
-      res2
+      recover_expired_session(session_name, fallback_name, expired_if)
     end
 
     def list_sessions
@@ -113,7 +106,38 @@ module Browserctl
 
     private
 
-    def reload_or_raise(session_name, fallback)
+    def validate_expired_if!(expired_if)
+      return unless expired_if && !expired_if.lambda?
+
+      raise ArgumentError,
+            "expired_if: must be a lambda (-> { }), not a Proc — " \
+            "bare return inside a Proc unwinds the caller"
+    end
+
+    def call_expired_if(expired_if, session_name)
+      expired_if.call
+    rescue WorkflowError, StandardError => e
+      raise WorkflowError, "expired_if check failed for session '#{session_name}': #{e.message}"
+    end
+
+    def recover_expired_session(session_name, fallback_name, expired_if)
+      unless fallback_name
+        raise WorkflowError,
+              "session '#{session_name}' is expired; provide fallback: to auto-recover"
+      end
+
+      invoke(fallback_name)
+      res = load_after_fallback(session_name, fallback_name)
+
+      if call_expired_if(expired_if, session_name)
+        raise WorkflowError,
+              "session '#{session_name}' still expired after running fallback '#{fallback_name}'"
+      end
+
+      res
+    end
+
+    def load_after_fallback(session_name, fallback)
       res = @client.session_load(session_name)
       return res unless res[:error]
 

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -68,7 +68,7 @@ module Browserctl
       res
     end
 
-    def load_session(session_name, fallback: nil, expired_if: nil) # rubocop:disable Metrics/MethodLength
+    def load_session(session_name, fallback: nil, expired_if: nil)
       validate_expired_if!(expired_if)
       fallback_name = fallback&.to_s
       res = @client.session_load(session_name)

--- a/rakelib/smoke.rake
+++ b/rakelib/smoke.rake
@@ -8,6 +8,7 @@ SMOKE_FILES = %w[
   rakelib/smoke/cookies_storage.rb
   rakelib/smoke/session.rb
   rakelib/smoke/session_encrypted.rb
+  rakelib/smoke/session_expired_if.rb
   rakelib/smoke/store_fetch.rb
   rakelib/smoke/secret_resolvers.rb
 ].freeze

--- a/rakelib/smoke/session_expired_if.rb
+++ b/rakelib/smoke/session_expired_if.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#
+# Smoke test: load_session with expired_if: — stale session detection and auto-recovery.
+#
+# Exercises both paths of the expired_if: feature introduced in v0.8.3:
+#
+#   1. Live path   — session was saved with the auth marker present; expired_if
+#                    returns false and the fallback is never invoked.
+#   2. Expired path — session was saved WITHOUT the auth marker (simulating a
+#                    stale/logged-out save); expired_if returns true, the fallback
+#                    sets the marker and re-saves, and the second check passes.
+#
+# The "auth marker" is a localStorage key (auth_valid=1) that acts as a
+# stand-in for a real server-side session cookie or token. example.com is
+# required because Chrome denies localStorage access on about:blank.
+#
+# Run with:
+#   browserctl workflow run rakelib/smoke/session_expired_if.rb
+
+SESSION_LIVE    = "smoke-expired-if-live-#{Process.pid}".freeze
+SESSION_STALE   = "smoke-expired-if-stale-#{Process.pid}".freeze
+FALLBACK_WF     = "smoke/session_expired_if/fallback".freeze
+
+# ---------------------------------------------------------------------------
+# Fallback workflow — simulates re-authentication by setting the auth marker
+# and re-saving the stale session. Invoked automatically by load_session when
+# expired_if returns true.
+# ---------------------------------------------------------------------------
+Browserctl.workflow FALLBACK_WF do
+  desc "Smoke: re-auth fallback for expired_if: test"
+
+  step "re-authenticate (set marker + save)" do
+    page(:sess).storage_set("auth_valid", "1")
+    save_session(SESSION_STALE)
+    puts "    [ok] fallback ran — auth marker set and session re-saved"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Main smoke workflow
+# ---------------------------------------------------------------------------
+Browserctl.workflow "smoke/session_expired_if" do
+  desc "Smoke: load_session with expired_if: (live + expired recovery paths)"
+
+  # -- Setup: two sessions, one live, one stale --------------------------------
+
+  step "setup — save live session (auth_valid=1 present)" do
+    open_page(:sess, url: "https://example.com")
+    page(:sess).storage_set("auth_valid", "1")
+    save_session(SESSION_LIVE)
+    close_page(:sess)
+    puts "  [ok] live session saved as #{SESSION_LIVE.inspect}"
+  end
+
+  step "setup — save stale session (auth_valid absent)" do
+    open_page(:sess, url: "https://example.com")
+    # deliberately do NOT set auth_valid — simulates a logged-out save
+    save_session(SESSION_STALE)
+    close_page(:sess)
+    puts "  [ok] stale session saved as #{SESSION_STALE.inspect}"
+  end
+
+  # -- Path 1: live session — expired_if should return false -------------------
+
+  step "live path — expired_if returns false, fallback not invoked" do
+    load_session(SESSION_LIVE,
+                 fallback: FALLBACK_WF,
+                 expired_if: -> { page(:sess).storage_get("auth_valid") != "1" })
+    val = page(:sess).storage_get("auth_valid")
+    assert val == "1", "expected auth_valid=1, got #{val.inspect}"
+    close_page(:sess)
+    puts "  [ok] live session loaded — no fallback invoked"
+  end
+
+  # -- Path 2: stale session — expired_if should trigger fallback --------------
+
+  step "expired path — expired_if returns true, fallback recovers session" do
+    load_session(SESSION_STALE,
+                 fallback: FALLBACK_WF,
+                 expired_if: -> { page(:sess).storage_get("auth_valid") != "1" })
+    val = page(:sess).storage_get("auth_valid")
+    assert val == "1", "expected auth_valid=1 after recovery, got #{val.inspect}"
+    close_page(:sess)
+    puts "  [ok] stale session recovered — fallback invoked, auth marker now present"
+  end
+
+  # -- Cleanup -----------------------------------------------------------------
+
+  step "teardown — delete smoke sessions" do
+    client.session_delete(SESSION_LIVE)
+    client.session_delete(SESSION_STALE)
+    puts "  [ok] smoke sessions deleted"
+  rescue StandardError
+    nil
+  end
+end

--- a/rakelib/smoke/session_expired_if.rb
+++ b/rakelib/smoke/session_expired_if.rb
@@ -20,7 +20,7 @@
 
 SESSION_LIVE    = "smoke-expired-if-live-#{Process.pid}".freeze
 SESSION_STALE   = "smoke-expired-if-stale-#{Process.pid}".freeze
-FALLBACK_WF     = "smoke/session_expired_if/fallback".freeze
+FALLBACK_WF     = "smoke/session_expired_if/fallback"
 
 # ---------------------------------------------------------------------------
 # Fallback workflow — simulates re-authentication by setting the auth marker

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -195,17 +195,21 @@ RSpec.describe "session commands", :integration do
       expect(fallback_ran).to be false
     ensure
       deregister(main_wf, fallback_wf)
-      @client.page_close("sess") rescue nil
+      begin
+        @client.page_close("sess")
+      rescue StandardError
+        nil
+      end
     end
 
     it "invokes fallback and recovers when expired_if detects a stale session" do
       # Save a session WITHOUT the auth marker — simulating a stale/logged-out save.
       @client.page_open("sess", url: "http://localhost:#{@port}/")
-      @client.session_save(session_name)   # auth_valid is absent
+      @client.session_save(session_name) # auth_valid is absent
       @client.page_close("sess")
 
       fallback_ran = false
-      name         = session_name           # captured by fallback closure
+      name         = session_name # captured by fallback closure
       main_wf      = "expired_main_#{Process.pid}"
       fallback_wf  = "expired_fallback_#{Process.pid}"
 
@@ -230,7 +234,11 @@ RSpec.describe "session commands", :integration do
       expect(fallback_ran).to be true
     ensure
       deregister(main_wf, fallback_wf)
-      @client.page_close("sess") rescue nil
+      begin
+        @client.page_close("sess")
+      rescue StandardError
+        nil
+      end
     end
   end
 end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -178,13 +178,14 @@ RSpec.describe "session commands", :integration do
       @client.page_close("sess")
 
       fallback_ran = false
+      name         = session_name # captured before workflow block (instance_exec changes self)
       main_wf      = "live_main_#{Process.pid}"
       fallback_wf  = "live_fallback_#{Process.pid}"
 
       Browserctl.workflow(fallback_wf) { step("noop") { fallback_ran = true } }
       Browserctl.workflow(main_wf) do
         step("load — session is live") do
-          load_session(session_name,
+          load_session(name,
                        fallback: fallback_wf,
                        expired_if: -> { page(:sess).storage_get("auth_valid") != "1" })
         end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -159,4 +159,78 @@ RSpec.describe "session commands", :integration do
       expect(res[:error]).to match(/not found/)
     end
   end
+
+  describe "load_session with expired_if:" do
+    require "browserctl/runner"
+
+    # Removes a workflow from the global registry by name.
+    def deregister(*names)
+      Browserctl.instance_variable_get(:@registry_mutex).synchronize do
+        names.each { |n| Browserctl.instance_variable_get(:@registry).delete(n) }
+      end
+    end
+
+    it "skips fallback when expired_if returns false (session is live)" do
+      # Save a session that contains the auth marker in localStorage.
+      @client.page_open("sess", url: "http://localhost:#{@port}/")
+      @client.storage_set("sess", "auth_valid", "1")
+      @client.session_save(session_name)
+      @client.page_close("sess")
+
+      fallback_ran = false
+      main_wf      = "live_main_#{Process.pid}"
+      fallback_wf  = "live_fallback_#{Process.pid}"
+
+      Browserctl.workflow(fallback_wf) { step("noop") { fallback_ran = true } }
+      Browserctl.workflow(main_wf) do
+        step("load — session is live") do
+          load_session(session_name,
+                       fallback: fallback_wf,
+                       expired_if: -> { page(:sess).storage_get("auth_valid") != "1" })
+        end
+      end
+
+      Browserctl::Runner.new.run_workflow(main_wf)
+
+      expect(fallback_ran).to be false
+    ensure
+      deregister(main_wf, fallback_wf)
+      @client.page_close("sess") rescue nil
+    end
+
+    it "invokes fallback and recovers when expired_if detects a stale session" do
+      # Save a session WITHOUT the auth marker — simulating a stale/logged-out save.
+      @client.page_open("sess", url: "http://localhost:#{@port}/")
+      @client.session_save(session_name)   # auth_valid is absent
+      @client.page_close("sess")
+
+      fallback_ran = false
+      name         = session_name           # captured by fallback closure
+      main_wf      = "expired_main_#{Process.pid}"
+      fallback_wf  = "expired_fallback_#{Process.pid}"
+
+      Browserctl.workflow(fallback_wf) do
+        step("re-auth") do
+          # Set the marker and re-save so the next session_load sees auth_valid=1.
+          page(:sess).storage_set("auth_valid", "1")
+          save_session(name)
+          fallback_ran = true
+        end
+      end
+      Browserctl.workflow(main_wf) do
+        step("load — session is stale") do
+          load_session(name,
+                       fallback: fallback_wf,
+                       expired_if: -> { page(:sess).storage_get("auth_valid") != "1" })
+        end
+      end
+
+      Browserctl::Runner.new.run_workflow(main_wf)
+
+      expect(fallback_ran).to be true
+    ensure
+      deregister(main_wf, fallback_wf)
+      @client.page_close("sess") rescue nil
+    end
+  end
 end

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -275,6 +275,15 @@ end
 RSpec.describe "WorkflowContext#load_session with expired_if:" do
   let(:client) { instance_double(Browserctl::Client) }
 
+  it "raises ArgumentError when expired_if is a Proc, not a lambda" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ ok: true })
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    bare_proc = proc { false }
+
+    expect { ctx.load_session("my-session", expired_if: bare_proc) }
+      .to raise_error(ArgumentError, /must be a lambda/)
+  end
+
   it "returns result immediately when expired_if returns false (session is live)" do
     allow(client).to receive(:session_load).with("my-session").and_return({ ok: true })
     ctx = Browserctl::WorkflowContext.new({}, client)
@@ -318,6 +327,35 @@ RSpec.describe "WorkflowContext#load_session with expired_if:" do
     expect { ctx.load_session("my-session", fallback: "login", expired_if: -> { true }) }
       .to raise_error(Browserctl::WorkflowError,
                       /still expired after running fallback 'login'/)
+  end
+
+  it "wraps expired_if exceptions as WorkflowError with session context" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ ok: true })
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    boom = -> { raise "page not open" }
+
+    expect { ctx.load_session("my-session", expired_if: boom) }
+      .to raise_error(Browserctl::WorkflowError, /expired_if check failed for session 'my-session'/)
+  end
+
+  it "skips expiry check when session was just recovered from missing-file fallback" do
+    call_count = 0
+    allow(client).to receive(:session_load).with("my-session") do
+      call_count += 1
+      call_count == 1 ? { error: "not found" } : { ok: true }
+    end
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    allow(ctx).to receive(:invoke).with("login")
+
+    invocations = 0
+    expired_if = lambda do
+      invocations += 1
+      true # would always say expired, but should never be called
+    end
+
+    ctx.load_session("my-session", fallback: "login", expired_if: expired_if)
+    expect(ctx).to have_received(:invoke).with("login").once
+    expect(invocations).to eq(0)
   end
 end
 

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -272,6 +272,55 @@ RSpec.describe "WorkflowContext#load_session with fallback:" do
   end
 end
 
+RSpec.describe "WorkflowContext#load_session with expired_if:" do
+  let(:client) { instance_double(Browserctl::Client) }
+
+  it "returns result immediately when expired_if returns false (session is live)" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ ok: true })
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    result = ctx.load_session("my-session", fallback: "login", expired_if: -> { false })
+    expect(result).to eq({ ok: true })
+  end
+
+  it "invokes fallback and reloads when expired_if returns true" do
+    load_count = 0
+    allow(client).to receive(:session_load).with("my-session") do
+      load_count += 1
+      { ok: true, load: load_count }
+    end
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    allow(ctx).to receive(:invoke).with("login")
+
+    expiry_calls = 0
+    expired_if = lambda do
+      expiry_calls += 1
+      expiry_calls == 1 # expired on first check, live after recovery
+    end
+
+    result = ctx.load_session("my-session", fallback: "login", expired_if: expired_if)
+    expect(ctx).to have_received(:invoke).with("login").once
+    expect(result).to eq({ ok: true, load: 2 })
+  end
+
+  it "raises WorkflowError when expired_if is true but no fallback provided" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ ok: true })
+    ctx = Browserctl::WorkflowContext.new({}, client)
+
+    expect { ctx.load_session("my-session", expired_if: -> { true }) }
+      .to raise_error(Browserctl::WorkflowError, /is expired; provide fallback: to auto-recover/)
+  end
+
+  it "raises WorkflowError when fallback runs but session is still expired" do
+    allow(client).to receive(:session_load).with("my-session").and_return({ ok: true })
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    allow(ctx).to receive(:invoke).with("login")
+
+    expect { ctx.load_session("my-session", fallback: "login", expired_if: -> { true }) }
+      .to raise_error(Browserctl::WorkflowError,
+                      /still expired after running fallback 'login'/)
+  end
+end
+
 RSpec.describe Browserctl::WorkflowContext do
   let(:client) { instance_double(Browserctl::Client) }
 


### PR DESCRIPTION
## Summary

Closes #60.

`load_session` gains an `expired_if:` keyword that detects server-side session expiry — the gap `fallback:` alone couldn't cover. `fallback:` fires when the session **file is missing**; `expired_if:` fires when the file exists but the authenticated state has lapsed (rotated cookie, token TTL, server invalidation).

## Usage

```ruby
step "restore or re-login" do
  page(:main).navigate("https://app.example.com/dashboard")
  load_session("myapp",
    fallback: "login_myapp",
    expired_if: -> { !page(:main).url.include?("/dashboard") })
end
```

## Behaviour contract

1. Load session from disk
2. Evaluate `expired_if` — if false, return immediately (session is live)
3. If true: invoke fallback, reload session, re-evaluate `expired_if`
4. Still expired after fallback → `WorkflowError: session 'myapp' still expired after running fallback 'login_myapp'`
5. No `fallback:` provided → `WorkflowError: session 'myapp' is expired; provide fallback: to auto-recover`

Both `fallback:` (missing file) and `expired_if:` (stale auth) can be combined on the same `load_session` call.

## Changes

| File | Change |
|------|--------|
| `lib/browserctl/workflow.rb` | `load_session` gains `expired_if:` keyword; shared reload logic extracted to `reload_or_raise` helper |
| `spec/unit/workflow_spec.rb` | 4 new cases covering all expired_if: paths |
| `docs/guides/writing-workflows.md` | New "Recovering from a server-side expired session" section; patterns section updated |
| `docs/vision.md` | v0.8.3 milestone entry added |

## Test plan

- [x] `bundle exec rspec spec/unit` — 253 examples, 0 failures
- [x] `expired_if` false → returns immediately, no fallback invoked
- [x] `expired_if` true → fallback invoked, session reloaded, returns recovered result
- [x] `expired_if` true, no fallback → raises with actionable message
- [x] `expired_if` true, fallback runs but still expired → raises with clear message