### PR TITLE
docs(adr): record ADR-0008 through ADR-0011 for identified gaps

### DIFF
--- a/docs/architecture/decisions/0008-session-persistence.md
+++ b/docs/architecture/decisions/0008-session-persistence.md
@@ -1,0 +1,46 @@
+# ADR-0008: Snapshot-Based Session Persistence
+
+**Date**: 2026-05-01
+**Status**: accepted
+**Deciders**: Patrick
+
+## Context
+
+The daemon holds live browser state (open pages, cookies, localStorage) that is lost when the process exits. Users need a way to save and restore sessions across daemon restarts for workflows that span multiple work sessions. The persistence format must be human-inspectable, secure by default, and not require a running browser to read.
+
+## Decision
+
+Sessions are saved as a set of JSON files under `~/.browserctl/sessions/<name>/`: `metadata.json`, `cookies.json`, `local_storage.json`, and optionally `session_storage.json`. All files are written with `0o600` permissions. An optional AES-256-GCM encryption mode is available, with keys stored in the macOS Keychain. Sessions are not automatically restored on daemon restart — they must be explicitly loaded via `session_load`.
+
+## Alternatives Considered
+
+### Marshal / Ruby object serialization
+- **Pros**: Captures the full Ruby object graph with no manual field selection
+- **Cons**: Format is Ruby-version-sensitive and opaque; cannot be inspected without a running Ruby process; security implications of deserializing untrusted data
+- **Why not**: Sessions may need to be inspected or ported; Marshal is a poor fit for long-lived storage
+
+### SQLite database
+- **Pros**: Queryable; atomic writes; handles concurrent access safely
+- **Cons**: Adds a native dependency; overkill for a single-user local tool; sessions are not frequently queried
+- **Why not**: File-per-session JSON is simpler and directly inspectable with standard tools
+
+### Auto-restore on daemon restart
+- **Pros**: Seamless recovery after crashes
+- **Cons**: Requires serializing page object references and Ferrum state, which is not safely serializable; a partially-restored browser is worse than a clean start
+- **Why not**: Explicit `session_load` keeps the contract clear; implicit restoration hides failures
+
+## Consequences
+
+### Positive
+- Sessions are inspectable with any JSON tool — no special tooling required
+- `0o600` permissions restrict access to the owning user without encryption
+- Optional AES-256-GCM with macOS Keychain provides strong protection for sensitive cookies without per-command password prompts
+- Session files can be version-controlled or shared (when encryption is used)
+
+### Negative
+- sessionStorage is collected but not restored — it is tab-scoped and cannot survive page navigation
+- Session load is not atomic: if restoring page 2 fails after page 1 succeeds, the browser is left in a partial state
+- macOS Keychain integration is Darwin-only; Linux/CI users rely solely on file permissions
+
+### Risks
+- Stale session files accumulate in `~/.browserctl/sessions/` with no automatic pruning — users must clean up manually

--- a/docs/architecture/decisions/0009-error-handling-strategy.md
+++ b/docs/architecture/decisions/0009-error-handling-strategy.md
@@ -1,0 +1,45 @@
+# ADR-0009: Uniform JSON-RPC Error Format with Per-Thread Isolation
+
+**Date**: 2026-05-01
+**Status**: accepted
+**Deciders**: Patrick
+
+## Context
+
+The daemon handles commands from multiple concurrent clients over a Unix socket. Errors can occur at several layers: input validation, page operation failures, browser exceptions, and unknown commands. A consistent error shape is needed so clients can handle all failure cases uniformly without special-casing each command.
+
+## Decision
+
+All responses use one of two shapes: `{ ok: true, ...fields }` for success or `{ error: "message string" }` for failure, with an optional `code` field (e.g., `page_not_found`, `domain_not_allowed`) for machine-readable error discrimination. Per-client threads catch all `StandardError` exceptions and serialize them into the error shape. Errors are isolated per client connection — a failing command on one client does not affect others.
+
+## Alternatives Considered
+
+### JSON-RPC 2.0 error objects (`{ error: { code: N, message: "..." } }`)
+- **Pros**: Spec-compliant; numeric codes are unambiguous; many client libraries understand it natively
+- **Cons**: Numeric codes require a lookup table; the spec's predefined codes (`-32600` etc.) don't map naturally to browser automation errors
+- **Why not**: The spec's error envelope adds nesting without benefit for a single-client, single-server local tool
+
+### Exception classes propagated to the client
+- **Pros**: Rich type information; clients can pattern-match on exception class
+- **Cons**: Requires a serialization convention for exception types; couples client and server class hierarchies
+- **Why not**: The Unix socket boundary already breaks object identity; string messages are sufficient for the CLI use case
+
+### Structured error codes on every response
+- **Pros**: Clients can branch on error type without string-matching
+- **Cons**: Significant cataloguing overhead; most errors are terminal (surface to user as message)
+- **Why not**: Only errors that clients need to handle programmatically (e.g., `page_not_found` to trigger page creation) warrant codes; the rest are human-readable messages
+
+## Consequences
+
+### Positive
+- Clients need only check `response.key?(:error)` — one branch, all commands
+- Per-thread exception isolation prevents one client's failure from cascading to others
+- Error messages include the Ruby exception class in daemon logs for debugging while exposing only the message to clients
+
+### Negative
+- Multi-step operations (e.g., `session_load` restoring multiple pages) have no transactional guarantee — partial success is possible with no rollback
+- Machine-readable `code` values are only defined for a subset of errors; most handler errors are string-only, limiting programmatic discrimination
+- No structured error codes for input validation failures — clients cannot distinguish "wrong param type" from "page operation failed" without string inspection
+
+### Risks
+- The 60-second client-side response timeout is hardcoded — long-running commands (large page loads, full-page screenshots) may time out on slow machines

