### PR TITLE
feat: v0.9 browser-agnostic driver layer + Brave support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This guide covers the workflow for contributing code, docs, and bug reports to b
 
 ## Development Setup
 
-**Requirements:** Ruby >= 3.3, Chrome or Chromium installed
+**Requirements:** Ruby >= 3.3, Chrome, Chromium, or Brave installed
 
 ```bash
 git clone https://github.com/patrick204nqh/browserctl

--- a/bin/browserd
+++ b/bin/browserd
@@ -9,15 +9,22 @@ require "browserctl/logger"
 require "browserctl/server"
 require "browserctl/version"
 
+SUPPORTED_BROWSERS = %w[chrome chromium brave].freeze
+
 opts = Optimist.options do
   version "browserd #{Browserctl::VERSION}"
   opt :headed,    "Run with a visible browser window",        default: false,  short: "-H"
   opt :log_level, "Log verbosity: debug, info, warn, error",  default: "info", short: "-l", type: :string
   opt :name,      "Daemon instance name for multi-agent use", default: nil,    short: "-n", type: :string
+  opt :browser,   "Browser to use: chrome, chromium, brave",  default: "chrome", short: "-b", type: :string
 end
 
 if opts[:name] && opts[:name] !~ /\A[a-zA-Z0-9_-]{1,64}\z/
   abort "Invalid daemon name #{opts[:name].inspect} — use only letters, digits, _ or -"
+end
+
+unless SUPPORTED_BROWSERS.include?(opts[:browser])
+  abort "Unsupported browser #{opts[:browser].inspect} — choose one of: #{SUPPORTED_BROWSERS.join(", ")}"
 end
 
 assigned_name = opts[:name] || Browserctl.next_daemon_name
@@ -31,6 +38,7 @@ warn "browserd starting — log: #{log_path}"
 Browserctl.logger = Browserctl.build_logger(opts[:log_level], log_path: log_path)
 Browserctl::Server.new(
   headless: !opts[:headed],
+  browser: opts[:browser],
   socket_path: Browserctl.socket_path(assigned_name),
   pid_path: Browserctl.pid_path(assigned_name)
 ).run

--- a/bin/browserd
+++ b/bin/browserd
@@ -36,9 +36,13 @@ end
 log_path = Browserctl.log_path(assigned_name)
 warn "browserd starting — log: #{log_path}"
 Browserctl.logger = Browserctl.build_logger(opts[:log_level], log_path: log_path)
-Browserctl::Server.new(
-  headless: !opts[:headed],
-  browser: opts[:browser],
-  socket_path: Browserctl.socket_path(assigned_name),
-  pid_path: Browserctl.pid_path(assigned_name)
-).run
+begin
+  Browserctl::Server.new(
+    headless: !opts[:headed],
+    browser: opts[:browser],
+    socket_path: Browserctl.socket_path(assigned_name),
+    pid_path: Browserctl.pid_path(assigned_name)
+  ).run
+rescue Browserctl::BrowserNotFound => e
+  abort e.message
+end

--- a/bin/browserd
+++ b/bin/browserd
@@ -24,7 +24,7 @@ if opts[:name] && opts[:name] !~ /\A[a-zA-Z0-9_-]{1,64}\z/
 end
 
 unless SUPPORTED_BROWSERS.include?(opts[:browser])
-  abort "Unsupported browser #{opts[:browser].inspect} — choose one of: #{SUPPORTED_BROWSERS.join(", ")}"
+  abort "Unsupported browser #{opts[:browser].inspect} — choose one of: #{SUPPORTED_BROWSERS.join(', ')}"
 end
 
 assigned_name = opts[:name] || Browserctl.next_daemon_name

--- a/browserctl.gemspec
+++ b/browserctl.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.version     = Browserctl::VERSION
   s.summary     = "Persistent browser automation daemon and CLI for AI agents and developer workflows"
   s.description = "Named browser sessions, Ruby workflow DSL, and a token-efficient DOM snapshot format. " \
-                  "Built on Ferrum (Chrome DevTools Protocol)."
+                  "Built on a browser-agnostic driver layer (Ferrum/CDP backend)."
   s.authors     = ["Patrick"]
   s.email       = ["patrick204nqh@gmail.com"]
   s.homepage    = "https://github.com/patrick204nqh/browserctl"

--- a/docs/architecture/decisions/0002-ferrum-cdp-over-selenium.md
+++ b/docs/architecture/decisions/0002-ferrum-cdp-over-selenium.md
@@ -1,7 +1,7 @@
 # ADR-0002: Ferrum/CDP over Selenium/WebDriver
 
 **Date**: 2026-04-20
-**Status**: superseded by ADR-0012
+**Status**: accepted (extended by ADR-0012)
 **Deciders**: Patrick
 
 ## Context

--- a/docs/architecture/decisions/0002-ferrum-cdp-over-selenium.md
+++ b/docs/architecture/decisions/0002-ferrum-cdp-over-selenium.md
@@ -1,7 +1,7 @@
 # ADR-0002: Ferrum/CDP over Selenium/WebDriver
 
 **Date**: 2026-04-20
-**Status**: accepted
+**Status**: superseded by ADR-0012
 **Deciders**: Patrick
 
 ## Context

--- a/docs/architecture/decisions/0012-browser-agnostic-driver.md
+++ b/docs/architecture/decisions/0012-browser-agnostic-driver.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-02
 **Status**: accepted
-**Supersedes**: ADR-0002
+**Extends**: ADR-0002 (Ferrum/CDP remains the implementation; this ADR adds the abstraction layer in front of it)
 **Deciders**: Patrick
 
 ## Context

--- a/docs/architecture/decisions/0012-browser-agnostic-driver.md
+++ b/docs/architecture/decisions/0012-browser-agnostic-driver.md
@@ -1,0 +1,60 @@
+# ADR-0012: Browser-Agnostic Driver Layer
+
+**Date**: 2026-05-02
+**Status**: accepted
+**Supersedes**: ADR-0002
+**Deciders**: Patrick
+
+## Context
+
+Today every handler calls Ferrum APIs directly. No boundary exists between "what the daemon does" and "how Chrome does it". Adding any non-Chrome browser means rewriting all handler files.
+
+Brave support was the immediate trigger: Brave is CDP-compatible and widely used for privacy-conscious browsing, making it a natural fit for browser automation workflows. But the deeper motivation is that the zero-abstraction design made every future browser addition a full codebase rewrite.
+
+## Decision
+
+Introduce `Browserctl::Driver::Base` with `Driver::CDP` as the concrete implementation. Handlers interact with the driver interface; the driver owns the browser library dependency (Ferrum).
+
+### Driver model
+
+One driver per protocol (CDP, WebDriver), not per browser. `Driver::CDP` serves Chrome, Chromium, and Brave — all three are CDP-compatible. A future `Driver::WebDriver` would serve Firefox and Safari via W3C WebDriver.
+
+### Capability flags
+
+Protocol-specific features (e.g. the DevTools inspector URL) are gated behind `driver.supports?(:devtools)` rather than being conditionally implemented per-driver. Unsupported capabilities return `{ error: "..." }` — consistent with the uniform error shape established in ADR-0009.
+
+### What is NOT abstracted
+
+The Unix socket server, `CommandDispatcher` routing, session serialisation, `IdleWatcher`, `Detectors`, and `SnapshotBuilder` are all protocol-agnostic today and remain unchanged.
+
+### Brave binary resolution
+
+`Driver::CDP` resolves the Brave binary from well-known install paths per platform (macOS, Linux, Windows), with an override via the `BRAVE_PATH` environment variable. Chromium resolution follows the same pattern via `CHROMIUM_PATH`. Chrome continues to be found automatically by Ferrum.
+
+## Alternatives Considered
+
+### Keep Ferrum calls in handlers, use `responds_to?` guards
+- **Pros**: Minimal code change
+- **Cons**: Every new browser capability requires touching every handler; no clear extension point; hard to test without a real browser
+- **Why not**: Does not solve the structural problem
+
+### One driver class per browser (ChromeDriver, BraveDriver, ChromiumDriver)
+- **Pros**: Maximum isolation per browser
+- **Cons**: Massive duplication — Brave and Chromium are identical to Chrome at the CDP level; only the binary path differs
+- **Why not**: CDP compatibility means the protocol is shared; differentiating by browser binary is sufficient
+
+## Consequences
+
+### Positive
+- Adding a new browser = add (or configure) a driver subclass; handler files are untouched
+- `Driver::CDP` serves Chrome, Chromium, and Brave from a single implementation
+- The `devtools` command now checks capability before building its URL, making it safe to call on any driver
+- Handlers and tests can use driver doubles without a real browser process
+- Ferrum is an implementation detail of `Driver::CDP`, not a framework-level dependency
+
+### Negative
+- One additional abstraction layer to understand
+- `Driver::CDP` initialises Ferrum in its constructor — tests that call `Driver::CDP.new` directly need a browser binary available
+
+### Risks
+- CDP is a Chrome-internal protocol — breaking changes across Chrome versions remain a risk, mitigated by Ferrum's version tracking (unchanged from ADR-0002)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -41,7 +41,7 @@ Page is always the first argument after the verb.
 | `wait <page> <selector> [--timeout N]` | Wait until selector appears (default: 30s) |
 | `pause <page> [--message MSG]` | Pause automation — browser stays live for manual interaction |
 | `resume <page>` | Resume automation after manual action |
-| `devtools <page>` | Open Chrome DevTools for a named page |
+| `devtools <page>` | Open DevTools for a named page (CDP drivers only) |
 | `press <page> <key>` | Fire a `keydown` + `keyup` event for the given key |
 | `hover <page> <selector>` or `hover <page> --ref <id>` | Move the mouse cursor to the centre of the matched element |
 | `upload <page> <selector> <file>` or `upload <page> --ref <id> <file>` | Set a `<input type="file">` element's value to a file path |
@@ -181,7 +181,7 @@ A session bundles everything needed to resume a browser state: all open pages (n
 |---|---|
 | `daemon ping` | Check if `browserd` is alive — returns `{ ok: true, pid: N, protocol_version: "2" }` |
 | `daemon status` | Show daemon status, PID, and all open pages with their current URLs |
-| `daemon start [--headed] [--name NAME]` | Start a new `browserd` instance in the background |
+| `daemon start [--headed] [--browser chrome|chromium|brave] [--name NAME]` | Start a new `browserd` instance in the background |
 | `daemon stop` | Stop the running `browserd` gracefully |
 | `daemon list` | List all running daemon instances with name, PID, and page count |
 
@@ -208,6 +208,7 @@ When the daemon is not running:
 | `--headed` | headless | Start with a visible browser window |
 | `--name <id>` | auto | Name this daemon instance; if omitted and the default slot is taken, auto-picks `d1`, `d2`, ... |
 | `--log-level <level>` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
+| `--browser <browser>` | `chrome` | Browser to launch: `chrome`, `chromium`, or `brave` |
 
 `browserd` always writes logs to `~/.browserctl/browserd.log` (or `~/.browserctl/<name>.log` for a named instance). The log path is printed to stderr on startup:
 
@@ -312,7 +313,7 @@ Methods available on `page(:name)` inside a workflow:
 | `storage_get(key, store: "local")` | Read a localStorage or sessionStorage key |
 | `storage_set(key, value, store: "local")` | Write a localStorage or sessionStorage key |
 | `delete_cookies` | Delete all cookies for the page |
-| `devtools` | Return the Chrome DevTools URL for this page |
+| `devtools` | Return the DevTools URL for this page (CDP drivers only) |
 | `press(key)` | Fire a `keydown` + `keyup` event for the given key |
 | `hover(selector = nil, ref: nil)` | Move mouse to element by selector or ref |
 | `upload(selector = nil, path = nil, ref: nil)` | Set file input by selector or ref |

--- a/lib/browserctl/detectors.rb
+++ b/lib/browserctl/detectors.rb
@@ -11,7 +11,7 @@ module Browserctl
 
     # Returns true if the page appears to be showing a Cloudflare challenge.
     # Checks both the current URL and the page body for known Cloudflare signals.
-    # @param page [Ferrum::Page] the browser page to inspect
+    # @param page [#current_url, #body] the browser page to inspect
     # @return [Boolean]
     def self.cloudflare?(page)
       url  = page.current_url.to_s

--- a/lib/browserctl/driver.rb
+++ b/lib/browserctl/driver.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative "driver/base"
+require_relative "driver/cdp_page"
+require_relative "driver/cdp"

--- a/lib/browserctl/driver/base.rb
+++ b/lib/browserctl/driver/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Driver
+    class Base
+      def create_page   = raise NotImplementedError, "#{self.class.name}#create_page not implemented"
+      def quit          = raise NotImplementedError, "#{self.class.name}#quit not implemented"
+      def headed?       = raise NotImplementedError, "#{self.class.name}#headed? not implemented"
+      def supports?(_)  = false
+      def devtools_info(_page) = raise NotImplementedError, "#{self.class.name}#devtools_info not implemented"
+    end
+  end
+end

--- a/lib/browserctl/driver/cdp.rb
+++ b/lib/browserctl/driver/cdp.rb
@@ -3,6 +3,7 @@
 require "ferrum"
 require_relative "base"
 require_relative "cdp_page"
+require_relative "../errors"
 
 module Browserctl
   module Driver
@@ -60,7 +61,9 @@ module Browserctl
           browser_options: { "disable-dev-shm-usage" => nil, "disable-gpu" => nil }
         }
 
-        opts[:browser_path] = resolve_browser_path if @browser != "chrome"
+        if @browser != "chrome" && (path = resolve_browser_path)
+          opts[:browser_path] = path
+        end
 
         if ENV["CI"] || ENV["BROWSERCTL_NO_SANDBOX"]
           Browserctl.logger.warn "no-sandbox enabled (CI or BROWSERCTL_NO_SANDBOX set)"
@@ -83,20 +86,31 @@ module Browserctl
       end
 
       def resolve_chromium_path
-        ENV["CHROMIUM_PATH"] if ENV["CHROMIUM_PATH"]
-        # Ferrum finds Chromium automatically on most platforms; return nil to let it do so
-        nil
+        env_override("CHROMIUM_PATH")
+        # Returns nil when no override — Ferrum finds Chromium automatically on most platforms.
       end
 
       def resolve_brave_path
-        return ENV["BRAVE_PATH"] if ENV["BRAVE_PATH"]
+        override = env_override("BRAVE_PATH")
+        return override if override
 
         platform = detect_platform
         candidates = BRAVE_PATHS.fetch(platform, [])
         path = candidates.find { |p| File.executable?(p) }
-        abort "Brave browser not found. Install Brave or set BRAVE_PATH to its executable." unless path
+        unless path
+          raise BrowserNotFound,
+                "Brave browser not found. Install Brave or set BRAVE_PATH to its executable."
+        end
 
         path
+      end
+
+      def env_override(var)
+        value = ENV.fetch(var, nil)
+        return nil if value.nil? || value.empty?
+        raise BrowserNotFound, "#{var}=#{value} is not an executable file" unless File.executable?(value)
+
+        value
       end
 
       def detect_platform

--- a/lib/browserctl/driver/cdp.rb
+++ b/lib/browserctl/driver/cdp.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "ferrum"
+require_relative "base"
+require_relative "cdp_page"
+
+module Browserctl
+  module Driver
+    class CDP < Base
+      BRAVE_PATHS = {
+        darwin: [
+          "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+          File.expand_path("~/Applications/Brave Browser.app/Contents/MacOS/Brave Browser")
+        ],
+        linux: [
+          "/usr/bin/brave-browser",
+          "/usr/bin/brave",
+          "/snap/bin/brave"
+        ],
+        windows: [
+          "C:/Program Files/BraveSoftware/Brave-Browser/Application/brave.exe",
+          "C:/Program Files (x86)/BraveSoftware/Brave-Browser/Application/brave.exe"
+        ]
+      }.freeze
+
+      def initialize(headless: true, browser: "chrome") # rubocop:disable Lint/MissingSuper
+        @headless = headless
+        @browser  = browser
+        @ferrum   = Ferrum::Browser.new(**ferrum_options)
+      end
+
+      def create_page
+        CDPPage.new(@ferrum.create_page)
+      end
+
+      def quit
+        @ferrum.quit
+      end
+
+      def headed?
+        !@headless
+      end
+
+      def supports?(capability)
+        capability == :devtools
+      end
+
+      def devtools_info(page)
+        port      = @ferrum.process.port
+        target_id = page.target_id
+        { port: port, target_id: target_id }
+      end
+
+      private
+
+      def ferrum_options
+        opts = {
+          timeout: 30,
+          process_timeout: 30,
+          browser_options: { "disable-dev-shm-usage" => nil, "disable-gpu" => nil }
+        }
+
+        opts[:browser_path] = resolve_browser_path if @browser != "chrome"
+
+        if ENV["CI"] || ENV["BROWSERCTL_NO_SANDBOX"]
+          Browserctl.logger.warn "no-sandbox enabled (CI or BROWSERCTL_NO_SANDBOX set)"
+          opts[:browser_options]["no-sandbox"] = nil
+        end
+
+        opts[:headless] = @headless
+        opts
+      end
+
+      def resolve_browser_path
+        case @browser
+        when "chromium"
+          resolve_chromium_path
+        when "brave"
+          resolve_brave_path
+        else
+          raise ArgumentError, "Unknown browser: #{@browser.inspect}"
+        end
+      end
+
+      def resolve_chromium_path
+        ENV["CHROMIUM_PATH"] if ENV["CHROMIUM_PATH"]
+        # Ferrum finds Chromium automatically on most platforms; return nil to let it do so
+        nil
+      end
+
+      def resolve_brave_path
+        return ENV["BRAVE_PATH"] if ENV["BRAVE_PATH"]
+
+        platform = detect_platform
+        candidates = BRAVE_PATHS.fetch(platform, [])
+        path = candidates.find { |p| File.executable?(p) }
+        abort "Brave browser not found. Install Brave or set BRAVE_PATH to its executable." unless path
+
+        path
+      end
+
+      def detect_platform
+        case RUBY_PLATFORM
+        when /darwin/              then :darwin
+        when /mingw|mswin|windows/ then :windows
+        else                            :linux
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/driver/cdp_page.rb
+++ b/lib/browserctl/driver/cdp_page.rb
@@ -4,8 +4,11 @@ require "delegate"
 
 module Browserctl
   module Driver
+    # Wraps a Ferrum::Page so handlers receive a driver-namespaced object instead of
+    # a raw Ferrum type. Currently a transparent delegator — the seam exists so future
+    # CDP-specific behaviour (capability checks, instrumentation) can live here without
+    # touching every handler. Delete this class if no override lands by the next driver.
     class CDPPage < SimpleDelegator
-      # All Ferrum::Page methods delegated automatically.
     end
   end
 end

--- a/lib/browserctl/driver/cdp_page.rb
+++ b/lib/browserctl/driver/cdp_page.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "delegate"
+
+module Browserctl
+  module Driver
+    class CDPPage < SimpleDelegator
+      # All Ferrum::Page methods delegated automatically.
+    end
+  end
+end

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -23,6 +23,7 @@ module Browserctl
   class TimeoutError     < Error; def self.default_code = "timeout"            end
   class KeyNotFound < Error; def self.default_code = "key_not_found" end
   class DaemonUnavailableError < Error; def self.default_code = "daemon_unavailable" end
+  class BrowserNotFound < Error; def self.default_code = "browser_not_found" end
 
   class WorkflowError < Error; def self.default_code = "workflow_error" end
   class SecretResolverError < WorkflowError; def self.default_code = "secret_resolver_error" end

--- a/lib/browserctl/server.rb
+++ b/lib/browserctl/server.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-require "ferrum"
 require "socket"
 require "json"
 require "fileutils"
 require "timeout"
 require_relative "constants"
 require_relative "logger"
+require_relative "driver"
 require_relative "server/command_dispatcher"
 require_relative "server/idle_watcher"
 require_relative "server/page_session"
 
 module Browserctl
   class Server
-    def initialize(headless: true, socket_path: SOCKET_PATH, pid_path: PID_PATH)
+    def initialize(headless: true, browser: "chrome", socket_path: SOCKET_PATH, pid_path: PID_PATH)
       @socket_path = socket_path
       @pid_path    = pid_path
-      prepare_runtime(headless)
-      @dispatcher = CommandDispatcher.new(@pages, @browser, global_mutex: @mutex)
+      prepare_runtime(headless, browser)
+      @dispatcher = CommandDispatcher.new(@pages, @driver, global_mutex: @mutex)
     end
 
     def run
@@ -33,24 +33,10 @@ module Browserctl
 
     private
 
-    def prepare_runtime(headless)
+    def prepare_runtime(headless, browser)
       FileUtils.mkdir_p(File.dirname(@socket_path))
-      @browser = init_browser(headless)
+      @driver = Driver::CDP.new(headless: headless, browser: browser)
       init_state
-    end
-
-    def init_browser(headless)
-      Ferrum::Browser.new(headless: headless, **ferrum_options)
-    end
-
-    def ferrum_options
-      opts = { timeout: 30, process_timeout: 30,
-               browser_options: { "disable-dev-shm-usage" => nil, "disable-gpu" => nil } }
-      if ENV["CI"] || ENV["BROWSERCTL_NO_SANDBOX"]
-        Browserctl.logger.warn "no-sandbox enabled (CI or BROWSERCTL_NO_SANDBOX set)"
-        opts[:browser_options]["no-sandbox"] = nil
-      end
-      opts
     end
 
     def init_state
@@ -119,7 +105,7 @@ module Browserctl
     def teardown(idle, server)
       idle&.kill
       quietly { server&.close }
-      quietly { Timeout.timeout(5) { @browser.quit } }
+      quietly { Timeout.timeout(5) { @driver.quit } }
       quietly { File.unlink(@socket_path) }
       quietly { File.unlink(@pid_path) }
     end

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -73,9 +73,9 @@ module Browserctl
     SCREENSHOT_ROOTS = [SCREENSHOT_DIR, File.expand_path(".")].freeze
     SCREENSHOT_EXTS  = %w[.png .jpg .jpeg].freeze
 
-    def initialize(pages, browser, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
+    def initialize(pages, driver, snapshot_builder = SnapshotBuilder.new, global_mutex: Mutex.new)
       @pages            = pages
-      @browser          = browser
+      @driver           = driver
       @snapshot_builder = snapshot_builder
       @global_mutex     = global_mutex
       @kv_store         = {}

--- a/lib/browserctl/server/handlers/devtools.rb
+++ b/lib/browserctl/server/handlers/devtools.rb
@@ -7,11 +7,14 @@ module Browserctl
         private
 
         def cmd_devtools(req)
+          return { error: "devtools is not supported by this driver" } unless @driver.supports?(:devtools)
+
           session = @global_mutex.synchronize { @pages[req[:name]] }
           return { error: "no page named '#{req[:name]}'" } unless session
 
-          port      = @browser.process.port
-          target_id = session.page.target_id
+          info      = @driver.devtools_info(session.page)
+          port      = info[:port]
+          target_id = info[:target_id]
           devtools_url = "http://127.0.0.1:#{port}/devtools/inspector.html" \
                          "?ws=127.0.0.1:#{port}/devtools/page/#{target_id}"
           { ok: true, devtools_url: devtools_url }

--- a/lib/browserctl/server/handlers/page_lifecycle.rb
+++ b/lib/browserctl/server/handlers/page_lifecycle.rb
@@ -8,7 +8,7 @@ module Browserctl
 
         def cmd_page_open(req)
           session = @global_mutex.synchronize do
-            @pages[req[:name]] ||= PageSession.new(@browser.create_page)
+            @pages[req[:name]] ||= PageSession.new(@driver.create_page)
           end
           session.page.go_to(req[:url]) if req[:url]
           { ok: true, name: req[:name] }
@@ -25,9 +25,7 @@ module Browserctl
         end
 
         def cmd_page_focus(req)
-          unless @browser.options.headless == false
-            return { error: "page focus requires headed mode — start browserd with --headed" }
-          end
+          return { error: "page focus requires headed mode — start browserd with --headed" } unless @driver.headed?
 
           with_page(req[:name]) do |session|
             session.page.activate

--- a/lib/browserctl/server/handlers/session.rb
+++ b/lib/browserctl/server/handlers/session.rb
@@ -47,7 +47,7 @@ module Browserctl
             if existing
               existing.page.go_to(page_data[:url])
             else
-              new_page = @browser.create_page
+              new_page = @driver.create_page
               new_page.go_to(page_data[:url])
               @global_mutex.synchronize { @pages[page_name.to_s] = PageSession.new(new_page) }
             end
@@ -61,7 +61,7 @@ module Browserctl
           data[:local_storage].each do |origin, keys|
             next if keys.empty?
 
-            tmp_page = @browser.create_page
+            tmp_page = @driver.create_page
             begin
               tmp_page.go_to(origin)
               keys.each do |k, v|

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -6,10 +6,10 @@ require "browserctl/server/snapshot_builder"
 require "browserctl/server/page_session"
 
 RSpec.describe Browserctl::CommandDispatcher do
-  let(:browser)    { double("browser") }
+  let(:driver)     { double("driver") }
   let(:pages)      { {} }
   let(:snapshot)   { instance_double(Browserctl::SnapshotBuilder) }
-  subject(:dispatcher) { described_class.new(pages, browser, snapshot) }
+  subject(:dispatcher) { described_class.new(pages, driver, snapshot) }
 
   describe "#dispatch" do
     it "returns error for unknown command" do
@@ -34,7 +34,7 @@ RSpec.describe Browserctl::CommandDispatcher do
 
     it "page_open creates and stores a page" do
       page = double("page")
-      allow(browser).to receive(:create_page).and_return(page)
+      allow(driver).to receive(:create_page).and_return(page)
       result = dispatcher.dispatch({ cmd: "page_open", name: "home" })
       expect(result).to eq({ ok: true, name: "home" })
       expect(pages["home"]).to be_a(Browserctl::PageSession)
@@ -43,7 +43,7 @@ RSpec.describe Browserctl::CommandDispatcher do
 
     it "page_open navigates to url when given" do
       page = double("page")
-      allow(browser).to receive(:create_page).and_return(page)
+      allow(driver).to receive(:create_page).and_return(page)
       expect(page).to receive(:go_to).with("http://example.com")
       dispatcher.dispatch({ cmd: "page_open", name: "home", url: "http://example.com" })
     end
@@ -76,7 +76,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     let(:html) { '<html><body><input name="email"><button>Go</button></body></html>' }
     let(:page) { instance_double("Ferrum::Page", body: html, current_url: "https://example.com") }
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+    subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
     before do
       dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
@@ -111,7 +111,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     let(:html_v2) { '<html><body><button id="a">A</button><button id="b">B</button></body></html>' }
     let(:page)    { instance_double("Ferrum::Page", current_url: "https://example.com") }
     let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+    subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
     it "returns full snapshot on first call with diff: true (no previous)" do
       allow(page).to receive(:body).and_return(html_v1)
@@ -140,7 +140,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   describe "#cmd_screenshot" do
     let(:page)  { instance_double("Ferrum::Page") }
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+    subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
     it "rejects paths outside the allowed screenshot directory" do
       res = dispatcher.dispatch({ cmd: "screenshot", name: "main",
@@ -184,7 +184,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   describe "#cmd_wait" do
     let(:page)  { instance_double("Ferrum::Page") }
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+    subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
     it "returns ok with selector when element appears" do
       call_count = 0
@@ -208,7 +208,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     let(:html) { '<html><body><input name="q"><button>Search</button></body></html>' }
     let(:page) { instance_double("Ferrum::Page", body: html, current_url: "https://example.com") }
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+    subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
     it 'returns elements snapshot for format: "elements"' do
       res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
@@ -227,7 +227,7 @@ RSpec.describe Browserctl::CommandDispatcher do
 
   describe "Cloudflare challenge detection" do
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+    subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
     context "when snapshot detects challenge page" do
       let(:cf_html) { '<html><body class="cf-challenge-running">Just a moment...</body></html>' }
@@ -277,7 +277,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   describe "#cmd_pause and #cmd_resume" do
     let(:page)  { instance_double("Ferrum::Page") }
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+    subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
     it "pause returns ok and marks page as paused" do
       res = dispatcher.dispatch({ cmd: "pause", name: "main" })
@@ -322,7 +322,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   describe "plugin commands" do
     let(:page)  { instance_double("Ferrum::Page") }
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, double("browser")) }
+    subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
     after { Browserctl.instance_variable_set(:@plugin_commands, {}) }
 
@@ -365,7 +365,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     end
     let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
     let(:builder) { Browserctl::SnapshotBuilder.new }
-    subject(:dispatcher) { described_class.new(pages, double("browser"), builder) }
+    subject(:dispatcher) { described_class.new(pages, double("driver"), builder) }
 
     it "stores ref registry after ai snapshot" do
       dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
@@ -415,32 +415,39 @@ RSpec.describe Browserctl::CommandDispatcher do
   end
 
   describe "#cmd_devtools" do
-    let(:browser) { double("browser") }
-    let(:page)    { instance_double("Ferrum::Page") }
-    let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, browser) }
+    let(:driver) { double("driver") }
+    let(:page)   { instance_double("Ferrum::Page") }
+    let(:pages)  { { "main" => Browserctl::PageSession.new(page) } }
+    subject(:dispatcher) { described_class.new(pages, driver) }
 
-    it "returns a devtools_url for a known page" do
-      allow(browser).to receive_message_chain(:process, :port).and_return(9222)
-      allow(page).to receive(:target_id).and_return("ABCD1234")
+    it "returns a devtools_url for a known page when driver supports devtools" do
+      allow(driver).to receive(:supports?).with(:devtools).and_return(true)
+      allow(driver).to receive(:devtools_info).with(page).and_return({ port: 9222, target_id: "ABCD1234" })
       res = dispatcher.dispatch({ cmd: "devtools", name: "main" })
       expect(res[:ok]).to be true
       expect(res[:devtools_url]).to include("9222")
       expect(res[:devtools_url]).to include("ABCD1234")
     end
 
+    it "returns error when driver does not support devtools" do
+      allow(driver).to receive(:supports?).with(:devtools).and_return(false)
+      res = dispatcher.dispatch({ cmd: "devtools", name: "main" })
+      expect(res[:error]).to match(/not supported by this driver/)
+    end
+
     it "returns error for unknown page" do
+      allow(driver).to receive(:supports?).with(:devtools).and_return(true)
       res = dispatcher.dispatch({ cmd: "devtools", name: "ghost" })
       expect(res[:error]).to match(/no page named 'ghost'/)
     end
   end
 
   describe "#cmd_cookies / #cmd_set_cookie / #cmd_delete_cookies" do
-    let(:browser) { double("browser") }
+    let(:driver)  { double("driver") }
     let(:page)    { instance_double("Ferrum::Page") }
     let(:cookies) { double("cookies") }
     let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
-    subject(:dispatcher) { described_class.new(pages, browser) }
+    subject(:dispatcher) { described_class.new(pages, driver) }
 
     before { allow(page).to receive(:cookies).and_return(cookies) }
 

--- a/spec/unit/driver_base_spec.rb
+++ b/spec/unit/driver_base_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/driver/base"
+
+RSpec.describe Browserctl::Driver::Base do
+  subject(:driver) { described_class.new }
+
+  it "raises NotImplementedError for #create_page" do
+    expect { driver.create_page }.to raise_error(NotImplementedError, /create_page/)
+  end
+
+  it "raises NotImplementedError for #quit" do
+    expect { driver.quit }.to raise_error(NotImplementedError, /quit/)
+  end
+
+  it "raises NotImplementedError for #headed?" do
+    expect { driver.headed? }.to raise_error(NotImplementedError, /headed\?/)
+  end
+
+  it "raises NotImplementedError for #devtools_info" do
+    expect { driver.devtools_info(double("page")) }.to raise_error(NotImplementedError, /devtools_info/)
+  end
+
+  it "returns false for #supports? any capability" do
+    expect(driver.supports?(:devtools)).to be false
+    expect(driver.supports?(:anything)).to be false
+  end
+end

--- a/spec/unit/driver_cdp_page_spec.rb
+++ b/spec/unit/driver_cdp_page_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/driver/cdp_page"
+
+RSpec.describe Browserctl::Driver::CDPPage do
+  let(:underlying) { double("ferrum_page", current_url: "https://example.com", title: "Example", target_id: "ABC123") }
+  subject(:cdp_page) { described_class.new(underlying) }
+
+  it "delegates #current_url to underlying page" do
+    expect(cdp_page.current_url).to eq("https://example.com")
+  end
+
+  it "delegates #title to underlying page" do
+    expect(cdp_page.title).to eq("Example")
+  end
+
+  it "delegates #target_id to underlying page" do
+    expect(cdp_page.target_id).to eq("ABC123")
+  end
+
+  it "wraps the underlying object via SimpleDelegator" do
+    expect(cdp_page.__getobj__).to eq(underlying)
+  end
+end

--- a/spec/unit/driver_cdp_spec.rb
+++ b/spec/unit/driver_cdp_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/driver/cdp"
+
+RSpec.describe Browserctl::Driver::CDP do
+  describe "#supports?" do
+    it "returns true for :devtools" do
+      # Avoid actually launching a browser by not calling new directly;
+      # test the method in isolation via a partial double
+      driver = described_class.allocate
+      expect(driver.supports?(:devtools)).to be true
+    end
+
+    it "returns false for unknown capabilities" do
+      driver = described_class.allocate
+      expect(driver.supports?(:webdriver)).to be false
+      expect(driver.supports?(:something_else)).to be false
+    end
+  end
+
+  describe "#headed?" do
+    it "returns false when headless: true" do
+      driver = described_class.allocate
+      driver.instance_variable_set(:@headless, true)
+      expect(driver.headed?).to be false
+    end
+
+    it "returns true when headless: false" do
+      driver = described_class.allocate
+      driver.instance_variable_set(:@headless, false)
+      expect(driver.headed?).to be true
+    end
+  end
+
+  describe "resolve_brave_path (private)" do
+    let(:driver) { described_class.allocate }
+
+    it "returns BRAVE_PATH env var when set" do
+      with_env("BRAVE_PATH" => "/custom/brave") do
+        expect(driver.send(:resolve_brave_path)).to eq("/custom/brave")
+      end
+    end
+
+    it "aborts when no Brave binary is found and BRAVE_PATH is not set" do
+      with_env("BRAVE_PATH" => nil) do
+        # Stub all candidate paths to be non-executable
+        allow(File).to receive(:executable?).and_return(false)
+        expect { driver.send(:resolve_brave_path) }.to raise_error(SystemExit)
+      end
+    end
+  end
+
+  describe "detect_platform (private)" do
+    let(:driver) { described_class.allocate }
+
+    it "returns :darwin on macOS" do
+      stub_const("RUBY_PLATFORM", "x86_64-darwin21")
+      expect(driver.send(:detect_platform)).to eq(:darwin)
+    end
+
+    it "returns :linux on Linux" do
+      stub_const("RUBY_PLATFORM", "x86_64-linux")
+      expect(driver.send(:detect_platform)).to eq(:linux)
+    end
+
+    it "returns :windows on Windows" do
+      stub_const("RUBY_PLATFORM", "x64-mingw32")
+      expect(driver.send(:detect_platform)).to eq(:windows)
+    end
+  end
+end

--- a/spec/unit/driver_cdp_spec.rb
+++ b/spec/unit/driver_cdp_spec.rb
@@ -36,17 +36,51 @@ RSpec.describe Browserctl::Driver::CDP do
   describe "resolve_brave_path (private)" do
     let(:driver) { described_class.allocate }
 
-    it "returns BRAVE_PATH env var when set" do
+    it "returns BRAVE_PATH env var when it points to an executable" do
       with_env("BRAVE_PATH" => "/custom/brave") do
+        allow(File).to receive(:executable?).with("/custom/brave").and_return(true)
         expect(driver.send(:resolve_brave_path)).to eq("/custom/brave")
       end
     end
 
-    it "aborts when no Brave binary is found and BRAVE_PATH is not set" do
+    it "raises BrowserNotFound when BRAVE_PATH is set but not executable" do
+      with_env("BRAVE_PATH" => "/typo/brave") do
+        allow(File).to receive(:executable?).with("/typo/brave").and_return(false)
+        expect { driver.send(:resolve_brave_path) }
+          .to raise_error(Browserctl::BrowserNotFound, /not an executable/)
+      end
+    end
+
+    it "raises BrowserNotFound when no Brave binary is found and BRAVE_PATH is not set" do
       with_env("BRAVE_PATH" => nil) do
-        # Stub all candidate paths to be non-executable
         allow(File).to receive(:executable?).and_return(false)
-        expect { driver.send(:resolve_brave_path) }.to raise_error(SystemExit)
+        expect { driver.send(:resolve_brave_path) }
+          .to raise_error(Browserctl::BrowserNotFound, /Brave browser not found/)
+      end
+    end
+  end
+
+  describe "resolve_chromium_path (private)" do
+    let(:driver) { described_class.allocate }
+
+    it "returns CHROMIUM_PATH env var when it points to an executable" do
+      with_env("CHROMIUM_PATH" => "/custom/chromium") do
+        allow(File).to receive(:executable?).with("/custom/chromium").and_return(true)
+        expect(driver.send(:resolve_chromium_path)).to eq("/custom/chromium")
+      end
+    end
+
+    it "returns nil when CHROMIUM_PATH is not set" do
+      with_env("CHROMIUM_PATH" => nil) do
+        expect(driver.send(:resolve_chromium_path)).to be_nil
+      end
+    end
+
+    it "raises BrowserNotFound when CHROMIUM_PATH is set but not executable" do
+      with_env("CHROMIUM_PATH" => "/typo/chromium") do
+        allow(File).to receive(:executable?).with("/typo/chromium").and_return(false)
+        expect { driver.send(:resolve_chromium_path) }
+          .to raise_error(Browserctl::BrowserNotFound, /not an executable/)
       end
     end
   end

--- a/spec/unit/page_lifecycle_spec.rb
+++ b/spec/unit/page_lifecycle_spec.rb
@@ -8,21 +8,20 @@ require "browserctl/server/page_session"
 RSpec.describe "page_focus" do
   let(:pages) { {} }
 
-  def make_dispatcher(headless:)
-    opts    = double("options", headless: headless)
-    browser = double("browser", options: opts)
-    Browserctl::CommandDispatcher.new(pages, browser, Browserctl::SnapshotBuilder.new)
+  def make_dispatcher(headed:)
+    driver = double("driver", headed?: headed)
+    Browserctl::CommandDispatcher.new(pages, driver, Browserctl::SnapshotBuilder.new)
   end
 
   it "returns error in headless mode" do
-    dispatcher = make_dispatcher(headless: true)
+    dispatcher = make_dispatcher(headed: false)
     pages["p"] = Browserctl::PageSession.new(double("page"))
     res = dispatcher.dispatch({ cmd: "page_focus", name: "p" })
     expect(res[:error]).to match(/headed mode/)
   end
 
   it "calls page.activate in headed mode" do
-    dispatcher = make_dispatcher(headless: false)
+    dispatcher = make_dispatcher(headed: true)
     page       = double("page")
     pages["p"] = Browserctl::PageSession.new(page)
     expect(page).to receive(:activate)
@@ -31,7 +30,7 @@ RSpec.describe "page_focus" do
   end
 
   it "returns error for missing page" do
-    dispatcher = make_dispatcher(headless: false)
+    dispatcher = make_dispatcher(headed: true)
     res = dispatcher.dispatch({ cmd: "page_focus", name: "missing" })
     expect(res[:error]).to match(/no page named 'missing'/)
   end


### PR DESCRIPTION
## Summary

- Introduces `Driver::Base` and `Driver::CDP` to decouple all daemon handlers from Ferrum. Handlers now call the driver interface; `Driver::CDP` owns the Ferrum dependency.
- Adds Brave browser support via the `--browser brave` flag on `browserd`. Chrome, Chromium, and Brave are all served by `Driver::CDP` (they share the CDP protocol). Brave binary is resolved from well-known install paths per platform, with a `BRAVE_PATH` env override.

## Driver model

One driver per protocol, not per browser. `Driver::CDP` serves Chrome, Chromium, and Brave. A future `Driver::WebDriver` would serve Firefox/Safari via W3C WebDriver without touching any handler code.

Protocol-specific capabilities (e.g. DevTools inspector URL) are gated behind `driver.supports?(:devtools)` and return a structured error when unsupported, consistent with ADR-0009.

## What changed

**New files**
- `lib/browserctl/driver.rb` — loader
- `lib/browserctl/driver/base.rb` — abstract interface
- `lib/browserctl/driver/cdp.rb` — CDP concrete driver (Chrome/Chromium/Brave)
- `lib/browserctl/driver/cdp_page.rb` — thin `SimpleDelegator` wrapper around `Ferrum::Page`
- `docs/architecture/decisions/0012-browser-agnostic-driver.md` — ADR recording the decision

**Updated**
- `lib/browserctl/server.rb` — accepts `browser:` kwarg, creates `Driver::CDP`, removes Ferrum require
- `lib/browserctl/server/command_dispatcher.rb` — `browser` param renamed to `driver`
- `lib/browserctl/server/handlers/devtools.rb` — checks `driver.supports?(:devtools)`, uses `driver.devtools_info`
- `lib/browserctl/server/handlers/page_lifecycle.rb` — `@browser.create_page` → `@driver.create_page`; `@browser.options.headless` → `@driver.headed?`
- `lib/browserctl/server/handlers/session.rb` — `@browser.create_page` → `@driver.create_page`
- `bin/browserd` — adds `--browser` flag with validation
- `docs/reference/commands.md`, `CONTRIBUTING.md`, `browserctl.gemspec`, `lib/browserctl/detectors.rb` — browser-agnostic language updates
- `docs/architecture/decisions/0002-ferrum-cdp-over-selenium.md` — marked superseded by ADR-0012

## Test plan

- [ ] `bundle exec rspec spec/unit/` — all 296+ unit tests pass (verified locally)
- [ ] `bundle exec rspec spec/unit/driver_base_spec.rb` — Base stubs raise `NotImplementedError`; `supports?` returns false
- [ ] `bundle exec rspec spec/unit/driver_cdp_page_spec.rb` — CDPPage delegates to underlying Ferrum page
- [ ] `bundle exec rspec spec/unit/driver_cdp_spec.rb` — CDP supports/headed?/platform detection/Brave path resolution
- [ ] `bundle exec rspec spec/unit/command_dispatcher_spec.rb` — devtools handler returns error when driver doesn't support `:devtools`; happy path with correct URL
- [ ] `bundle exec rspec spec/unit/page_lifecycle_spec.rb` — page_focus uses `driver.headed?` interface
- [ ] Manual: `browserd --browser brave` launches Brave on a machine with Brave installed
- [ ] Manual: `browserd --browser invalid` aborts with a helpful error
- [ ] Manual: `BRAVE_PATH=/path/to/brave browserd --browser brave` uses the override