### PR TITLE
docs: refocus roadmap on flows, replayable, and stability

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,16 @@
+# Execution plans
+
+Per-milestone PR-sized breakdowns. Strategy lives in `../vision.md`; this directory is how we run it.
+
+| Plan | Theme | Status |
+|------|-------|--------|
+| [v0.10 — Flows](v0.10-flows.md) | Reusable flow DSL, unified `state`, auth re-detection | Not started |
+| [v0.11 — Replayable](v0.11-replayable.md) | Stable refs, fingerprint self-healing, recording → workflow → flow pipeline | Blocked on v0.10 |
+| [v0.12 — Solid](v0.12-solid.md) | Versioned formats, error model, observability, test pyramid, perf budgets | Blocked on v0.11 |
+
+Each plan file follows the same shape: goal · non-goals · dependencies · workstreams (each = a stack of PRs with file paths and acceptance criteria) · ADRs to write · breaking changes log · milestone acceptance · open questions · sequencing diagram.
+
+When a milestone closes:
+1. Tick the "done" checklist in its plan file.
+2. Move the strategy entry in `../vision.md` from `[ ]` to `✓ _(shipped)_`.
+3. Leave the plan file in place as historical record.

--- a/docs/plans/v0.10-flows.md
+++ b/docs/plans/v0.10-flows.md
@@ -1,0 +1,146 @@
+# v0.10 — Flows: execution plan
+
+> Companion to the v0.10 entry in `../vision.md`. This file is the per-PR breakdown.
+
+## Goal
+
+Ship reusable, parameterised, secret-aware browser flows; collapse cookie/storage management into a single `state` command; let the daemon detect expired auth and re-run the bound flow automatically.
+
+## Non-goals (this milestone)
+
+- Recording → workflow → flow promotion pipeline (that's v0.11).
+- Stable refs / fingerprints (v0.11).
+- MCP server (parked).
+- Remote / cloud daemon (parked).
+
+## Dependencies
+
+- v0.9 driver abstraction is on `main`. ✓
+- Existing secret resolver (env / keychain / 1Password) — already in v0.8. ✓
+- Existing session save/load — wraps under new `state` command in WS-4.
+
+## Workstreams
+
+Each workstream is a stack of PRs. WS-1 → WS-2 → WS-3 are sequential. WS-4 and WS-5 can land in parallel after WS-1.
+
+---
+
+### WS-1 · Flow DSL primitives
+
+**Outcome:** A flow can be defined and executed in isolation, no registry yet.
+
+PRs:
+1. **`feat: Browserctl::Flow class + DSL`** — `lib/browserctl/flow.rb`. Methods: `version`, `desc`, `param`, `step`, `precondition`, `postcondition`, `produces_state`. Mirror existing workflow DSL where it makes sense.
+2. **`feat: flow execution`** — `Flow#run(params)`. Resolves `secret_ref:` params via the existing resolver. Runs precondition → steps → postcondition. Raises typed errors on failure.
+3. **`test: flow unit specs`** — `spec/unit/flow_spec.rb`. Cover param coercion, secret resolution, pre/post short-circuit, error paths.
+
+Acceptance: a hand-written `flow.rb` file can be loaded with `require` and executed via `flow.run(username: "...", password: "...")`.
+
+---
+
+### WS-2 · Flow registry & invocation
+
+**Outcome:** Flows discoverable by name from CLI and from inside workflows.
+
+PRs:
+4. **`feat: flow registry`** — `lib/browserctl/flow_registry.rb`. Auto-load order: `./.browserctl/flows/*.rb` → `~/.browserctl/flows/*.rb` → bundled stdlib. Project wins ties.
+5. **`feat: invoke from workflow DSL`** — `invoke :flow_name, **params` inside a workflow runs the registered flow against the current page proxy.
+6. **`feat: CLI commands`** — `browserctl flow run/list/describe`. `bin/browserctl/commands/flow.rb`.
+
+Acceptance: `browserctl flow list` shows a stdlib flow; `browserctl flow run github_login` works against a live page.
+
+---
+
+### WS-3 · Stdlib flows
+
+**Outcome:** Six flows shipped in the gem, exercising the DSL on real surfaces.
+
+PRs:
+7. **`feat: stdlib flow — totp_2fa`** — generic TOTP given a secret. Smallest, no network. Lives in `lib/browserctl/flows/stdlib/totp_2fa.rb`.
+8. **`feat: stdlib flows — basic_auth, magic_link_email`** — basic_auth handles HTTP basic prompts; magic_link_email pauses for the link, navigates.
+9. **`feat: stdlib flows — oauth_google, oauth_github`** — consent screen flows. Each gets a smoke spec with mocked navigation.
+10. **`feat: stdlib flow — cloudflare_solve`** — pause + HITL signal + cookie capture. Reuses existing detector.
+
+Acceptance: every stdlib flow has a unit spec + a documented invocation example in `docs/guides/`.
+
+---
+
+### WS-4 · Unified `state` command + `.bctl` bundle
+
+**Outcome:** One verb for all auth-state management; portable encrypted bundle.
+
+PRs:
+11. **`feat: .bctl bundle codec`** — `lib/browserctl/state/bundle.rb`. Manifest + cookies + localStorage + sessionStorage + (optional) IndexedDB, HMAC-signed, optional passphrase encryption. Reuses v0.8 encryption primitives.
+12. **`feat: state save/load/list/info/delete`** — `bin/browserctl/commands/state.rb`. Wraps existing session save/load under origin-scoped semantics.
+13. **`feat: state export/import with transports`** — file (default), `s3://`, `op://`. Pluggable transport interface.
+14. **`feat: state rotate`** — invokes the bound flow (from manifest) to refresh a stale bundle.
+15. **`docs: state vs session vs cookie`** — `docs/concepts/state.md` explains the new top-level concept; `cookie *` and `storage *` documented as low-level escape hatches.
+
+Acceptance: `browserctl state save github && browserctl state load github` round-trips on a fresh daemon. `state info github` reports origin, expiry, source flow, size.
+
+---
+
+### WS-5 · Auth re-detection
+
+**Outcome:** Daemon notices expired auth; CLI surfaces it; workflows recover automatically.
+
+PRs:
+16. **`feat: auth_required detector`** — `lib/browserctl/detectors/auth_required.rb`. Triggers on cookie expiry, login-path redirects (`/login`, `/signin`, `/auth`), 401/403 from page network log. Pluggable (registers via existing `Browserctl::Detectors`).
+17. **`feat: structured error code AUTH_REQUIRED`** — daemon JSON response carries `{code: "AUTH_REQUIRED", state: "...", suggested_flow: "..."}`. CLI exit code `7`.
+18. **`feat: load_state auto re-run`** — when `load_state :github` finds an expired bundle and the manifest names a flow, run the flow, save fresh bundle, continue. New `on_auth_required` workflow hook for explicit override.
+
+Acceptance: a workflow that calls `load_state :github` with a deliberately expired cookie automatically re-authenticates via the bound flow without user code change.
+
+---
+
+### WS-6 · Skill update
+
+**Outcome:** AI agents using the `automate` skill know about flows, state, and auth recovery.
+
+PRs:
+19. **`docs: automate skill — flows section`** — `.claude-plugin/skills/automate/SKILL.md`. Add: "If auth is needed, prefer `flow run <name>` over hand-coded login steps. State persists across sessions via `state save/load`. Exit code 7 means run a flow."
+20. **`docs: automate skill — examples`** — three concrete examples showing the new loop (load_state → if AUTH_REQUIRED → flow run → retry).
+
+Acceptance: a fresh Claude Code session with browserctl installed can recover from expired GitHub auth without manual coaching.
+
+---
+
+## ADRs to write (under `docs/architecture/decisions/`)
+
+- **ADR-0012** — Flow DSL: why a separate registry from workflows; lifetime semantics.
+- **ADR-0013** — `.bctl` bundle format: HMAC-then-encrypt, manifest layout, transport interface.
+- **ADR-0014** — `auth_required` detection: signals, false-positive handling, pluggability.
+
+## Format / breaking changes log
+
+This milestone is permitted to break:
+- `cookie *` and `storage *` are demoted to escape-hatch status; recommended docs path is `state *`.
+- Existing session export format gains a manifest layer (old session zips still readable, no auto-migration script).
+- Workflow `load_session fallback:` (v0.8.3) is superseded by `load_state` auto re-run; both remain functional through v0.10, deprecation warning added.
+
+CHANGELOG.md must call these out under `### Breaking`.
+
+## Acceptance for "v0.10 done"
+
+- [ ] WS-1 → WS-6 all merged.
+- [ ] Three ADRs merged.
+- [ ] CHANGELOG breaking section written.
+- [ ] `docs/concepts/state.md` and `docs/concepts/flows.md` exist and link from `README.md`.
+- [ ] One end-to-end smoke spec: open page → load expired state → auth_required → flow run → page reaches authenticated URL.
+- [ ] `automate` skill examples updated and tested in a real Claude Code session.
+
+## Open questions
+
+1. **Flow versioning runtime check** — when a registered flow's `version` mismatches the version in a bundle's manifest, do we warn or refuse? (Default: warn for minor, refuse for major.)
+2. **Origin scope default** — `state save` defaults to current origin only. What about workflows that span subdomains (e.g. `accounts.google.com` → `mail.google.com`)? Multi-origin opt-in via `--origins` flag, or auto-detect by following navigation chain during the flow?
+3. **Stdlib flow discovery** — ship as Ruby files inside the gem, or as a separate `browserctl-flows-stdlib` gem? (Default: bundled inside `browserctl` until we have >10 stdlib flows.)
+
+## Sequencing summary
+
+```
+WS-1 ─┬─ WS-2 ── WS-3
+      ├─ WS-4 ──────────┐
+      └─ WS-5 ──────────┴── WS-6 (last; depends on WS-2, WS-4, WS-5 surface)
+```
+
+Estimated PR count: 20. Estimated calendar time: 4–6 weeks at one PR per ~1.5 days.

--- a/docs/plans/v0.11-replayable.md
+++ b/docs/plans/v0.11-replayable.md
@@ -1,0 +1,120 @@
+# v0.11 — Replayable: execution plan
+
+> Companion to the v0.11 entry in `../vision.md`. Per-PR breakdown.
+
+## Goal
+
+Turn ephemeral AI exploration into durable, version-controlled workflows. Two hard problems: refs that survive across snapshots, and replay that doesn't break when the page wiggles.
+
+## Non-goals (this milestone)
+
+- New flow primitives (v0.10 territory).
+- Format versioning of the snapshot (we replace it directly per the v0.11 vision note).
+- MCP server (parked).
+
+## Dependencies
+
+- v0.10 Flows merged. Recording → flow promotion (WS-3 below) is a no-op without `Browserctl.flow` and the registry.
+- Existing `record start/stop` infrastructure (v0.2). Already produces a recording log; this milestone enriches the log with fingerprints.
+
+## Workstreams
+
+WS-1 → WS-2 sequential. WS-3 starts once WS-1 lands. WS-4 is the skill update, last.
+
+---
+
+### WS-1 · Replace `snapshot` — stable refs + fingerprints
+
+**Outcome:** Same DOM element gets the same ref across snapshots. Every element ships a fingerprint that can rematch it after structural drift.
+
+PRs:
+1. **`feat: stable ref derivation`** — `lib/browserctl/snapshot/ref.rb`. Refs become `e<short-hash>` of `(role, accessible-name, tag, parent-path)`. Drop the incrementing counter. Breaking change to wire format; bump `protocol_version`.
+2. **`feat: element fingerprint`** — emit `fingerprint: { text, role, neighbors: [...], position }` per element. Stable across small DOM changes.
+3. **`refactor: snapshot pipeline`** — split `snapshot` into `extract → annotate → serialise` so ref + fingerprint logic is testable in isolation.
+4. **`test: snapshot determinism specs`** — golden tests: same page → same refs across two snapshot calls; mutated page → fingerprint-matchable refs survive.
+5. **`docs: refs and fingerprints`** — rewrite `docs/concepts/snapshots-and-refs.md`; add migration note for users coming from the counter-based refs.
+
+Acceptance: snapshot a page twice → ref set is identical. Mutate a class on the target element → ref still resolves via fingerprint fallback.
+
+---
+
+### WS-2 · Self-healing replay
+
+**Outcome:** When a recorded selector fails, fingerprint match takes over silently; drift is logged but doesn't break the run.
+
+PRs:
+6. **`feat: fingerprint matcher`** — `lib/browserctl/replay/fingerprint_matcher.rb`. Score = weighted match across text, role, neighbors, position. Configurable threshold.
+7. **`feat: replay fallback in PageProxy`** — when `click(selector)` raises `SELECTOR_NOT_FOUND` and a fingerprint is available in the active recording context, attempt fingerprint match. Log the rematch with old + new selector.
+8. **`feat: replay drift report`** — `browserctl workflow run --check` outputs a structured diff report: which steps used fingerprint fallback, which steps' postconditions changed.
+9. **`feat: drift telemetry`** — emit `replay_drift` events to the daemon log (JSONL) for offline analysis. Local only, no upload.
+
+Acceptance: a recorded workflow against a deliberately-mutated page (e.g. test fixture with renamed CSS classes) replays successfully via fingerprint fallback, with drift report listing affected steps.
+
+---
+
+### WS-3 · Recording → workflow → flow pipeline
+
+**Outcome:** AI explores interactively; one command produces a clean workflow; another promotes it to a reusable flow.
+
+PRs:
+10. **`feat: enriched recording log`** — recording captures `{cmd, ref, selector, fingerprint, snapshot_id, postcondition_hint}` per event. Replaces the v0.2 log format.
+11. **`feat: workflow generate`** — `browserctl workflow generate <recording>` emits a Ruby workflow. Stable selectors first; fingerprint fallback as inline comments. Auto-detect secret-shaped values (API keys, passwords) and replace with `secret_ref:` placeholders + a TODO comment listing candidates.
+12. **`feat: inferred waits`** — generator inserts `wait` between steps based on observed delays; conservative defaults.
+13. **`feat: postcondition extraction`** — generator adds `assert url_matches: ...` or `assert selector_present: ...` when the recording shows a deterministic post-step page state.
+14. **`feat: workflow run --check`** — replay with snapshot-diff. Compare each post-step snapshot against the recorded one. Pass / drift / fail.
+15. **`feat: workflow promote`** — `browserctl workflow promote <name>` moves a workflow from `recordings/` to `~/.browserctl/workflows/`. Requires N successful `--check` runs (default 3) before allowing promotion; override with `--force`.
+16. **`feat: workflow promote --as-flow`** — wraps the workflow as a `Browserctl.flow` definition with inferred params. Closes the loop with v0.10.
+17. **`docs: AI-driven authoring guide`** — `docs/guides/ai-authoring.md`. Walk an agent through explore → generate → check → promote.
+
+Acceptance: starting from `record start`, an AI agent (or human) can produce a clean Ruby workflow file with no manual editing required for the happy path. Promotion to a flow yields an invocable `:flow_name` available across projects.
+
+---
+
+### WS-4 · Skill update
+
+**Outcome:** Claude Code agents using `automate` know the full loop.
+
+PRs:
+18. **`docs: automate skill — replayable loop`** — add the explore → generate → check → promote section. Show the exact CLI sequence and how to react to drift reports.
+19. **`docs: automate skill — fingerprint reasoning`** — teach the agent that a fingerprint mismatch is data, not failure: read the drift report, decide whether to update the workflow or re-record.
+
+Acceptance: a fresh Claude Code session can take a "scrape my GitHub issues" instruction → produce a verified, promoted workflow with no human intervention beyond approving HITL pauses (auth, captchas).
+
+---
+
+## ADRs to write
+
+- **ADR-0015** — Stable ref scheme: hash inputs, collision handling, why we replace instead of version.
+- **ADR-0016** — Fingerprint algorithm: signal selection, weighting, threshold defaults, false-positive bound.
+- **ADR-0017** — Promotion gates: why N successful runs, why `--force` exists, what disqualifies a workflow.
+
+## Format / breaking changes log
+
+- **Snapshot wire format changes.** Refs are no longer monotonically increasing. Anything that hard-coded `e1`/`e2` in tests or scripts breaks. Bump `protocol_version` so clients can detect.
+- **Recording log format changes.** v0.2 logs cannot replay under v0.11. Provide a one-shot `browserctl recording migrate` for the structural rename, but fingerprint fields will be empty for old logs (replay falls back to selector-only behaviour).
+- **`workflow run --check` is a new exit code.** `0` clean, `2` drift (still passed), `1` fail.
+
+CHANGELOG.md `### Breaking` section.
+
+## Acceptance for "v0.11 done"
+
+- [ ] WS-1 → WS-4 all merged.
+- [ ] Three ADRs merged.
+- [ ] Smoke spec: record a 5-step interaction → generate → check → promote → invoke from another workflow.
+- [ ] Drift smoke: record against a fixture page, mutate the fixture, replay reports drift but completes.
+- [ ] `automate` skill examples updated and tested in a real Claude Code session.
+
+## Open questions
+
+1. **Fingerprint storage location** — inline in the snapshot output (every call), or only in recording logs? (Trade-off: per-call cost vs. agents that want to fingerprint-match outside recording context.)
+2. **Recording → flow promotion params** — when `promote --as-flow` infers params from `secret_ref:` placeholders, what's the source of truth for the param list? (Default: every detected `secret_ref:` becomes a `param`; user can edit before final promotion.)
+3. **Drift threshold** — fixed default or per-workflow override? (Default: per-workflow override stored in the workflow file as a comment directive; absent means use library default.)
+
+## Sequencing summary
+
+```
+WS-1 ── WS-2 ──┐
+       └─ WS-3 ┴── WS-4
+```
+
+Estimated PR count: 19. Estimated calendar time: 4–6 weeks.

--- a/docs/plans/v0.12-solid.md
+++ b/docs/plans/v0.12-solid.md
@@ -1,0 +1,157 @@
+# v0.12 — Solid: execution plan
+
+> Companion to the v0.12 entry in `../vision.md`. Per-PR breakdown.
+
+## Goal
+
+Earn the right to call 1.0. Determinism, observability, real test pyramid, performance budgets defended in CI. No new product surface — only sharpening what exists.
+
+## Non-goals (this milestone)
+
+- New commands, flows, or workflow features.
+- MCP, cloud daemon, GUI, visual regression — all parked.
+- 1.0 itself. v0.12 ships, then we run on it for two months before cutting 1.0.
+
+## Dependencies
+
+- v0.10 + v0.11 merged. The format-versioning work (WS-1) needs all current formats to exist first.
+
+## Workstreams
+
+WS-1 through WS-5 are mostly independent and can land in parallel after their first PR (the foundation in each).
+
+---
+
+### WS-1 · Versioned formats
+
+**Outcome:** Every persisted artifact declares its format version. We can change formats without breaking historical data.
+
+PRs:
+1. **`feat: format version header convention`** — every persisted file (recording, workflow, state bundle, drift report) starts with `version: <int>`. Codify in `docs/reference/format-versions.md`.
+2. **`feat: bundle format version`** — `.bctl` manifest gets `format_version`. Codec rejects unknown versions with a typed error.
+3. **`feat: recording format version`** — recording log header stamps version. Replay engine refuses incompatible versions.
+4. **`feat: workflow format version`** — workflow file front-matter (Ruby comment block) declares version. Loader warns on unknown.
+5. **`feat: migration helpers`** — `Browserctl::Migrations` registry; `browserctl migrate <path>` runs registered upgraders. Empty registry shipped — first real migration arrives only when a format actually changes post-1.0.
+6. **`docs: format-versions.md`** — single page documenting every format and its current version.
+
+Acceptance: every persisted artifact in a fresh install has a version. Loading an artifact with version `999` fails with a clear typed error.
+
+---
+
+### WS-2 · Standardised error model
+
+**Outcome:** Every error has a code. Every CLI exit code maps 1:1 to a category. Agents can switch on error codes deterministically.
+
+PRs:
+7. **`feat: error code enum`** — `lib/browserctl/error/codes.rb`. Enum of stable strings: `AUTH_REQUIRED`, `SELECTOR_NOT_FOUND`, `STATE_EXPIRED`, `SECRET_RESOLUTION_FAILED`, `DAEMON_UNREACHABLE`, `PROTOCOL_MISMATCH`, etc.
+8. **`refactor: typed errors everywhere`** — sweep `lib/` to ensure every raise carries a code. Lint rule (RuboCop cop) added to enforce on new code.
+9. **`feat: structured error payload`** — daemon JSON-RPC errors and CLI stderr both emit `{code, message, context, suggested_action}`.
+10. **`feat: exit code map`** — codify `0=ok, 1=generic, 2=drift, 3=auth required, 4=daemon unreachable, 5=protocol mismatch, 6=selector not found, 7=state expired`. Document in `docs/reference/exit-codes.md`.
+11. **`docs: error reference`** — `docs/reference/errors.md` lists every code, its meaning, and the suggested-action template.
+
+Acceptance: an agent can branch on stderr `code` field for every failure mode without parsing prose.
+
+---
+
+### WS-3 · Observability
+
+**Outcome:** When something goes wrong, the user (or AI) can see why without re-running.
+
+PRs:
+12. **`feat: structured JSONL logs`** — daemon and CLI log to `~/.browserctl/logs/` as JSONL. Existing `--log-level` controls verbosity. Log rotation: 10 files × 10MB.
+13. **`feat: trace command`** — `browserctl trace [<session>]` prints a pretty timeline of events, snapshots, network, errors. Defaults to most recent session.
+14. **`feat: crash reports`** — daemon writes `crash-<timestamp>.json` on panic with last 50 events, stack trace, daemon version, OS info. Hint in startup banner: "if browserd crashes, attach the crash report."
+15. **`feat: trace --redact`** — secret-aware redaction so traces are safe to attach to issues by default.
+16. **`docs: debugging guide`** — `docs/guides/debugging.md`. Walks through the trace → crash report → issue flow.
+
+Acceptance: a deliberately-crashed daemon leaves a crash report. `browserctl trace` displays a readable timeline of the last session. Secret values never appear in traces.
+
+---
+
+### WS-4 · Test pyramid
+
+**Outcome:** Coverage that makes refactoring safe; smoke that catches regressions before users do.
+
+PRs:
+17. **`test: unit coverage gaps — snapshot/ref/fingerprint`** — cover the v0.11 logic explicitly (fingerprint matcher, ref hashing, drift scoring) at unit level.
+18. **`test: unit coverage gaps — bundle codec, secret resolver`** — round-trip every bundle/state combination; failure modes for every resolver.
+19. **`test: integration matrix expansion`** — every CLI command × every error path. Generate table-driven tests from the error code enum.
+20. **`test: workflow replay matrix`** — sample workflows replay across Chrome, Chromium, Brave. Single CI job, parallel matrix.
+21. **`test: smoke suite`** — nightly CI runs against stable public surfaces (`example.com`, this repo's GitHub Pages site, your own demo page). Detects ferrum/CDP/browser drift.
+22. **`ci: nightly smoke workflow`** — `.github/workflows/smoke.yml` scheduled run. Failures auto-open an issue with the trace attached.
+
+Acceptance: `bundle exec rspec` passes with all integration specs running against a real browser (no `pending` for browser-required cases on a developer machine). Nightly smoke CI is green for one week.
+
+---
+
+### WS-5 · Performance budgets
+
+**Outcome:** Numbers we defend, not aspirations.
+
+PRs:
+23. **`feat: benchmark harness`** — `bench/` directory with `benchmark-ips`-driven scripts for snapshot, click, daemon idle RSS, bundle codec.
+24. **`feat: budget enforcement in CI`** — fail the build if `snapshot` p95 > 250ms, `click` ack > 50ms, daemon idle RSS > 200MB, typical state bundle > 50KB. Numbers stored in `bench/budgets.yml`.
+25. **`feat: regression report`** — every PR comment includes a delta vs. main for each tracked metric. Threshold: 10% regression flagged, 25% blocks merge.
+26. **`docs: performance budgets`** — `docs/reference/performance.md` documents what we measure, why these numbers, how to relax them with justification.
+
+Acceptance: CI on `main` has been within budget for 14 consecutive days. A deliberately-slow PR fails the budget check.
+
+---
+
+### WS-6 · Compatibility matrix
+
+**Outcome:** Clear, narrow, defended support surface.
+
+PRs:
+27. **`ci: Ruby 3.3 only`** — drop any 3.4 jobs from the matrix; explicit rationale in `docs/reference/compatibility.md` (cost-saving choice through 0.x).
+28. **`ci: OS matrix`** — macOS 14+, Ubuntu 22+, Windows-via-WSL2. Each OS gets one CI job, not the full matrix.
+29. **`feat: pinned Ferrum minor`** — Gemfile.lock pins; explicit upgrade ADR template (`adr-template-ferrum-bump.md`) for any minor bump.
+30. **`docs: compatibility.md`** — single page of supported Ruby × browser × OS. Anything outside is "may work, no commitment."
+
+Acceptance: `docs/reference/compatibility.md` matches the CI matrix exactly. Any drift is the source of an issue.
+
+---
+
+## ADRs to write
+
+- **ADR-0018** — Format versioning convention.
+- **ADR-0019** — Error code taxonomy and exit-code map.
+- **ADR-0020** — Performance budget methodology and how budgets evolve.
+- **ADR-0021** — Compatibility matrix policy: Ruby 3.3 floor through 0.x; deprecation cadence post-1.0.
+
+## Format / breaking changes log
+
+v0.12 is a polish milestone, but it does break:
+- Error payloads everywhere now include `code`. Anything that scraped error prose before will need to switch to the code field.
+- CLI exit codes are reassigned. Scripts that hard-coded specific exit codes need a one-time update.
+- Old recordings without a version header are rejected with `PROTOCOL_MISMATCH`; provide `browserctl recording migrate --add-version 1` for back-compat with the latest pre-v0.12 format.
+
+CHANGELOG.md `### Breaking` section.
+
+## Acceptance for "v0.12 done" (= 1.0 candidate)
+
+- [ ] WS-1 through WS-6 all merged.
+- [ ] Four ADRs merged.
+- [ ] CI green for 14 consecutive days, including nightly smoke.
+- [ ] Performance budget green for 14 consecutive days.
+- [ ] Zero open `panic`-class bugs.
+- [ ] `docs/reference/api-stability.md` updated to declare 1.0 candidacy of the Fixed and Stable zones.
+- [ ] Two months of v0.12.x patch releases without breaking changes.
+
+After all of the above: cut **1.0**. Adopt deprecation policy in `docs/reference/api-stability.md` — one minor of warning before any Stable-zone change; never break the Fixed zone without a major.
+
+## Open questions
+
+1. **Snapshot in performance budget** — page-dependent timings make absolute thresholds noisy. Use a fixed local fixture page in CI? (Default: yes, `bench/pages/budget.html`.)
+2. **Crash report telemetry** — local-only file is the safe default. Should we offer an opt-in `browserctl crash submit <file>` that uploads to a maintainer-controlled endpoint? (Default: no for 0.x, revisit post-1.0.)
+3. **Smoke-test failure auto-issue** — duplicate-issue protection? (Default: GitHub Action labels with `smoke-failure` and skips creation if an open issue with that label exists.)
+
+## Sequencing summary
+
+```
+WS-1 (versioned formats) ─┐
+WS-2 (errors) ─────────────┼── WS-4 (test pyramid) ── WS-5 (perf budgets) ── WS-6 (compat)
+WS-3 (observability) ─────┘
+```
+
+Estimated PR count: 30. Estimated calendar time: 6–8 weeks. After that: two months of stabilisation before 1.0.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -144,29 +144,103 @@ It is the difference between a browser **you restart** and a browser **you steer
 
 - [x] `expired_if:` on `load_session` — detect server-side session expiry and auto-recover via fallback
 
-### v0.9 — Evidence & Reproduction
-**Goal:** Every session leaves a trail. Every bug is reproducible from code.
+### v0.9 — Browser-Agnostic Driver ✓ _(shipped)_
+**Goal:** Decouple the daemon from a single browser. Same daemon, same protocol, multiple Chromium-family browsers.
 
-- [ ] Evidence capture hooks — configurable auto-screenshot (on HITL pause, on step failure, per-step)
-- [ ] Session trace export — structured JSON log of every command; `browserctl session export-trace`
-- [ ] `replay` command — step through a recorded workflow with live screenshots at each step
-- [ ] Extensible HITL detection modules — DataDome, 2FA prompts, consent banners as built-in detectors
-- [ ] `register_detector` plugin API — third-party detectors installable via plugin system
+- [x] Driver abstraction layer — CDP client interface separated from Ferrum specifics
+- [x] Chrome / Chromium / Brave support via `-b/--browser` flag
+- [x] Auto binary discovery with `CHROME_PATH`, `CHROMIUM_PATH`, `BRAVE_PATH` overrides
+- [x] Skill split — `automate` (AI-driven) and `feedback` (user-invoked) as separate manifests
 
-### v0.10 — Platform
-**Goal:** browserctl becomes the runtime layer where human oversight produces better agents.
+> **Strategic shift after v0.9.** Pre-1.0 development now optimises for two things: making AI-driven exploration produce durable workflows, and proving the HITL + reusable-flow model that no competitor has. **Breaking changes are acceptable** between minor versions until 1.0; deprecation policy starts at 1.0. Ruby support is **3.3 only** through the 0.x series to keep the CI matrix small. MCP server work is parked — skills remain the primary AI surface.
 
-- [ ] Annotated session traces — export pause/resume sessions as fine-tuning data for browser agents
-- [ ] Session recording + replay — deterministic browser regression testing
-- [ ] Visual regression — `shot --compare baseline.png` with pixel diff
-- [ ] Distributed sessions — fan-out a command across N named pages in parallel
-- [ ] Webhook triggers — run a workflow when an HTTP POST arrives
-- [ ] GUI companion app — macOS status bar showing live page list and daemon health
+### v0.10 — Flows
+**Goal:** Make browser auth and any other repeatable interaction a named, parameterised, secret-aware, composable artifact. The moat.
+
+**Reusable Flow DSL**
+- [ ] `Browserctl.flow :name do … end` — first-class flow definition with `version`, `desc`, `param`, `step`, `precondition`, `postcondition`, `produces_state`
+- [ ] Flow registry — auto-load from `~/.browserctl/flows/` (user) and `./.browserctl/flows/` (project), project wins
+- [ ] `invoke :flow_name` from inside any workflow or other flow
+- [ ] CLI: `browserctl flow run/list/describe`
+- [ ] Stdlib flows — `oauth_google`, `oauth_github`, `totp_2fa`, `magic_link_email`, `cloudflare_solve`, `basic_auth`
+
+**Unified state command**
+- [ ] `browserctl state save/load/list/info/delete/export/import/rotate`
+- [ ] `.bctl` bundle format — manifest + cookies + localStorage + sessionStorage + (optional) IndexedDB, HMAC-signed, optionally encrypted
+- [ ] Origin-scoped by default; full-browser scope opt-in
+- [ ] Bundle metadata declares `expires_at`, source flow, flow version
+- [ ] Three blessed transports for portability: file, S3-compatible, 1Password document
+- [ ] Existing `cookie *` / `storage *` verbs retained as low-level escape hatches
+
+**Auth re-detection**
+- [ ] Daemon emits `auth_required` event when login redirects, 401/403, or expired cookies are detected
+- [ ] CLI exit code `7` for auth-required; structured error payload with `suggested_flow`
+- [ ] Workflow DSL: automatic re-run of bound flow on `load_state` expiry; explicit `on_auth_required` override
+- [ ] Skill update — `automate` teaches the AI to react to `auth_required`
+
+### v0.11 — Replayable
+**Goal:** Turn ephemeral AI exploration into durable, version-controlled workflows.
+
+**Stable refs and fingerprints**
+- [ ] `snapshot_v2` — refs derived from `(role, accessible-name, tag, parent-path)` hash; same element → same ref across snapshots
+- [ ] Fingerprint blob per element (text, ARIA role, neighbor signature, position) emitted alongside ref
+- [ ] Fingerprint-based fuzzy match on replay when selectors fail — Scrapling-style self-healing for recordings
+- [ ] Versioned snapshot format header so old recordings remain replayable
+
+**Recording → workflow → flow pipeline**
+- [ ] `browserctl workflow generate <recording>` — emits a Ruby workflow with stable selectors, fingerprint fallbacks as comments, secret detection (`secret_ref:` placeholders), inferred waits, postconditions
+- [ ] `browserctl workflow run --check` — replay with snapshot-diff assertions; flag drift
+- [ ] `browserctl workflow promote <name>` — graduate to `~/.browserctl/workflows/`
+- [ ] `browserctl workflow promote --as-flow` — register a workflow as a reusable flow (closes the loop with v0.10)
+- [ ] Skill update — `automate` teaches the AI the explore → generate → check → promote loop
+
+### v0.12 — Solid
+**Goal:** Earn the right to call 1.0. Determinism, observability, performance budgets, real test pyramid.
+
+**Determinism**
+- [ ] Versioned formats for snapshots, recordings, workflows, state bundles — explicit `version:` in every header
+- [ ] Migration helpers between format versions
+- [ ] No implicit waits; every wait is explicit and surfaced in errors
+
+**Error model**
+- [ ] Standardised error codes across daemon and CLI (e.g. `AUTH_REQUIRED`, `SELECTOR_NOT_FOUND`, `STATE_EXPIRED`)
+- [ ] CLI exit codes mapped 1:1 to error categories
+- [ ] Structured `{code, message, context, suggested_action}` payload everywhere
+
+**Observability**
+- [ ] JSONL structured logs in `~/.browserctl/logs/`
+- [ ] `browserctl trace <session>` — pretty timeline of events, snapshots, network, errors
+- [ ] Crash reports on daemon panic with last 50 events
+
+**Test pyramid**
+- [ ] Unit tests for snapshot/ref/fingerprint, secret resolver, bundle codec
+- [ ] Integration tests for every CLI command, error path, and JSON-RPC contract
+- [ ] Workflow replay matrix across Chrome / Chromium / Brave
+- [ ] Smoke tests against stable public sites, run nightly
+
+**Performance budgets (CI-enforced)**
+- [ ] `snapshot` p95 < 250 ms on a typical page
+- [ ] `click` ack < 50 ms (action dispatch)
+- [ ] Daemon RSS < 200 MB idle
+- [ ] State bundle < 50 KB typical
+
+**Compatibility matrix**
+- [ ] CI: Ruby 3.3 only (cost-saving choice through 0.x)
+- [ ] CI: macOS 14+, Ubuntu 22+, Windows-via-WSL2
+- [ ] Pinned Ferrum minor; explicit upgrade PRs only
 
 ### v1.0 — Production-Ready
-**Goal:** Ship it when it's ready. No checklist owns this milestone — it will be cut when the project is stable enough to warrant a compatibility promise and a deprecation policy.
+**Goal:** A compatibility promise the project can keep.
 
-What "ready" means: the Fixed and Stable zones carry an explicit compatibility promise — breaking them is a considered decision with a migration path, not an accident. The security audit is closed. The architecture has absorbed real usage feedback from agents and developers in the wild.
+Ship 1.0 when v0.12 has been crash-free for two months in real use, the Fixed and Stable zones in `docs/reference/api-stability.md` carry an explicit compatibility promise, the security review is closed, and the architecture has absorbed feedback from agents and developers in the wild.
+
+After 1.0: deprecation policy kicks in — one minor of warning before any breaking change in the Stable zone; never break the Fixed zone without a major.
+
+### Parked
+- **MCP server.** Skills remain the primary AI surface. Revisit only if there is concrete demand from non-Claude clients (Cursor, Codex, Cline) that skills can't address.
+- **Cloud / remote daemon mode.** Local-only is a core philosophy; remoting is an explicit non-goal pre-1.0.
+- **Annotated screenshots with ref-overlay numbers.** Useful for vision agents but a smaller segment than the flow/replay work; revisit post-1.0.
+- **Visual regression / pixel diff, distributed fan-out, webhook triggers, macOS GUI.** From the previous v0.10 plan — deferred behind the moat-building work.
 
 ---
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -182,10 +182,10 @@ It is the difference between a browser **you restart** and a browser **you steer
 **Goal:** Turn ephemeral AI exploration into durable, version-controlled workflows.
 
 **Stable refs and fingerprints**
-- [ ] `snapshot_v2` — refs derived from `(role, accessible-name, tag, parent-path)` hash; same element → same ref across snapshots
+- [ ] Replace `snapshot` — refs derived from `(role, accessible-name, tag, parent-path)` hash; same element → same ref across snapshots (breaking change, no `_v2` suffix)
 - [ ] Fingerprint blob per element (text, ARIA role, neighbor signature, position) emitted alongside ref
 - [ ] Fingerprint-based fuzzy match on replay when selectors fail — Scrapling-style self-healing for recordings
-- [ ] Versioned snapshot format header so old recordings remain replayable
+- [ ] Migration note in CHANGELOG — old recordings re-record, not auto-migrate
 
 **Recording → workflow → flow pipeline**
 - [ ] `browserctl workflow generate <recording>` — emits a Ruby workflow with stable selectors, fingerprint fallbacks as comments, secret detection (`secret_ref:` placeholders), inferred waits, postconditions
@@ -198,8 +198,8 @@ It is the difference between a browser **you restart** and a browser **you steer
 **Goal:** Earn the right to call 1.0. Determinism, observability, performance budgets, real test pyramid.
 
 **Determinism**
-- [ ] Versioned formats for snapshots, recordings, workflows, state bundles — explicit `version:` in every header
-- [ ] Migration helpers between format versions
+- [ ] Versioned formats for recordings, workflows, state bundles — explicit `version:` in every header (snapshot stays unversioned; refs are deterministic by construction)
+- [ ] Migration helpers between format versions where needed
 - [ ] No implicit waits; every wait is explicit and surfaced in errors
 
 **Error model**


### PR DESCRIPTION
## Summary

Refocuses the post-v0.9 roadmap in `docs/vision.md` on the moat-building work surfaced by the competitive analysis vs Scrapling and vercel-labs/agent-browser:

- **v0.9** marked shipped (browser-agnostic driver + Brave already landed in `0156c2d`).
- **v0.10 Flows** — reusable flow DSL (`Browserctl.flow :name`), unified `state` command with `.bctl` bundle format, daemon-emitted `auth_required` event with auto re-run of bound flows, stdlib of common auth flows.
- **v0.11 Replayable** — stable refs (`snapshot_v2`), fingerprint-based self-healing on replay, full recording → `workflow generate` → `workflow run --check` → `workflow promote --as-flow` pipeline so AI exploration becomes durable artifacts.
- **v0.12 Solid** — versioned formats, standardised error model + exit codes, `browserctl trace`, real test pyramid, CI-enforced performance budgets, Ruby 3.3-only CI matrix.
- **v1.0** reframed as a compatibility promise rather than a feature checklist.

### Strategic notes added
- Breaking changes acceptable between minors until 1.0.
- Ruby 3.3 only through 0.x for CI cost.
- MCP server parked — skills remain the primary AI surface.
- Visual regression, pixel diff, distributed fan-out, webhook triggers, and the macOS GUI app moved to **Parked**.

## Why this shape

The competitive teardown showed:
- **agent-browser** has reach (Rust binary, Vercel distribution, annotated screenshots) but no story for promoting an LLM's working interaction into a stable script.
- **Scrapling** has self-healing selectors and a built-in MCP, but is a Python scraping library, not a stateful browser daemon.
- **browserctl's** unique surface is HITL + secret-aware reusable flows + recording → workflow promotion. v0.10–v0.12 doubles down on exactly that.

## Test plan
- [ ] Read-through review of `docs/vision.md` for tone and accuracy
- [ ] Confirm v0.9 checkboxes match what actually shipped in `0156c2d` and `65c1a8e`
- [ ] Confirm Parked list captures everything dropped from the previous v0.10 plan