--- a/docs/architecture/decisions/0010-concurrency-model.md
+++ b/docs/architecture/decisions/0010-concurrency-model.md
@@ -1,0 +1,46 @@
+# ADR-0010: Thread-Per-Client with Layered Mutexes
+
+**Date**: 2026-05-01
+**Status**: accepted
+**Deciders**: Patrick
+
+## Context
+
+The daemon accepts commands from multiple concurrent clients (CLI invocations, workflow scripts) over a Unix socket. Browser operations are slow and blocking. A concurrency model is needed that allows concurrent clients without corrupting shared state — specifically the page registry and individual page sessions — while remaining simple enough to reason about without async frameworks.
+
+## Decision
+
+The server spawns one Ruby thread per connected client. Shared state is protected by two layers of mutexes: a global mutex (`@global_mutex`) that guards the page registry and last-used timestamp, and a per-page mutex (`PageSession#mutex`) with a `ConditionVariable` for pause/resume that serializes operations on each individual page. A separate KV store mutex protects the daemon-scoped key-value store. The idle watcher runs as a fourth background thread. Lock ordering is always global first, then per-page.
+
+## Alternatives Considered
+
+### Single-threaded event loop (e.g., EventMachine / async)
+- **Pros**: No mutex complexity; no deadlock risk; lower memory per connection
+- **Cons**: Ferrum uses blocking I/O to CDP; adapting it to an async event loop requires wrapping every CDP call; adds a significant non-trivial dependency
+- **Why not**: The browser control layer is inherently blocking; an event loop buys nothing without async-capable Ferrum bindings
+
+### Thread pool with fixed worker count
+- **Pros**: Bounded resource usage; prevents thread explosion under load
+- **Cons**: Clients block waiting for a pool slot; for a local developer tool, concurrent client count is rarely > 2-3
+- **Why not**: The overhead of pool management is not justified; the tool is not designed for high-concurrency workloads
+
+### Global lock (single mutex around all operations)
+- **Pros**: Trivially correct; no deadlock risk
+- **Cons**: Serializes all commands across all clients and all pages; kills concurrency for independent page operations
+- **Why not**: Two clients operating on different pages should not block each other
+
+## Consequences
+
+### Positive
+- Independent pages can be operated concurrently — the per-page mutex only blocks operations on the same page
+- Global mutex is held only during fast registry lookups, not during browser I/O — contention is minimal
+- Lock ordering (global → per-page) is consistent throughout the codebase, eliminating deadlock risk
+- `ConditionVariable` on per-page mutex enables pause/resume semantics for workflow step coordination
+
+### Negative
+- No thread pool upper bound — a burst of concurrent clients spawns an unbounded number of threads
+- Ferrum's browser instance is shared across all threads without internal thread-safety guarantees; correctness relies on per-page mutex ensuring only one thread operates on a given page at a time
+- Thread lifecycle is managed by GC, not explicitly — leaked threads from abruptly-closed connections are not explicitly cleaned up
+
+### Risks
+- A deadlock is possible if a handler acquires the global mutex and then tries to acquire a per-page mutex while another thread holds the per-page mutex and waits for the global mutex — current code avoids this but the constraint is not enforced mechanically

