### PR TITLE
fix: UX/DX and docs improvements (M1–M4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">browserctl</h1>
 
 <p align="center">
-  A browser daemon that keeps sessions alive between commands — for AI agents and iterative dev workflows.
+  The browser you delegate to your agents — with a pause button for the parts that still need you.
 </p>
 
 <p align="center">
@@ -26,29 +26,6 @@ browserctl fill main --ref e1 --value me@example.com    # interact by ref, no se
 browserctl click main --ref e2
 browserctl daemon stop
 ```
-
----
-
-## See it in action
-
-<table align="center"><tr>
-<td align="center" width="50%">
-
-**Terminal**<br/>
-<sub>CLI commands, live output, session persistence proof</sub>
-
-<img src="docs/assets/terminal.gif" alt="browserctl terminal demo"/>
-
-</td>
-<td align="center" width="50%">
-
-**Browser**<br/>
-<sub>What the browser sees as those commands run</sub>
-
-<img src="docs/assets/browser_demo.gif" alt="browserctl browser demo"/>
-
-</td>
-</tr></table>
 
 ---
 
@@ -82,6 +59,29 @@ browserctl daemon stop
 ```
 
 → [Full Getting Started guide](docs/getting-started.md)
+
+---
+
+## See it in action
+
+<table align="center"><tr>
+<td align="center" width="50%">
+
+**Terminal**<br/>
+<sub>CLI commands, live output, session persistence proof</sub>
+
+<img src="docs/assets/terminal.gif" alt="browserctl terminal demo"/>
+
+</td>
+<td align="center" width="50%">
+
+**Browser**<br/>
+<sub>What the browser sees as those commands run</sub>
+
+<img src="docs/assets/browser_demo.gif" alt="browserctl browser demo"/>
+
+</td>
+</tr></table>
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,6 @@ Mental models before mechanics.
 | [Sessions and Pages](concepts/sessions-and-pages.md) | Why a daemon beats a script, and what named pages give you |
 | [Snapshots and Refs](concepts/snapshots-and-refs.md) | The compact JSON snapshot format and ref-based interaction |
 | [Human-in-the-Loop](concepts/hitl.md) | Pause/resume, challenge detection, the extensible blocker model |
-| [Secrets and Credentials](guides/writing-workflows.md#sourcing-secrets-with-secret_ref) | Secret resolver system — env://, keychain://, op://, and custom resolvers |
 
 ---
 
@@ -35,6 +34,7 @@ Narrative how-tos for real tasks.
 | | |
 |---|---|
 | [Writing Workflows](guides/writing-workflows.md) | Automate multi-step flows with the Ruby DSL |
+| [Secrets and Credentials](guides/writing-workflows.md#sourcing-secrets-with-secret_ref) | Secret resolver system — env://, keychain://, op://, and custom resolvers |
 | [Handling Challenges](guides/handling-challenges.md) | Cloudflare, 2FA, and the pause/resume pattern in practice |
 | [Smoke Testing](guides/smoke-testing.md) | Ready-to-run examples against the-internet.herokuapp.com |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,6 +7,8 @@ This guide gets you from zero to a working browser session in about five minutes
 - Ruby >= 3.3
 - Chrome or Chromium on your `PATH`
 
+> On macOS, Chrome installed as a `.app` bundle (the standard installer) is not on your PATH — `browserd` locates it automatically via its default install path, so no PATH configuration is needed.
+
 Check:
 
 ```bash
@@ -38,7 +40,7 @@ gem "browserctl"
 browserd &
 ```
 
-For a visible browser window (useful when debugging, or when you need to interact manually):
+For a visible browser window — required if you need to solve Cloudflare challenges or 2FA prompts manually, or if you want to watch interactions in real time:
 
 ```bash
 browserd --headed &
@@ -58,7 +60,7 @@ browserctl daemon ping
 Open a browser tab and give it a name:
 
 ```bash
-browserctl page open main --url https://example.com
+browserctl page open main --url https://the-internet.herokuapp.com/login
 ```
 
 The name (`main`) is what you'll use to address this tab in every subsequent command. Call it anything — `login`, `dashboard`, `session-1`.
@@ -79,31 +81,35 @@ You'll get a compact JSON array of every interactable element on the page, each 
 [
   {
     "ref": "e1",
-    "tag": "a",
-    "text": "More information...",
-    "selector": "body > div > p > a",
-    "attrs": { "href": "https://www.iana.org/domains/reserved" }
+    "tag": "input",
+    "placeholder": "Username",
+    "selector": "input[name='username']",
+    "attrs": { "type": "text", "name": "username" }
+  },
+  {
+    "ref": "e2",
+    "tag": "input",
+    "placeholder": "Password",
+    "selector": "input[name='password']",
+    "attrs": { "type": "password", "name": "password" }
+  },
+  {
+    "ref": "e3",
+    "tag": "button",
+    "text": "Login",
+    "selector": "button[type='submit']",
+    "attrs": { "type": "submit" }
   }
 ]
 ```
 
 These ref IDs are how you interact with elements without writing CSS selectors.
 
+> **Note:** Ref IDs are valid for the current page state only. Always take a fresh snapshot before interacting — refs change when the page updates.
+
 ---
 
-## 4. Navigate and interact
-
-Navigate to a different URL on the same named page:
-
-```bash
-browserctl navigate main https://the-internet.herokuapp.com/login
-```
-
-Snapshot again to discover the form fields:
-
-```bash
-browserctl snapshot main
-```
+## 4. Fill and submit
 
 Fill and submit using refs:
 
@@ -121,7 +127,7 @@ browserctl url main
 
 ---
 
-## 5. Observe results
+## 5. Check the result
 
 Take a screenshot:
 
@@ -145,6 +151,8 @@ browserctl daemon stop
 
 The daemon stops and the browser closes. Your session state is gone — next time you'll start fresh.
 
+> To preserve state across restarts, save and restore it: see [Session save/load](reference/commands.md#session).
+
 > The daemon also shuts itself down automatically after 30 minutes of inactivity.
 
 ---
@@ -165,3 +173,28 @@ You just drove a live browser from the command line with no scripts and no selec
 
 **Look things up**
 - [Command Reference](reference/commands.md) — every command and flag
+
+---
+
+## Troubleshooting
+
+### `browserd` is not running
+
+If any command returns an error like `browserd is not running`, or:
+
+```json
+{ "ok": false, "daemon": "offline", "error": "browserd is not running — start it with: browserd" }
+```
+
+Start the daemon:
+
+```bash
+browserd &
+```
+
+Confirm it's running:
+
+```bash
+browserctl daemon ping
+# → {"ok":true,"pid":12345,"protocol_version":"2"}
+```

--- a/docs/guides/handling-challenges.md
+++ b/docs/guides/handling-challenges.md
@@ -54,22 +54,7 @@ The workflow unblocks and continues:
 
 ## The HITL pattern in code
 
-```ruby
-step "navigate to target URL" do
-  res = client.navigate("main", url)
-
-  if res[:challenge]
-    client.pause("main")
-
-    # poll until the human solves the challenge
-    loop do
-      snap = client.snapshot("main", format: "html")
-      break unless snap[:challenge]
-      sleep 3
-    end
-  end
-end
-```
+See the full runnable example in [Human-in-the-Loop — The polling loop](../concepts/hitl.md#the-polling-loop).
 
 `pause` blocks all further commands on the named page via a `ConditionVariable`. When `browserctl resume main` is called from any terminal, the CV is signalled and the polling loop proceeds to the `break` check.
 

--- a/docs/guides/writing-workflows.md
+++ b/docs/guides/writing-workflows.md
@@ -370,26 +370,7 @@ Circular invocation (`a → b → a`) raises immediately.
 
 ## PageProxy methods
 
-| Method | Description |
-|---|---|
-| `navigate(url)` | Navigate the page to a URL |
-| `fill(selector, value)` | Fill an input field |
-| `click(selector)` | Click an element |
-| `wait(selector, timeout: 30)` | Wait until selector appears (default 30s) |
-| `url` | Return the current page URL as a string |
-| `evaluate(expression)` | Evaluate a JS expression and return the result |
-| `snapshot(**opts)` | Return a DOM snapshot |
-| `screenshot(**opts)` | Take a screenshot |
-| `storage_get(key, store: "local")` | Read a localStorage or sessionStorage key |
-| `storage_set(key, value, store: "local")` | Write a localStorage or sessionStorage key |
-| `delete_cookies` | Delete all cookies for this page |
-| `devtools` | Return the Chrome DevTools URL for this page |
-| `press(key)` | Fire a `keydown` + `keyup` event for the given key |
-| `hover(selector)` | Move the mouse to the centre of the matched element |
-| `upload(selector, path)` | Set a file input's value to a file path |
-| `select(selector, value)` | Set a `<select>` element's value and fire a `change` event |
-| `dialog_accept(text: nil)` | Pre-register a one-shot handler to accept the next JS dialog; `text` is used for `prompt` dialogs |
-| `dialog_dismiss` | Pre-register a one-shot handler to dismiss the next JS dialog |
+For the full list of `PageProxy` methods (including `ref:` keyword support on `fill`, `click`, `hover`, `upload`, and `select`), see [Command Reference → PageProxy methods](../reference/commands.md#pageproxy-methods).
 
 All methods raise `WorkflowError` on a daemon error, which fails the current step.
 
@@ -612,21 +593,6 @@ end
 
 ### Human-in-the-loop inside a workflow
 
-When a step hits a wall that needs human action, pause the session and resume when the human is done:
-
-```ruby
-step "navigate to protected page" do
-  res = client.navigate("main", target_url)
-  if res[:challenge]
-    puts "→ Challenge detected. Solve it in the browser, then: browserctl resume main"
-    client.pause("main")
-    loop do
-      snap = client.snapshot("main", format: "html")
-      break unless snap[:challenge]
-      sleep 3
-    end
-  end
-end
-```
+When a step hits a wall that needs human action, pause the session and resume when the human is done. See the full runnable example in [Human-in-the-Loop — The polling loop](../concepts/hitl.md#the-polling-loop).
 
 See [Handling Challenges](handling-challenges.md) for a full runnable example.

--- a/docs/guides/writing-workflows.md
+++ b/docs/guides/writing-workflows.md
@@ -133,6 +133,22 @@ end
 
 `fetch` raises `WorkflowError` with a descriptive message if the key was never stored. Values are stored in the daemon's KV store and persist for as long as the daemon is running — a later `workflow run` that connects to the same daemon can read a value stored by an earlier run. Values are lost when the daemon stops.
 
+> **Use plain Ruby for step-to-step data; use `store`/`fetch` for cross-run data.**
+>
+> Inside a workflow, `@variable = value` works in every step block and is local to this run:
+>
+> ```ruby
+> step "capture OTP" do
+>   @otp = page(:inbox).evaluate("document.querySelector('.otp').textContent")
+> end
+>
+> step "submit OTP" do
+>   page(:app).fill("input#otp", @otp)
+> end
+> ```
+>
+> `store`/`fetch` call the daemon's KV store — values **persist after the workflow finishes** and are readable by any later workflow run against the same daemon. Use them for cross-run sharing, not within a single run.
+
 ---
 
 ### `assert`
@@ -212,17 +228,21 @@ The `fallback:` path above only fires when the **session file is missing**. If t
 
 Pass `expired_if:` with a lambda that returns `true` when the session is stale. The lambda runs after the session is restored and has access to all DSL methods (`page`, `assert`, etc.).
 
-**Important:** `load_session` restores pages to their saved URLs, not to a specific URL you choose at load time. If your expiry check is URL-based, navigate first, then call `load_session`:
+**Important:** `load_session` restores pages to their saved URLs, not to a specific URL you choose at load time. If your expiry check is URL-based, navigate *inside* the lambda:
 
 ```ruby
 step "restore or re-login" do
-  # navigate first so the URL check is meaningful
-  page(:main).navigate("https://app.example.com/dashboard")
   load_session("myapp",
     fallback: "login_myapp",
-    expired_if: -> { !page(:main).url.include?("/dashboard") })
+    expired_if: -> {
+      page(:main).navigate("https://app.example.com/dashboard")
+      !page(:main).url.include?("/dashboard")
+    }
+  )
 end
 ```
+
+The navigation must happen inside the lambda — it runs after `load_session` restores saved URLs.
 
 For a check that does not require navigation, use cookie or storage state:
 
@@ -355,6 +375,47 @@ Returns a `PageProxy` for a named browser page. The page must already be open (v
 page(:login).fill("input[name=email]", email)
 page(:login).click("button[type=submit]")
 ```
+
+## Composing workflows (`compose`)
+
+`compose` splices another workflow's steps into the current workflow **at definition time**. The inlined steps run in the calling workflow's param scope.
+
+```ruby
+Browserctl.workflow "login" do
+  param :email, required: true
+  param :password, required: true, secret: true
+
+  step "open login page" do
+    open_page(:main, url: "https://app.example.com/login")
+  end
+
+  step "submit credentials" do
+    page(:main).fill("input[name=email]", email)
+    page(:main).fill("input[name=password]", password)
+    page(:main).click("button[type=submit]")
+  end
+end
+
+Browserctl.workflow "checkout_with_login" do
+  param :email, required: true
+  param :password, required: true, secret: true
+
+  compose "login"   # inlines login's two steps here
+
+  step "navigate to checkout" do
+    page(:main).navigate("https://app.example.com/checkout")
+  end
+end
+```
+
+| | `compose` | `invoke` |
+|---|---|---|
+| When it runs | At workflow definition time | At runtime, inside a step block |
+| Where to call it | Top level of the `workflow` block | Inside a `step` block |
+| Param scope | Shares calling workflow's params | Can pass/override params |
+| Use for | Structural reuse (bake steps in) | Parameterised delegation |
+
+> `compose` must be called at the workflow definition level — not inside a `step` block. Use `invoke` for runtime delegation.
 
 ### `invoke`
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -84,7 +84,7 @@ Browserctl.workflow :verify_checkout do
 
   step "confirm checkout reached" do
     page(:main).wait("[data-test=checkout-header]", timeout: 15)
-    page(:main).screenshot(out: "evidence/checkout.png")
+    page(:main).screenshot(path: "evidence/checkout.png")
   end
 end
 ```

--- a/docs/product.md
+++ b/docs/product.md
@@ -89,6 +89,8 @@ Browserctl.workflow :verify_checkout do
 end
 ```
 
+> The DSL supports both CSS selectors (as above) and snapshot refs — use `page(:main).fill(nil, email, ref: "e1")` after snapshotting to interact without knowing the page structure in advance. Refs are preferred in AI-agent workflows.
+
 Workflows are plain Ruby. They compose, retry, timeout, and share steps. Params are typed. Secrets are never written to recordings.
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -43,14 +43,16 @@ Page is always the first argument after the verb.
 | `resume <page>` | Resume automation after manual action |
 | `devtools <page>` | Open Chrome DevTools for a named page |
 | `press <page> <key>` | Fire a `keydown` + `keyup` event for the given key |
-| `hover <page> <selector>` | Move the mouse cursor to the centre of the matched element |
-| `upload <page> <selector> <file>` | Set a `<input type="file">` element's value to a file path |
-| `select <page> <selector> <value>` | Set a `<select>` element's value and fire a `change` event |
+| `hover <page> <selector>` or `hover <page> --ref <id>` | Move the mouse cursor to the centre of the matched element |
+| `upload <page> <selector> <file>` or `upload <page> --ref <id> <file>` | Set a `<input type="file">` element's value to a file path |
+| `select <page> <selector> <value>` or `select <page> --ref <id> <value>` | Set a `<select>` element's value and fire a `change` event |
 | `dialog accept <page> [text]` | Pre-register a one-shot handler to accept the next JS dialog |
 | `dialog dismiss <page>` | Pre-register a one-shot handler to dismiss the next JS dialog |
-| `ask <prompt>` | Pause and prompt the human for a value via stdin |
+| `ask <prompt>` | Pause and prompt the human for a value via stdin (orchestration-level — takes no `<page>` argument; reads from operator stdin) |
 
 `navigate` and `snapshot` responses include `"challenge": true` when a Cloudflare interstitial is detected. See [Handling Challenges](../guides/handling-challenges.md).
+
+> `navigate` steers an already-open page. Use `page open --url` to create a new tab and navigate in one step.
 
 ### `press <page> <key>`
 
@@ -300,8 +302,8 @@ Methods available on `page(:name)` inside a workflow:
 | Method | Description |
 |---|---|
 | `navigate(url)` | Navigate to a URL |
-| `fill(selector, value)` | Fill an input by CSS selector |
-| `click(selector)` | Click an element by CSS selector |
+| `fill(selector = nil, value = nil, ref: nil)` | Fill an input by selector or ref |
+| `click(selector = nil, ref: nil)` | Click an element by selector or ref |
 | `wait(selector, timeout: 30)` | Wait until selector appears (default 30s) |
 | `url` | Return the current page URL |
 | `evaluate(expression)` | Evaluate a JS expression and return the result |
@@ -312,9 +314,9 @@ Methods available on `page(:name)` inside a workflow:
 | `delete_cookies` | Delete all cookies for the page |
 | `devtools` | Return the Chrome DevTools URL for this page |
 | `press(key)` | Fire a `keydown` + `keyup` event for the given key |
-| `hover(selector)` | Move the mouse to the centre of the matched element |
-| `upload(selector, path)` | Set a file input's value to a file path |
-| `select(selector, value)` | Set a `<select>` element's value and fire a `change` event |
+| `hover(selector = nil, ref: nil)` | Move mouse to element by selector or ref |
+| `upload(selector = nil, path = nil, ref: nil)` | Set file input by selector or ref |
+| `select(selector = nil, value = nil, ref: nil)` | Set select element by selector or ref |
 | `dialog_accept(text: nil)` | Pre-register a one-shot handler to accept the next JS dialog; `text` is used for `prompt` dialogs |
 | `dialog_dismiss` | Pre-register a one-shot handler to dismiss the next JS dialog |
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -78,6 +78,8 @@ It is the difference between a browser **you restart** and a browser **you steer
 - [x] `browserctl inspect` — open DevTools UI for a named page
 - [x] `browserctl cookies` / `set_cookie` / `clear_cookies` / `export-cookies` / `import-cookies` — full cookie management including CF clearance replay
 
+> _(All commands in this section were renamed in v0.6: `inspect` → `devtools`; `cookies`/`set_cookie`/`clear_cookies`/`export-cookies`/`import-cookies` → `cookie list`/`cookie set`/`cookie delete`/`cookie export`/`cookie import`.)_
+
 ### v0.4 — Distribution & Installability ✓ _(shipped)_
 **Goal:** Install with one command, anywhere.
 

--- a/docs/vs-agent-browser.md
+++ b/docs/vs-agent-browser.md
@@ -114,6 +114,6 @@ agent-browser provides a WebSocket-based dashboard with a live browser viewport,
 | **Workflow layer** | Ruby DSL, compose, record, replay | None |
 | **Prompt injection safety** | Not yet | Content boundaries (nonce-wrapped output) |
 | **Command surface** | ~20 commands | 100+ commands |
-| **Live preview** | DevTools via `inspect` | WebSocket viewport streaming |
+| **Live preview** | DevTools via `devtools` | WebSocket viewport streaming |
 
 browserctl is not trying to be the browser-for-every-framework. It is the browser for agents that work alongside humans, run on your machine, and need to handle the web as it actually is — not as a clean, bot-friendly surface.

--- a/docs/vs-agent-browser.md
+++ b/docs/vs-agent-browser.md
@@ -112,7 +112,7 @@ agent-browser provides a WebSocket-based dashboard with a live browser viewport,
 | **HITL** | First-class — `pause`/`resume` primitive | Not implemented |
 | **Blocker detection** | Built-in (Cloudflare), extensible | Not surfaced |
 | **Workflow layer** | Ruby DSL, compose, record, replay | None |
-| **Prompt injection safety** | Not yet | Content boundaries (nonce-wrapped output) |
+| **Prompt injection safety** | `nonce` field on every snapshot response (Fixed zone) | Content boundaries (nonce-wrapped output) |
 | **Command surface** | ~20 commands | 100+ commands |
 | **Live preview** | DevTools via `devtools` | WebSocket viewport streaming |
 

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -234,7 +234,7 @@ module Browserctl
     # @param name [String] logical page name
     # @param key [String] key name e.g. "Enter", "Tab", "Escape", "ArrowDown"
     # @return [Hash] `{ ok: true }` or `{ error: }`
-    def press(name, key)          = call("press",  name: name, key: key)
+    def press(name, key) = call("press", name: name, key: key)
 
     # Moves the mouse to the centre of the element matched by selector.
     # @param name [String] logical page name

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -18,7 +18,7 @@ module Browserctl
       Recording.append(cmd, **params) if result[:ok]
       result
     rescue Errno::ENOENT, Errno::ECONNREFUSED
-      raise "browserd is not running — start it with: browserd"
+      raise DaemonUnavailableError, "browserd is not running — start it with: browserd"
     end
 
     # Opens or focuses a named browser page.

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -240,21 +240,35 @@ module Browserctl
     # @param name [String] logical page name
     # @param selector [String] CSS selector
     # @return [Hash] `{ ok: true }` or `{ error: }`
-    def hover(name, selector)     = call("hover",  name: name, selector: selector)
+    def hover(name, selector = nil, ref: nil)
+      raise ArgumentError, "hover: provide selector or ref:" unless selector || ref
+
+      call("hover", name: name, selector: selector, ref: ref)
+    end
 
     # Sets a file-input element to the given file path.
     # @param name [String] logical page name
-    # @param selector [String] CSS selector for the file input
-    # @param path [String] absolute or relative file path
+    # @param selector [String, nil] CSS selector for the file input
+    # @param path [String, nil] absolute or relative file path
+    # @param ref [String, nil] element ref from a prior snapshot
     # @return [Hash] `{ ok: true }` or `{ error: }`
-    def upload(name, selector, path) = call("upload", name: name, selector: selector, path: path)
+    def upload(name, selector = nil, path = nil, ref: nil)
+      raise ArgumentError, "upload: provide selector or ref:" unless selector || ref
+
+      call("upload", name: name, selector: selector, ref: ref, path: path)
+    end
 
     # Sets a <select> element's value and fires a change event.
     # @param name [String] logical page name
-    # @param selector [String] CSS selector for the select element
-    # @param value [String] option value to select
+    # @param selector [String, nil] CSS selector for the select element
+    # @param value [String, nil] option value to select
+    # @param ref [String, nil] element ref from a prior snapshot
     # @return [Hash] `{ ok: true }` or `{ error: }`
-    def select(name, selector, value) = call("select", name: name, selector: selector, value: value)
+    def select(name, selector = nil, value = nil, ref: nil)
+      raise ArgumentError, "select: provide selector or ref:" unless selector || ref
+
+      call("select", name: name, selector: selector, ref: ref, value: value)
+    end
 
     # Pre-registers a one-shot handler to accept the next JS dialog on a page.
     # @param name [String] logical page name

--- a/lib/browserctl/commands/daemon.rb
+++ b/lib/browserctl/commands/daemon.rb
@@ -71,7 +71,7 @@ module Browserctl
           next unless status&.dig(:ok)
 
           { name: display_name, pid: status[:pid], pages: (client.page_list[:pages] || []).length }
-        rescue RuntimeError
+        rescue Browserctl::DaemonUnavailableError, RuntimeError
           nil
         end.compact
         puts({ daemons: rows }.to_json)

--- a/lib/browserctl/commands/daemon.rb
+++ b/lib/browserctl/commands/daemon.rb
@@ -14,7 +14,13 @@ module Browserctl
       def self.run(client, args)
         sub = args.shift or abort USAGE
         case sub
-        when "ping"   then print_result(client.ping)
+        when "ping"
+          begin
+            print_result(client.ping)
+          rescue Browserctl::DaemonUnavailableError => e
+            puts JSON.generate({ ok: false, daemon: "offline", error: e.message })
+            exit 1
+          end
         when "status" then run_status(client)
         when "start"  then run_start(args)
         when "stop"   then print_result(client.shutdown)
@@ -36,9 +42,7 @@ module Browserctl
           protocol_version: ping[:protocol_version],
           pages: page_info
         )
-      rescue RuntimeError => e
-        raise unless e.message.include?("browserd is not running")
-
+      rescue Browserctl::DaemonUnavailableError => e
         puts JSON.pretty_generate(daemon: "offline", error: e.message)
         exit 1
       end

--- a/lib/browserctl/commands/record.rb
+++ b/lib/browserctl/commands/record.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "json"
 require "optimist"
 require "browserctl/recording"
 
@@ -29,8 +30,7 @@ module Browserctl
           abort "Invalid recording name #{name.inspect} — use only letters, digits, _ or -" \
             unless name =~ /\A[a-zA-Z0-9_-]{1,64}\z/
           Recording.start(name)
-          puts "Recording started: #{name}"
-          puts "Run browser commands, then: browserctl record stop"
+          puts JSON.generate({ ok: true, name: name })
         end
 
         def run_stop(args)
@@ -42,13 +42,12 @@ module Browserctl
           out  = opts[:out] || File.join(".browserctl/workflows", "#{name}.rb")
           FileUtils.mkdir_p(File.dirname(out))
           Recording.generate_workflow(name, output_path: out)
-          puts "Workflow saved: #{out}"
-          puts "Run with: browserctl workflow run #{name}"
+          puts JSON.generate({ ok: true, name: name, path: out })
         end
 
         def run_status
           active = Recording.active
-          puts active ? "Active recording: #{active}" : "No active recording."
+          puts JSON.generate({ active: active })
         end
       end
     end

--- a/lib/browserctl/commands/session.rb
+++ b/lib/browserctl/commands/session.rb
@@ -85,6 +85,8 @@ module Browserctl
         sessions_dir = File.join(Browserctl::BROWSERCTL_DIR, "sessions")
         FileUtils.mkdir_p(sessions_dir)
 
+        before = Dir[File.join(sessions_dir, "*/")].map { |p| File.basename(p) }
+
         if encrypted_zip?(zip_path)
           passphrase = prompt_passphrase
           decrypt_import(zip_path, sessions_dir, passphrase)
@@ -93,7 +95,10 @@ module Browserctl
           Process.wait(pid)
         end
 
-        puts({ ok: true }.to_json)
+        after = Dir[File.join(sessions_dir, "*/")].map { |p| File.basename(p) }
+        name = (after - before).first
+
+        puts({ ok: true, name: name }.to_json)
       end
 
       # --- private helpers ---

--- a/lib/browserctl/commands/workflow.rb
+++ b/lib/browserctl/commands/workflow.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require_relative "cli_output"
 
 module Browserctl
@@ -52,7 +53,7 @@ module Browserctl
 
       def self.run_list(runner)
         list = runner.list_workflows
-        list.each { |w| puts "#{w[:name].ljust(24)} #{w[:desc]}" }
+        puts JSON.generate({ workflows: list.map { |w| { name: w[:name], desc: w[:desc] } } })
       end
 
       def self.run_describe(runner, args)

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -21,8 +21,8 @@ module Browserctl
   class PathNotAllowed   < Error; def self.default_code = "path_not_allowed"   end
   class DomainNotAllowed < Error; def self.default_code = "domain_not_allowed" end
   class TimeoutError     < Error; def self.default_code = "timeout"            end
-  class KeyNotFound           < Error; def self.default_code = "key_not_found"           end
-  class DaemonUnavailableError < Error; def self.default_code = "daemon_unavailable"    end
+  class KeyNotFound < Error; def self.default_code = "key_not_found" end
+  class DaemonUnavailableError < Error; def self.default_code = "daemon_unavailable" end
 
   class WorkflowError < StandardError; end
   class SecretResolverError < WorkflowError; end

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -21,7 +21,8 @@ module Browserctl
   class PathNotAllowed   < Error; def self.default_code = "path_not_allowed"   end
   class DomainNotAllowed < Error; def self.default_code = "domain_not_allowed" end
   class TimeoutError     < Error; def self.default_code = "timeout"            end
-  class KeyNotFound      < Error; def self.default_code = "key_not_found"      end
+  class KeyNotFound           < Error; def self.default_code = "key_not_found"           end
+  class DaemonUnavailableError < Error; def self.default_code = "daemon_unavailable"    end
 
   class WorkflowError < StandardError; end
   class SecretResolverError < WorkflowError; end

--- a/lib/browserctl/server/handlers/interaction.rb
+++ b/lib/browserctl/server/handlers/interaction.rb
@@ -16,15 +16,18 @@ module Browserctl
 
         def cmd_hover(req)
           with_page(req[:name]) do |session|
+            sel = resolve_selector_from(session, req)
+            return sel if sel.is_a?(Hash)
+
             coords = session.page.evaluate(
               "(function(sel) {   " \
               "var el = document.querySelector(sel);   " \
               "if (!el) return null;   " \
               "var r = el.getBoundingClientRect();   " \
               "return { x: r.left + r.width / 2, y: r.top + r.height / 2 }; " \
-              "})(#{req[:selector].to_json})"
+              "})(#{sel.to_json})"
             )
-            return { error: "selector not found: #{req[:selector]}" } unless coords
+            return { error: "selector not found: #{sel}" } unless coords
 
             session.page.mouse.move(x: coords["x"], y: coords["y"])
             { ok: true }
@@ -36,8 +39,11 @@ module Browserctl
           return { error: "file not found: #{path}" } unless File.exist?(path)
 
           with_page(req[:name]) do |session|
-            el = session.page.at_css(req[:selector])
-            return { error: "selector not found: #{req[:selector]}" } unless el
+            sel = resolve_selector_from(session, req)
+            return sel if sel.is_a?(Hash)
+
+            el = session.page.at_css(sel)
+            return { error: "selector not found: #{sel}" } unless el
 
             el.select_file(path)
             { ok: true }
@@ -46,8 +52,11 @@ module Browserctl
 
         def cmd_select(req)
           with_page(req[:name]) do |session|
-            el = session.page.at_css(req[:selector])
-            return { error: "selector not found: #{req[:selector]}" } unless el
+            sel = resolve_selector_from(session, req)
+            return sel if sel.is_a?(Hash)
+
+            el = session.page.at_css(sel)
+            return { error: "selector not found: #{sel}" } unless el
 
             el.evaluate(
               "this.value = #{req[:value].to_json}; " \

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -191,8 +191,13 @@ module Browserctl
     end
 
     def navigate(url)             = unwrap @client.navigate(@name, url)
-    def fill(sel, val)            = unwrap @client.fill(@name, sel, val)
-    def click(sel)                = unwrap @client.click(@name, sel)
+    def fill(selector = nil, value = nil, ref: nil)
+      unwrap @client.fill(@name, selector, value, ref: ref)
+    end
+
+    def click(selector = nil, ref: nil)
+      unwrap @client.click(@name, selector, ref: ref)
+    end
     def snapshot(**)              = unwrap @client.snapshot(@name, **)
     def screenshot(**)            = unwrap @client.screenshot(@name, **)
     def wait(sel, timeout: 30)    = unwrap @client.wait(@name, sel, timeout: timeout)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -190,7 +190,8 @@ module Browserctl
       @client = client
     end
 
-    def navigate(url)             = unwrap @client.navigate(@name, url)
+    def navigate(url) = unwrap @client.navigate(@name, url)
+
     def fill(selector = nil, value = nil, ref: nil)
       unwrap @client.fill(@name, selector, value, ref: ref)
     end
@@ -198,6 +199,7 @@ module Browserctl
     def click(selector = nil, ref: nil)
       unwrap @client.click(@name, selector, ref: ref)
     end
+
     def snapshot(**)              = unwrap @client.snapshot(@name, **)
     def screenshot(**)            = unwrap @client.screenshot(@name, **)
     def wait(sel, timeout: 30)    = unwrap @client.wait(@name, sel, timeout: timeout)
@@ -215,9 +217,17 @@ module Browserctl
     end
 
     def press(key)               = unwrap @client.press(@name, key)
-    def hover(selector)          = unwrap @client.hover(@name, selector)
-    def upload(selector, path)   = unwrap @client.upload(@name, selector, path)
-    def select(selector, value)  = unwrap @client.select(@name, selector, value)
+    def hover(selector = nil, ref: nil)
+      unwrap @client.hover(@name, selector, ref: ref)
+    end
+
+    def upload(selector = nil, path = nil, ref: nil)
+      unwrap @client.upload(@name, selector, path, ref: ref)
+    end
+
+    def select(selector = nil, value = nil, ref: nil)
+      unwrap @client.select(@name, selector, value, ref: ref)
+    end
     def dialog_accept(text: nil) = unwrap @client.dialog_accept(@name, text: text)
     def dialog_dismiss           = unwrap @client.dialog_dismiss(@name)
 

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -104,14 +104,28 @@ module Browserctl
       raise WorkflowError, msg unless condition
     end
 
+    def compose(*)
+      raise WorkflowError,
+            "`compose` must be called at the workflow definition level, not inside a step block. " \
+            "Did you mean `invoke`?"
+    end
+
     private
 
     def validate_expired_if!(expired_if)
-      return unless expired_if && !expired_if.lambda?
+      return unless expired_if
 
-      raise ArgumentError,
-            "expired_if: must be a lambda (-> { }), not a Proc — " \
-            "bare return inside a Proc unwinds the caller"
+      unless expired_if.lambda?
+        raise ArgumentError,
+              "expired_if: must be a lambda (-> { }), not a Proc — " \
+              "bare return inside a Proc unwinds the caller"
+      end
+
+      unless expired_if.arity == 0
+        raise ArgumentError,
+              "expired_if: lambda must take zero arguments (got #{expired_if.arity}) — " \
+              "use -> { page(:name).url... } to access pages via the workflow context"
+      end
     end
 
     def call_expired_if(expired_if, session_name)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -121,11 +121,11 @@ module Browserctl
               "bare return inside a Proc unwinds the caller"
       end
 
-      unless expired_if.arity == 0
-        raise ArgumentError,
-              "expired_if: lambda must take zero arguments (got #{expired_if.arity}) — " \
-              "use -> { page(:name).url... } to access pages via the workflow context"
-      end
+      return if expired_if.arity.zero?
+
+      raise ArgumentError,
+            "expired_if: lambda must take zero arguments (got #{expired_if.arity}) — " \
+            "use -> { page(:name).url... } to access pages via the workflow context"
     end
 
     def call_expired_if(expired_if, session_name)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -216,7 +216,8 @@ module Browserctl
       unwrap @client.storage_set(@name, key, value, store: store)
     end
 
-    def press(key)               = unwrap @client.press(@name, key)
+    def press(key) = unwrap @client.press(@name, key)
+
     def hover(selector = nil, ref: nil)
       unwrap @client.hover(@name, selector, ref: ref)
     end
@@ -228,6 +229,7 @@ module Browserctl
     def select(selector = nil, value = nil, ref: nil)
       unwrap @client.select(@name, selector, value, ref: ref)
     end
+
     def dialog_accept(text: nil) = unwrap @client.dialog_accept(@name, text: text)
     def dialog_dismiss           = unwrap @client.dialog_dismiss(@name)
 

--- a/skills/browserctl/SKILL.md
+++ b/skills/browserctl/SKILL.md
@@ -85,8 +85,11 @@ browserctl record status                     # check if a recording is active
 # Keyboard and mouse
 browserctl press  main Enter                             # fire keydown+keyup (Enter, Tab, Escape, ArrowDown, ...)
 browserctl hover  main "#menu-trigger"                  # move mouse to element centre
+browserctl hover  main --ref e3                          # move mouse to ref element
 browserctl select main "select#country" "AU"            # set <select> value + fire change event
+browserctl select main --ref e4 "AU"                    # set <select> by ref
 browserctl upload main "#resume-input" /path/file.pdf   # set file input to a local file
+browserctl upload main --ref e5 /path/file.pdf          # set file input by ref
 
 # Dialogs — register handler BEFORE the action that triggers the dialog
 browserctl dialog accept  main                          # accept the next alert/confirm/prompt
@@ -138,6 +141,7 @@ browserctl page focus login    # bring tab to front (headed mode only)
 
 # Daemon
 browserctl daemon ping    # → { ok: true, pid: N, protocol_version: "2" }
+                          #   or { ok: false, daemon: "offline", error: "..." } if not running
 browserctl daemon status  # → { daemon: "online", pid: N, pages: [{name:, url:}] }
 browserctl daemon start [--headed] [--name NAME]
 browserctl daemon stop
@@ -305,7 +309,7 @@ browserctl navigate main https://protected.example.com
 - **Probe before you harden** — explore with discrete commands or a throwaway file, then write the named workflow.
 - **Prefer discrete commands** (`fill`, `click`, `press`, `select`, `hover`, `upload`) over `eval` for actions. Use `eval` only when no discrete command fits (e.g. reading computed DOM state, complex JS assertions).
 - **Use `snapshot`** for any page you haven't seen before — the default `elements` format gives valid selectors and ref IDs without reading raw HTML.
-- **Use `--ref` for interactions** — after a `snapshot`, prefer `--ref eN` over CSS selectors. Refs are valid until the next `snapshot` call — re-snapshot if you need fresh refs after page changes.
+- **Use `--ref` for interactions** — after a `snapshot`, prefer `--ref eN` over CSS selectors for `fill`, `click`, `hover`, `select`, and `upload`. Refs are valid until the next `snapshot` call — re-snapshot if you need fresh refs after page changes.
 - **Use `snapshot --diff`** to detect DOM changes efficiently — avoids re-processing the full DOM after each action.
 - **Use `wait`** when you need to wait for an element that appears asynchronously — more efficient than polling `snapshot`.
 - **Use named daemons** (`browserd --name X`) when running multiple parallel sessions — each gets an isolated socket and browser.
@@ -363,7 +367,7 @@ end
 | `step "label", retry_count: N { }` | Retry the step up to N additional times on any error |
 | `step "label", timeout: S { }` | Fail the step if it exceeds S seconds |
 | `step "label", retry_count: N, timeout: S { }` | Both retry and timeout |
-| `compose "workflow"` | Inline all steps from another workflow at this point |
+| `compose "workflow"` | Inline all steps from another workflow at this point. Must be called at the workflow definition level — calling it inside a `step` block raises `WorkflowError`. Use `invoke` inside steps instead. |
 | `invoke "workflow", **overrides` | Call another workflow by name, optionally overriding params |
 | `open_page(name, url: nil)` | Open a named page, optionally navigating to a URL |
 | `close_page(name)` | Close a named page |
@@ -371,6 +375,7 @@ end
 | `save_session(name, encrypt: false)` | Snapshot current browser state to a named session; `encrypt: true` stores sensitive files as AES-256-GCM blobs with the key in macOS Keychain (darwin only) |
 | `load_session(name)` | Restore a saved session into the running daemon |
 | `load_session(name, fallback: "workflow_name")` | Restore session; if load fails, invoke the named fallback workflow then retry once. Use this instead of hand-rolling detect-expiry logic. |
+| `load_session(name, fallback: "workflow_name", expired_if: -> { ... })` | Same as above, but also calls the lambda after restore; if it returns `true`, the fallback workflow is invoked and the session is re-established. Use when the server can invalidate sessions without changing cookies (e.g. server-side logout, expired JWT in localStorage). |
 | `list_sessions` | Return all saved session metadata |
 | `store :key, value` | Store a value for use in later steps (persists in daemon until it stops) |
 | `fetch :key` | Retrieve a value stored by an earlier step |
@@ -448,12 +453,12 @@ Methods available on `page(:name)` inside a workflow (all raise `WorkflowError` 
 
 ```ruby
 page(:main).navigate(url)
-page(:main).fill(selector, value)
-page(:main).click(selector)
-page(:main).press(key)                   # "Enter", "Tab", "Escape", "ArrowDown", ...
-page(:main).hover(selector)              # move mouse to element centre
-page(:main).upload(selector, path)       # set <input type="file"> to a local file
-page(:main).select(selector, value)      # set <select> value + fire change event
+page(:main).fill(selector = nil, value = nil, ref: nil)
+page(:main).click(selector = nil, ref: nil)
+page(:main).press(key)                                   # "Enter", "Tab", "Escape", "ArrowDown", ...
+page(:main).hover(selector = nil, ref: nil)              # move mouse to element centre
+page(:main).upload(selector = nil, path = nil, ref: nil) # set <input type="file"> to a local file
+page(:main).select(selector = nil, value = nil, ref: nil) # set <select> value + fire change event
 page(:main).dialog_accept(text: nil)     # register one-shot: accept next alert/confirm/prompt
 page(:main).dialog_dismiss               # register one-shot: dismiss next confirm
 page(:main).wait(selector, timeout: 30)

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -52,3 +52,34 @@ RSpec.describe Browserctl::KeyNotFound do
     expect(described_class.new("x").code).to eq("key_not_found")
   end
 end
+
+RSpec.describe Browserctl::DaemonUnavailableError do
+  it "has code daemon_unavailable" do
+    expect(described_class.new("x").code).to eq("daemon_unavailable")
+  end
+end
+
+RSpec.describe "daemon ping JSON error path" do
+  require "browserctl/commands/daemon"
+  require "stringio"
+
+  it "emits JSON with ok:false and daemon:offline and exits 1 when daemon is unavailable" do
+    client = instance_double(Browserctl::Client)
+    allow(client).to receive(:ping).and_raise(Browserctl::DaemonUnavailableError, "browserd is not running")
+
+    original = $stdout
+    $stdout = StringIO.new
+    begin
+      expect do
+        Browserctl::Commands::Daemon.run(client, ["ping"])
+      end.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      output = $stdout.string
+    ensure
+      $stdout = original
+    end
+
+    parsed = JSON.parse(output)
+    expect(parsed["ok"]).to be false
+    expect(parsed["daemon"]).to eq("offline")
+  end
+end

--- a/spec/unit/interaction_spec.rb
+++ b/spec/unit/interaction_spec.rb
@@ -108,4 +108,54 @@ RSpec.describe "interaction handlers" do
       expect(res[:error]).to match(/selector not found/)
     end
   end
+
+  describe "hover with ref" do
+    it "resolves selector from ref_registry and moves mouse" do
+      mouse = double("mouse")
+      page  = double("page", mouse: mouse)
+      make_page(page)
+      pages["p"].ref_registry = { "e4" => "#dropdown" }
+      allow(page).to receive(:evaluate)
+        .with(a_string_including("getBoundingClientRect"))
+        .and_return({ "x" => 100.0, "y" => 200.0 })
+      expect(mouse).to receive(:move).with(x: 100.0, y: 200.0)
+      res = dispatcher.dispatch({ cmd: "hover", name: "p", ref: "e4" })
+      expect(res).to eq({ ok: true })
+    end
+
+    it "returns error for unknown ref" do
+      page = double("page")
+      make_page(page)
+      pages["p"].ref_registry = {}
+      res = dispatcher.dispatch({ cmd: "hover", name: "p", ref: "e99" })
+      expect(res[:error]).to match(/ref 'e99' not found/)
+    end
+  end
+
+  describe "upload with ref" do
+    it "resolves selector from ref_registry" do
+      page = double("page")
+      make_page(page)
+      pages["p"].ref_registry = { "e5" => "#file-input" }
+      el = double("el")
+      allow(page).to receive(:at_css).with("#file-input").and_return(el)
+      expect(el).to receive(:select_file).with(anything)
+      # Use a real file path — use __FILE__ (this spec file itself)
+      res = dispatcher.dispatch({ cmd: "upload", name: "p", ref: "e5", path: __FILE__ })
+      expect(res).to eq({ ok: true })
+    end
+  end
+
+  describe "select with ref" do
+    it "resolves selector from ref_registry" do
+      page = double("page")
+      make_page(page)
+      pages["p"].ref_registry = { "e6" => "#country" }
+      el = double("el")
+      allow(page).to receive(:at_css).with("#country").and_return(el)
+      allow(el).to receive(:evaluate)
+      res = dispatcher.dispatch({ cmd: "select", name: "p", ref: "e6", value: "AU" })
+      expect(res).to eq({ ok: true })
+    end
+  end
 end

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require "tmpdir"
+require "stringio"
+require "json"
 require "browserctl/recording"
+require "browserctl/commands/record"
 
 RSpec.describe Browserctl::Recording do
   around do |example|
@@ -143,6 +146,56 @@ RSpec.describe Browserctl::Recording do
       described_class.append("navigate", name: "main", url: "https://example.com/clean")
       ruby = described_class.generate_workflow("redact_test")
       expect(ruby).not_to include("# NOTE: sensitive query params were redacted")
+    end
+  end
+end
+
+RSpec.describe Browserctl::Commands::Record do
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  describe "record start" do
+    it "emits JSON with ok and name on start" do
+      allow(Browserctl::Recording).to receive(:start)
+      output = capture_stdout { described_class.run(["start", "my-rec"]) }
+      parsed = JSON.parse(output)
+      expect(parsed["ok"]).to be true
+      expect(parsed["name"]).to eq("my-rec")
+    end
+  end
+
+  describe "record stop" do
+    it "emits JSON with ok, name, and path on stop" do
+      allow(Browserctl::Recording).to receive(:stop).and_return("my-workflow")
+      allow(Browserctl::Recording).to receive(:generate_workflow)
+      allow(FileUtils).to receive(:mkdir_p)
+      output = capture_stdout { described_class.run(["stop"]) }
+      parsed = JSON.parse(output)
+      expect(parsed["ok"]).to be true
+      expect(parsed["name"]).to eq("my-workflow")
+      expect(parsed["path"]).to include("my-workflow")
+    end
+  end
+
+  describe "record status" do
+    it "emits JSON with active name when recording" do
+      allow(Browserctl::Recording).to receive(:active).and_return("my-rec")
+      output = capture_stdout { described_class.run(["status"]) }
+      parsed = JSON.parse(output)
+      expect(parsed["active"]).to eq("my-rec")
+    end
+
+    it "emits JSON with null active when no recording" do
+      allow(Browserctl::Recording).to receive(:active).and_return(nil)
+      output = capture_stdout { described_class.run(["status"]) }
+      parsed = JSON.parse(output)
+      expect(parsed["active"]).to be_nil
     end
   end
 end

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Browserctl::Commands::Record do
   describe "record start" do
     it "emits JSON with ok and name on start" do
       allow(Browserctl::Recording).to receive(:start)
-      output = capture_stdout { described_class.run(["start", "my-rec"]) }
+      output = capture_stdout { described_class.run(%w[start my-rec]) }
       parsed = JSON.parse(output)
       expect(parsed["ok"]).to be true
       expect(parsed["name"]).to eq("my-rec")

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -2,8 +2,10 @@
 
 require "spec_helper"
 require "browserctl/runner"
+require "browserctl/commands/workflow"
 require "tmpdir"
 require "json"
+require "stringio"
 
 RSpec.describe Browserctl::Runner do
   subject(:runner) { described_class.new }
@@ -124,6 +126,31 @@ RSpec.describe Browserctl::Runner do
       result = runner.describe_workflow("describe_test")
       expect(result[:params][:email]).not_to have_key(:secret_ref)
       expect(result[:params][:note]).not_to have_key(:secret_ref)
+    end
+  end
+end
+
+RSpec.describe Browserctl::Commands::Workflow do
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  describe ".run list" do
+    it "emits JSON with workflows array" do
+      runner = instance_double(Browserctl::Runner)
+      allow(runner).to receive(:list_workflows).and_return([
+        { name: "login", desc: "Log in to the app" },
+        { name: "checkout", desc: "Run checkout flow" }
+      ])
+      output = capture_stdout { described_class.run(runner, ["list"]) }
+      parsed = JSON.parse(output)
+      expect(parsed["workflows"]).to be_an(Array)
+      expect(parsed["workflows"].first["name"]).to eq("login")
     end
   end
 end

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -144,9 +144,9 @@ RSpec.describe Browserctl::Commands::Workflow do
     it "emits JSON with workflows array" do
       runner = instance_double(Browserctl::Runner)
       allow(runner).to receive(:list_workflows).and_return([
-        { name: "login", desc: "Log in to the app" },
-        { name: "checkout", desc: "Run checkout flow" }
-      ])
+                                                             { name: "login", desc: "Log in to the app" },
+                                                             { name: "checkout", desc: "Run checkout flow" }
+                                                           ])
       output = capture_stdout { described_class.run(runner, ["list"]) }
       parsed = JSON.parse(output)
       expect(parsed["workflows"]).to be_an(Array)

--- a/spec/unit/session_spec.rb
+++ b/spec/unit/session_spec.rb
@@ -2,7 +2,9 @@
 
 require "tmpdir"
 require "json"
+require "stringio"
 require "browserctl/session"
+require "browserctl/commands/session"
 
 RSpec.describe Browserctl::Session do
   before do
@@ -120,6 +122,35 @@ RSpec.describe Browserctl::Session do
                                            local_storage: local_storage, session_storage: {})
       mode = File.stat(File.join(described_class.path("test_session"), "local_storage.json")).mode & 0o777
       expect(mode).to eq(0o600)
+    end
+  end
+end
+
+RSpec.describe "session import name detection" do
+  it "includes the session name in the JSON response" do
+    Dir.mktmpdir do |tmp|
+      sessions_dir = File.join(tmp, "sessions")
+      FileUtils.mkdir_p(sessions_dir)
+
+      # Create a minimal session zip: sessions/mysession/metadata.json
+      session_content_dir = File.join(tmp, "mysession")
+      FileUtils.mkdir_p(session_content_dir)
+      File.write(File.join(session_content_dir, "metadata.json"), '{"pages":[]}')
+      zip_path = File.join(tmp, "mysession.zip")
+      system("zip -r #{zip_path} mysession", chdir: tmp, out: File::NULL, err: File::NULL)
+
+      stub_const("Browserctl::BROWSERCTL_DIR", tmp)
+
+      # capture stdout, run import
+      original_stdout = $stdout
+      $stdout = StringIO.new
+      Browserctl::Commands::Session.run(double("client"), ["import", zip_path])
+      output = $stdout.string
+      $stdout = original_stdout
+
+      parsed = JSON.parse(output)
+      expect(parsed["ok"]).to be true
+      expect(parsed["name"]).to eq("mysession")
     end
   end
 end

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -357,6 +357,13 @@ RSpec.describe "WorkflowContext#load_session with expired_if:" do
     expect(ctx).to have_received(:invoke).with("login").once
     expect(invocations).to eq(0)
   end
+
+  it "raises ArgumentError when expired_if: lambda takes arguments" do
+    ctx = Browserctl::WorkflowContext.new({}, client)
+    expect {
+      ctx.load_session("s", expired_if: ->(page) { false })
+    }.to raise_error(ArgumentError, /expired_if.*zero arguments/)
+  end
 end
 
 RSpec.describe Browserctl::WorkflowContext do
@@ -422,5 +429,21 @@ RSpec.describe Browserctl::WorkflowContext do
 
       expect { ctx.invoke("loop_a") }.to raise_error(Browserctl::WorkflowError, /circular/)
     end
+  end
+end
+
+RSpec.describe "WorkflowContext compose guard" do
+  let(:client) { instance_double(Browserctl::Client) }
+
+  it "raises WorkflowError with a helpful message when compose is called inside a step block" do
+    defn = Browserctl::WorkflowDefinition.new("test")
+    defn.step("bad") do
+      compose "other_workflow"
+    end
+
+    expect { defn.call({}, client) }.to raise_error(
+      Browserctl::WorkflowError,
+      /compose.*definition level.*invoke/i
+    )
   end
 end

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -478,4 +478,28 @@ RSpec.describe "PageProxy ref-based interaction" do
       proxy.click("button#submit")
     end
   end
+
+  describe "#hover" do
+    it "passes ref: to client" do
+      expect(client).to receive(:hover).with("main", nil, ref: "e4").and_return({ ok: true })
+      proxy = Browserctl::PageProxy.new("main", client)
+      proxy.hover(nil, ref: "e4")
+    end
+  end
+
+  describe "#upload" do
+    it "passes ref: to client" do
+      expect(client).to receive(:upload).with("main", nil, "/tmp/file.pdf", ref: "e5").and_return({ ok: true })
+      proxy = Browserctl::PageProxy.new("main", client)
+      proxy.upload(nil, "/tmp/file.pdf", ref: "e5")
+    end
+  end
+
+  describe "#select" do
+    it "passes ref: to client" do
+      expect(client).to receive(:select).with("main", nil, "AU", ref: "e6").and_return({ ok: true })
+      proxy = Browserctl::PageProxy.new("main", client)
+      proxy.select(nil, "AU", ref: "e6")
+    end
+  end
 end

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -447,3 +447,35 @@ RSpec.describe "WorkflowContext compose guard" do
     )
   end
 end
+
+RSpec.describe "PageProxy ref-based interaction" do
+  let(:client) { instance_double(Browserctl::Client) }
+
+  describe "#fill" do
+    it "passes ref: to client when ref: is given" do
+      expect(client).to receive(:fill).with("main", nil, "hello", ref: "e1").and_return({ ok: true })
+      proxy = Browserctl::PageProxy.new("main", client)
+      proxy.fill(nil, "hello", ref: "e1")
+    end
+
+    it "passes selector positionally when no ref given" do
+      expect(client).to receive(:fill).with("main", "input#email", "hello", ref: nil).and_return({ ok: true })
+      proxy = Browserctl::PageProxy.new("main", client)
+      proxy.fill("input#email", "hello")
+    end
+  end
+
+  describe "#click" do
+    it "passes ref: to client when ref: is given" do
+      expect(client).to receive(:click).with("main", nil, ref: "e3").and_return({ ok: true })
+      proxy = Browserctl::PageProxy.new("main", client)
+      proxy.click(nil, ref: "e3")
+    end
+
+    it "passes selector positionally when no ref given" do
+      expect(client).to receive(:click).with("main", "button#submit", ref: nil).and_return({ ok: true })
+      proxy = Browserctl::PageProxy.new("main", client)
+      proxy.click("button#submit")
+    end
+  end
+end

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -360,9 +360,9 @@ RSpec.describe "WorkflowContext#load_session with expired_if:" do
 
   it "raises ArgumentError when expired_if: lambda takes arguments" do
     ctx = Browserctl::WorkflowContext.new({}, client)
-    expect {
-      ctx.load_session("s", expired_if: ->(page) { false })
-    }.to raise_error(ArgumentError, /expired_if.*zero arguments/)
+    expect do
+      ctx.load_session("s", expired_if: ->(_page) { false })
+    end.to raise_error(ArgumentError, /expired_if.*zero arguments/)
   end
 end
 


### PR DESCRIPTION
## Summary

- **M1 — Doc & API bug fixes:** corrected `screenshot` `path:` keyword, `devtools` command name in comparison table, nonce row in `vs-agent-browser.md`, and `session import` now returns session name in response
- **M2 — DSL hardening:** typed `DaemonUnavailableError` (JSON on `ping` offline); `compose` guard raises when called inside a step block; `expired_if:` arity validation; `workflow list` and `record` subcommands emit JSON per style guide
- **M3 — Ref surface completion:** extended `ref:` kwarg through all three layers (server handlers → `Client` → `PageProxy`) for `hover`, `upload`, `select`, and fixed `fill`/`click` on `PageProxy`; wire additions are non-breaking
- **M4 — Docs cleanup:** getting-started unified to single demo URL + ref ephemerality callout + `--headed` note + troubleshooting section; README tagline promoted + GIF moved after Quick Start; HITL and PageProxy table deduplicated; compose guide + `store`/`fetch` vs `@var` callout + `load_session` anti-pattern fix in writing-workflows; v0.3 command rename annotations in vision.md; Secrets row moved in docs/README.md

## Test plan

- [ ] `bundle exec rspec` — 330 examples, 0 failures
- [ ] `daemon ping` with daemon offline → emits `{ ok: false, daemon: "offline", error: "..." }` and exits 1
- [ ] `workflow list` → emits `{ workflows: [...] }`
- [ ] `record stop` → emits `{ ok: true, name: "...", path: "..." }`
- [ ] `session import` → response includes `name` field
- [ ] `page(:main).hover(ref: "e3")` inside workflow → dispatches without selector
- [ ] `compose` inside a step block → raises `WorkflowError` with clear message
- [ ] `expired_if: ->(x) { }` → raises `ArgumentError` with arity message