### PR TITLE
fix: onboarding UX/DX improvements before v0.8.4

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,17 +143,62 @@ browserctl snapshot main --diff
 
 ---
 
-## 6. Shut down
+## 6. Save your session (optional)
+
+If you want to pick up exactly where you left off next time — same tabs, same cookies, same auth — save your session before stopping:
+
+```bash
+browserctl session save my-first-session
+```
+
+Restore it on a fresh daemon:
+
+```bash
+browserd &
+browserctl session load my-first-session
+# → pages re-opened, cookies restored, localStorage seeded
+```
+
+---
+
+## 7. Shut down
 
 ```bash
 browserctl daemon stop
 ```
 
-The daemon stops and the browser closes. Your session state is gone — next time you'll start fresh.
-
-> To preserve state across restarts, save and restore it: see [Session save/load](reference/commands.md#session).
+The daemon stops and the browser closes. Unsaved session state is gone — next time you'll start fresh unless you saved above.
 
 > The daemon also shuts itself down automatically after 30 minutes of inactivity.
+
+---
+
+## 8. Your first workflow (optional)
+
+CLI commands are great for one-off exploration. Workflows let you save a sequence of steps as a reusable Ruby script:
+
+```ruby
+# .browserctl/workflows/hello.rb
+Browserctl.workflow "hello" do
+  desc "Open a page, print its title"
+
+  step "open page" do
+    open_page(:main, url: "https://example.com")
+  end
+
+  step "print title" do
+    title = page(:main).evaluate("document.title")
+    puts "  → #{title}"
+  end
+end
+```
+
+```bash
+browserctl workflow run hello
+# → Example Domain
+```
+
+That's the complete mental model: `open_page` opens a tab, `page(:name)` addresses it, `evaluate` runs JavaScript on it. Everything else in the [Writing Workflows](guides/writing-workflows.md) guide builds on these three primitives.
 
 ---
 

--- a/docs/guides/smoke-testing.md
+++ b/docs/guides/smoke-testing.md
@@ -19,12 +19,12 @@ browserctl workflow run examples/the_internet/dynamic_loading.rb
 browserctl workflow run examples/the_internet/add_remove_elements.rb
 
 # test-automation-practices examples
-browserctl workflow run examples/test_automation_practices/login.rb
-browserctl workflow run examples/test_automation_practices/login_negative.rb
-browserctl workflow run examples/test_automation_practices/dynamic_elements.rb
-browserctl workflow run examples/test_automation_practices/checkboxes.rb
-browserctl workflow run examples/test_automation_practices/notifications.rb
-browserctl workflow run examples/test_automation_practices/key_press.rb
+browserctl workflow run examples/test_automation_practices/auth/login.rb
+browserctl workflow run examples/test_automation_practices/auth/login_negative.rb
+browserctl workflow run examples/test_automation_practices/dynamic/dynamic_elements.rb
+browserctl workflow run examples/test_automation_practices/forms/checkboxes.rb
+browserctl workflow run examples/test_automation_practices/dialogs/notifications.rb
+browserctl workflow run examples/test_automation_practices/interactions/key_press.rb
 
 browserctl daemon stop
 ```
@@ -46,7 +46,7 @@ Each example saves a screenshot to `docs/assets/` on completion. Screenshots are
 
 Target: `https://moatazeldebsy.github.io/test-automation-practices` — a self-hosted React SPA that can also be run locally with `npm run dev`. All interactive elements carry `data-test` attributes for stable targeting.
 
-### `test_automation_practices/login.rb` — Login and Logout
+### `test_automation_practices/auth/login.rb` — Login and Logout
 
 Covers: `fill`, `click`, `wait`, `evaluate`
 
@@ -65,7 +65,7 @@ Fills the public test credentials into the auth form, submits, waits for the suc
 
 ---
 
-### `test_automation_practices/login_negative.rb` — Invalid Credentials
+### `test_automation_practices/auth/login_negative.rb` — Invalid Credentials
 
 Covers: `fill`, `click`, `wait`, `evaluate`
 
@@ -81,7 +81,7 @@ Submits wrong credentials and asserts the error element appears while no success
 
 ---
 
-### `test_automation_practices/dynamic_elements.rb` — Dynamic Content Loading
+### `test_automation_practices/dynamic/dynamic_elements.rb` — Dynamic Content Loading
 
 Covers: `click`, `wait`, `wait`, `evaluate`
 
@@ -99,7 +99,7 @@ Asserts no dynamic items exist before triggering a reload, clicks the reload but
 
 ---
 
-### `test_automation_practices/checkboxes.rb` — Checkbox State Management
+### `test_automation_practices/forms/checkboxes.rb` — Checkbox State Management
 
 Covers: `click`, `evaluate`
 
@@ -117,7 +117,7 @@ Reads initial state (all unchecked), toggles one checkbox individually, then use
 
 ---
 
-### `test_automation_practices/notifications.rb` — Toast Notifications
+### `test_automation_practices/dialogs/notifications.rb` — Toast Notifications
 
 Covers: `click`, `wait`, `evaluate`
 
@@ -134,7 +134,7 @@ Triggers a success notification and waits for it using a `data-test` attribute p
 
 ---
 
-### `test_automation_practices/key_press.rb` — Keyboard Event Capture
+### `test_automation_practices/interactions/key_press.rb` — Keyboard Event Capture
 
 Covers: `evaluate`, `store`, `fetch`
 
@@ -165,7 +165,6 @@ Navigates to the login page, fills in the public test credentials, submits the f
   [ok]   fill and submit credentials
   [ok]   verify secure area
   [ok]   logout and verify
-  [ok]   capture screenshot
 ```
 
 ---
@@ -240,16 +239,16 @@ Clicks "Add Element" three times, asserts three delete buttons are present, remo
 
 | Pattern | Where it appears |
 |---------|-----------------|
-| Open a named page with initial URL | All examples — `client.open_page("main", url: ...)` |
-| Fill form inputs | `login.rb` — `page(:main).fill(selector, value)` |
+| Open a named page with initial URL | All examples — `open_page(:main, url: ...)` |
+| Fill form inputs | `auth/login.rb` — `page(:main).fill(selector, value)` |
 | Click buttons and links | All examples — `page(:main).click(selector)` |
 | Assert current URL | `the_internet/login.rb` — `page(:main).url` |
-| Read DOM state via JS | `checkboxes.rb`, `dropdown.rb`, `add_remove_elements.rb` — `client.evaluate("main", expression)[:result]` |
-| Set `<select>` element | `dropdown.rb` — `page(:main).select("select#dropdown", "1")` |
-| Dispatch synthetic events via JS | `key_press.rb` — `client.evaluate("main", "document.dispatchEvent(new KeyboardEvent(...))")` |
-| Wait for async element | `dynamic_loading.rb` — `page(:main).wait(selector, timeout:)` |
-| Poll for async element | `dynamic_elements.rb` — `page(:main).wait(selector, timeout:)` |
-| Attribute prefix selector | `notifications.rb` — `[data-test^="notification-"]` for dynamic IDs |
-| Share state across steps | `key_press.rb` — `store(:key, value)` / `fetch(:key)` |
-| Negative-path assertion | `login_negative.rb` — assert error shown, success absent |
+| Read DOM state via JS | `forms/checkboxes.rb`, `the_internet/dropdown.rb` — `page(:main).evaluate(expression)` |
+| Set `<select>` element | `the_internet/dropdown.rb` — `page(:main).select("select#dropdown", "1")` |
+| Dispatch synthetic events via JS | `interactions/key_press.rb` — `page(:main).evaluate("document.dispatchEvent(new KeyboardEvent(...))")` |
+| Wait for async element | `the_internet/dynamic_loading.rb` — `page(:main).wait(selector, timeout:)` |
+| Poll for async element | `dynamic/dynamic_elements.rb` — `page(:main).wait(selector, timeout:)` |
+| Attribute prefix selector | `dialogs/notifications.rb` — `[data-test^="notification-"]` for dynamic IDs |
+| Share state across steps | `interactions/key_press.rb` — `store(:key, value)` / `fetch(:key)` |
+| Negative-path assertion | `auth/login_negative.rb` — assert error shown, success absent |
 | Assert with message | All examples — `assert condition, "message"` |

--- a/examples/session_reuse.rb
+++ b/examples/session_reuse.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Demonstrates the authenticate-once, reuse-forever pattern.
+#
+# The first run (no saved session) invokes `login_once` to authenticate,
+# which saves the session. Every subsequent run loads the saved session
+# directly — no re-authentication needed.
+#
+# `expired_if:` detects when the saved session exists but server-side auth
+# has lapsed (rotated cookie, token TTL), and automatically re-authenticates.
+#
+# Run:
+#   browserctl workflow run examples/session_reuse.rb \
+#     --app_url https://the-internet.herokuapp.com \
+#     --username tomsmith \
+#     --password "SuperSecretPassword!"
+#
+# On the first run: authenticates and saves the session.
+# On subsequent runs: loads the session and skips the login page entirely.
+
+# --- Step 1: define the login workflow (run once, triggered automatically on missing/expired session) ---
+
+Browserctl.workflow "session_reuse/login_once" do
+  desc "Authenticate and save session — called automatically by session_reuse when needed"
+
+  param :app_url,  required: true
+  param :username, required: true
+  param :password, required: true, secret: true
+
+  step "open login page" do
+    open_page(:main, url: "#{app_url}/login")
+  end
+
+  step "fill and submit credentials" do
+    page(:main).fill("input#username", username)
+    page(:main).fill("input#password", password)
+    page(:main).click("button[type=submit]")
+  end
+
+  step "verify login succeeded" do
+    assert page(:main).url.include?("/secure"), "login failed — still on login page"
+  end
+
+  step "save authenticated session" do
+    save_session("session_reuse_demo")
+    puts "  ✓ Session saved — future runs will skip this step"
+  end
+end
+
+# --- Step 2: the main workflow that reuses the saved session ---
+
+Browserctl.workflow "session_reuse" do
+  desc "Authenticate once, reuse forever — demonstrates load_session with fallback and expired_if"
+
+  param :app_url,  default: "https://the-internet.herokuapp.com"
+  param :username, default: "tomsmith"
+  param :password, default: "SuperSecretPassword!", secret: true
+
+  step "restore session or log in" do
+    load_session("session_reuse_demo",
+      fallback: "session_reuse/login_once",
+      expired_if: -> {
+        page(:main).navigate("#{app_url}/secure")
+        !page(:main).url.include?("/secure")
+      }
+    )
+    puts "  ✓ Session ready — authenticated as #{username}"
+  end
+
+  step "do authenticated work" do
+    page(:main).navigate("#{app_url}/secure")
+    heading = page(:main).evaluate("document.querySelector('h2')?.textContent?.trim()")
+    assert heading&.include?("Secure Area"), "expected to be in secure area, got: #{heading.inspect}"
+    puts "  ✓ Landed in secure area without re-authenticating"
+  end
+end

--- a/examples/session_reuse.rb
+++ b/examples/session_reuse.rb
@@ -58,12 +58,11 @@ Browserctl.workflow "session_reuse" do
 
   step "restore session or log in" do
     load_session("session_reuse_demo",
-      fallback: "session_reuse/login_once",
-      expired_if: -> {
-        page(:main).navigate("#{app_url}/secure")
-        !page(:main).url.include?("/secure")
-      }
-    )
+                 fallback: "session_reuse/login_once",
+                 expired_if: lambda {
+                   page(:main).navigate("#{app_url}/secure")
+                   !page(:main).url.include?("/secure")
+                 })
     puts "  ✓ Session ready — authenticated as #{username}"
   end
 

--- a/examples/the_internet/login.rb
+++ b/examples/the_internet/login.rb
@@ -20,14 +20,14 @@ Browserctl.workflow "the_internet/login" do
 
   step "verify secure area" do
     assert page(:main).url.include?("/secure"), "expected redirect to /secure"
-    flash = client.evaluate("main", "document.querySelector('.flash.success')?.innerText?.trim()")[:result]
+    flash = page(:main).evaluate("document.querySelector('.flash.success')?.innerText?.trim()")
     assert flash&.include?("You logged into a secure area!"), "expected success flash, got: #{flash.inspect}"
     page(:main).screenshot(path: screenshot_path)
   end
 
   step "logout and verify" do
     page(:main).click("a[href='/logout']")
-    flash = client.evaluate("main", "document.querySelector('.flash.success')?.innerText?.trim()")[:result]
+    flash = page(:main).evaluate("document.querySelector('.flash.success')?.innerText?.trim()")
     assert flash&.include?("You logged out"), "expected logout flash, got: #{flash.inspect}"
   end
 end


### PR DESCRIPTION
## Summary

- **Blocker fixed:** smoke-testing guide had 6 example `run` commands pointing to pre-restructure flat paths — every newcomer following the guide would hit file-not-found errors immediately
- **Blocker fixed:** smoke-testing patterns table used `client.open_page(...)` and `client.evaluate(...)[:result]` — the old raw API, not the DSL form newcomers should copy
- **Fixed:** `examples/the_internet/login.rb` used `client.evaluate("main", ...)[:result]` — the file linked from the README Quick Start, now consistent with `page(:main).evaluate(...)`
- **Fixed:** smoke-testing step output for `the_internet/login.rb` showed 5 steps, file has 4
- **Added:** `getting-started.md` step 6 — session save before shutdown, surfaces the v0.8 persistence feature where a newcomer naturally reaches for it
- **Added:** `getting-started.md` step 8 — minimal workflow hello world to bridge the CLI→DSL gap before sending newcomers to the full writing-workflows guide
- **Added:** `examples/session_reuse.rb` — canonical authenticate-once, reuse-forever example demonstrating `load_session` with `fallback:` and `expired_if:` (the v0.8 headline features had no runnable example file)

## Test plan

- [ ] Run `browserctl workflow run examples/test_automation_practices/auth/login.rb` — should find the file and pass
- [ ] Run all 6 corrected TAP commands from smoke-testing guide — all should resolve
- [ ] Read getting-started.md top to bottom as a newcomer — session save and hello world workflow should feel natural at their positions
- [ ] Run `browserctl workflow run examples/session_reuse.rb` against the-internet (requires daemon)