### PR TITLE
fix(test): clear localStorage before stale session save to prevent test pollution

### DIFF
--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -205,7 +205,9 @@ RSpec.describe "session commands", :integration do
 
     it "invokes fallback and recovers when expired_if detects a stale session" do
       # Save a session WITHOUT the auth marker — simulating a stale/logged-out save.
+      # Explicitly clear the key so prior-test localStorage pollution can't cause a false pass.
       @client.page_open("sess", url: "http://localhost:#{@port}/")
+      @client.storage_delete("sess", stores: "local")
       @client.session_save(session_name) # auth_valid is absent
       @client.page_close("sess")
 


### PR DESCRIPTION
## Summary

- Integration test `load_session with expired_if: invokes fallback` was failing in CI with seed `17133` when the "live" test ran before the "stale" test.
- Root cause: `cmd_session_load` seeds localStorage with `setItem` but never clears first. If a prior test had set `auth_valid = "1"` for the same origin, `session_save` would snapshot it into the "stale" session file, then `session_load` would restore it — causing `expired_if` to see `auth_valid == "1"` and skip the fallback.
- Fix: call `storage_delete("sess", stores: "local")` before `session_save` in the stale-session test setup to guarantee a clean baseline regardless of test order.

## Test plan

- [ ] `bundle exec rspec spec/integration/session_spec.rb --order random` — both `expired_if:` tests pass in any order
- [ ] `bundle exec rspec` — 330 examples, 0 failures