--- a/docs/architecture/decisions/0011-screenshot-format.md
+++ b/docs/architecture/decisions/0011-screenshot-format.md
@@ -1,0 +1,46 @@
+# ADR-0011: PNG Default for Screenshots with Path-Scoped Safety
+
+**Date**: 2026-05-01
+**Status**: accepted
+**Deciders**: Patrick
+
+## Context
+
+The `screenshot` command captures the browser viewport as an image file. A default format and allowed format set must be chosen. Screenshot paths are user-supplied, which creates a path traversal risk — the daemon must validate paths without being overly restrictive for legitimate use. Screenshots and DOM snapshots (ADR-0006) serve different purposes and are distinct commands.
+
+## Decision
+
+Screenshots default to PNG. JPG and JPEG are also accepted (case-insensitive extension check). Paths are validated against two allowed roots: `~/.browserctl/screenshots/` and the caller's current working directory. Symlinks are resolved before validation. Full-page capture is available via a `--full` flag; viewport capture is the default. Screenshots and DOM snapshots are separate commands — `snapshot` returns JSON element data, `screenshot` returns an image file.
+
+## Alternatives Considered
+
+### WebP as default format
+- **Pros**: Better compression than PNG at equivalent quality; modern browser support
+- **Cons**: Less universally supported by image viewers and tools; Ferrum delegates format to Chrome, and WebP support in headless Chrome screenshot APIs is less consistent
+- **Why not**: PNG is universally supported and lossless; compression savings are not a priority for a developer debugging tool
+
+### Allow any path (no restriction)
+- **Pros**: Maximum flexibility for callers
+- **Cons**: The daemon runs with the user's file permissions and could overwrite arbitrary files if given a malicious path; CI environments may have write access to sensitive paths
+- **Why not**: Path traversal attacks are a known risk for any tool that writes user-supplied paths; scoping to two well-known roots is a minimal, non-intrusive safety measure
+
+### Embed screenshots in JSON-RPC response (base64)
+- **Pros**: No filesystem writes required; response is self-contained
+- **Cons**: Large base64 blobs in JSON responses conflict with the streaming limitation noted in ADR-0004; base64 adds ~33% overhead; callers typically want a file anyway
+- **Why not**: File-based output is the natural interface for screenshot use cases (sharing, attaching to tickets, visual diffing)
+
+## Consequences
+
+### Positive
+- PNG losslessness preserves text legibility for debugging UI state — preferred over lossy formats for developer tooling
+- Path restriction to two roots prevents accidental or malicious overwrites without requiring a separate permission system
+- `--full` flag enables full-page capture when the visible viewport is insufficient (e.g., long forms)
+- Screenshots and snapshots are complementary: snapshots for agent action planning, screenshots for human review and debugging
+
+### Negative
+- JPG quality is browser-default with no user-controllable quality parameter — fine for most use cases but not suitable for image-quality-sensitive workflows
+- Viewport resolution depends on the Chrome instance's configured viewport — no explicit resolution control exposed to callers
+- Screenshots cannot be returned inline in CLI output; callers must handle the output file path
+
+### Risks
+- Path validation resolves symlinks at write time — a symlink created after validation but before write (TOCTOU) could redirect the write; acceptable risk for a single-user local tool

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -9,3 +9,7 @@
 | [0005](0005-ruby-dsl-for-workflows.md) | Ruby DSL for workflow authoring | accepted | 2026-04-20 |
 | [0006](0006-ai-optimized-snapshot-format.md) | AI-optimized DOM snapshot format | accepted | 2026-04-20 |
 | [0007](0007-daemon-idle-ttl.md) | 30-minute idle TTL for auto-shutdown | accepted | 2026-04-20 |
+| [0008](0008-session-persistence.md) | Snapshot-based session persistence | accepted | 2026-05-01 |
+| [0009](0009-error-handling-strategy.md) | Uniform JSON-RPC error format with per-thread isolation | accepted | 2026-05-01 |
+| [0010](0010-concurrency-model.md) | Thread-per-client with layered mutexes | accepted | 2026-05-01 |
+| [0011](0011-screenshot-format.md) | PNG default for screenshots with path-scoped safety | accepted | 2026-05-01 |


### PR DESCRIPTION
## Summary

- ADR-0008: Snapshot-based session persistence — JSON files under `~/.browserctl/sessions/`, optional AES-256-GCM encryption, explicit load-only model
- ADR-0009: Uniform JSON-RPC error format — `{ ok: true }` / `{ error: "..." }` shape, per-thread isolation, partial-success behaviour documented
- ADR-0010: Thread-per-client with layered mutexes — global registry mutex + per-page mutex with ConditionVariable, fixed lock ordering to prevent deadlock
- ADR-0011: PNG default for screenshots with path-scoped safety — two allowed write roots, `--full` flag, screenshots vs snapshots distinction

## Context

These four ADRs fill gaps identified during a review of the existing ADR set (0001–0007). Each decision was already implemented in code; these records formalise the rationale and trade-offs alongside the code.