### PR TITLE
feat: Browserctl::Flow class + DSL

### DIFF
--- a/docs/plans/v0.10-flows.md
+++ b/docs/plans/v0.10-flows.md
@@ -70,7 +70,7 @@ Acceptance: every stdlib flow has a unit spec + a documented invocation example 
 **Outcome:** One verb for all auth-state management; portable encrypted bundle.
 
 PRs:
-11. **`feat: .bctl bundle codec`** — `lib/browserctl/state/bundle.rb`. Manifest + cookies + localStorage + sessionStorage + (optional) IndexedDB, HMAC-signed, optional passphrase encryption. Reuses v0.8 encryption primitives.
+11. **`feat: .bctl bundle codec`** — `lib/browserctl/state/bundle.rb`. Manifest + cookies + localStorage + sessionStorage + (optional) IndexedDB, HMAC-signed, optional passphrase encryption. Reuses v0.8 encryption primitives. Manifest captures `origins[]` auto-detected from the producing flow's navigation chain; `state save --origins a,b,c` overrides.
 12. **`feat: state save/load/list/info/delete`** — `bin/browserctl/commands/state.rb`. Wraps existing session save/load under origin-scoped semantics.
 13. **`feat: state export/import with transports`** — file (default), `s3://`, `op://`. Pluggable transport interface.
 14. **`feat: state rotate`** — invokes the bound flow (from manifest) to refresh a stale bundle.
@@ -107,9 +107,11 @@ Acceptance: a fresh Claude Code session with browserctl installed can recover fr
 
 ## ADRs to write (under `docs/architecture/decisions/`)
 
-- **ADR-0012** — Flow DSL: why a separate registry from workflows; lifetime semantics.
-- **ADR-0013** — `.bctl` bundle format: HMAC-then-encrypt, manifest layout, transport interface.
-- **ADR-0014** — `auth_required` detection: signals, false-positive handling, pluggability.
+> ADR-0012 is taken (`browser-agnostic-driver`). New ADRs start at 0013.
+
+- **ADR-0013** — Flow DSL: why a separate registry from workflows; lifetime semantics; stdlib gem-split trigger (split into `browserctl-flows-stdlib` once flow count exceeds ~10 **or** a flow needs a heavy optional dep the core gem shouldn't require).
+- **ADR-0014** — `.bctl` bundle format: HMAC-then-encrypt, manifest layout, transport interface, origin scoping (default = auto-detected from navigation chain captured during the flow's `produces_state` block; `--origins` flag overrides).
+- **ADR-0015** — `auth_required` detection: signals, false-positive handling, pluggability.
 
 ## Format / breaking changes log
 
@@ -129,11 +131,11 @@ CHANGELOG.md must call these out under `### Breaking`.
 - [ ] One end-to-end smoke spec: open page → load expired state → auth_required → flow run → page reaches authenticated URL.
 - [ ] `automate` skill examples updated and tested in a real Claude Code session.
 
-## Open questions
+## Resolved decisions
 
-1. **Flow versioning runtime check** — when a registered flow's `version` mismatches the version in a bundle's manifest, do we warn or refuse? (Default: warn for minor, refuse for major.)
-2. **Origin scope default** — `state save` defaults to current origin only. What about workflows that span subdomains (e.g. `accounts.google.com` → `mail.google.com`)? Multi-origin opt-in via `--origins` flag, or auto-detect by following navigation chain during the flow?
-3. **Stdlib flow discovery** — ship as Ruby files inside the gem, or as a separate `browserctl-flows-stdlib` gem? (Default: bundled inside `browserctl` until we have >10 stdlib flows.)
+1. **Flow versioning runtime check** — warn on minor mismatch, refuse on major. CLI `--force` overrides; no workflow-level override. Bundles with no `flow_version` (pre-v0.10 imports) treated as "unknown" — warn once, accept.
+2. **Origin scope default** — auto-detect by recording the navigation chain during the flow's `produces_state` block. `state info` surfaces captured origins. `--origins a,b,c` overrides on `state save`.
+3. **Stdlib flow discovery** — bundled inside `browserctl`. Split to `browserctl-flows-stdlib` once flow count exceeds ~10 **or** a flow needs a heavy optional dep the core gem shouldn't require. Each stdlib flow declares minimum `browserctl` version in DSL frontmatter.
 
 ## Sequencing summary
 

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -27,4 +27,10 @@ module Browserctl
 
   class WorkflowError < Error; def self.default_code = "workflow_error" end
   class SecretResolverError < WorkflowError; def self.default_code = "secret_resolver_error" end
+
+  class FlowError < WorkflowError; def self.default_code = "flow_error" end
+  class FlowParamError < FlowError; def self.default_code = "flow_param_error" end
+  class FlowPreconditionError < FlowError; def self.default_code = "flow_precondition_failed" end
+  class FlowStepError < FlowError; def self.default_code = "flow_step_failed" end
+  class FlowPostconditionError < FlowError; def self.default_code = "flow_postcondition_failed" end
 end

--- a/lib/browserctl/flow.rb
+++ b/lib/browserctl/flow.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative "errors"
+
+module Browserctl
+  FlowParamDef    = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
+  FlowStepDef     = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
+  FlowConditionDef = Struct.new(:kind, :label, :block, keyword_init: true)
+
+  class Flow
+    SEMVER_RE = /\A\d+\.\d+\.\d+\z/
+
+    attr_reader :name,
+                :version_string,
+                :description,
+                :param_defs,
+                :steps,
+                :preconditions,
+                :postconditions,
+                :produces_state_block,
+                :min_browserctl_version
+
+    def initialize(name)
+      @name                   = name.to_s
+      @version_string         = "0.0.0"
+      @description            = nil
+      @param_defs             = {}
+      @steps                  = []
+      @preconditions          = []
+      @postconditions         = []
+      @produces_state_block   = nil
+      @min_browserctl_version = nil
+    end
+
+    def version(value)
+      validate_semver!(value, label: "version")
+      @version_string = value.to_s
+    end
+
+    def requires_browserctl(value)
+      validate_semver!(value, label: "requires_browserctl")
+      @min_browserctl_version = value.to_s
+    end
+
+    def desc(text)
+      @description = text.to_s
+    end
+
+    def param(name, required: false, secret: false, default: nil, secret_ref: nil)
+      secret = true if secret_ref
+      @param_defs[name] = FlowParamDef.new(
+        name: name,
+        required: required,
+        secret: secret,
+        default: default,
+        secret_ref: secret_ref
+      )
+    end
+
+    def step(label, retry_count: 0, timeout: nil, &block)
+      raise ArgumentError, "flow step '#{label}' requires a block" unless block
+
+      @steps << FlowStepDef.new(label: label, block: block, retry_count: retry_count, timeout: timeout)
+    end
+
+    def precondition(label = "precondition", &block)
+      raise ArgumentError, "precondition '#{label}' requires a block" unless block
+
+      @preconditions << FlowConditionDef.new(kind: :precondition, label: label, block: block)
+    end
+
+    def postcondition(label = "postcondition", &block)
+      raise ArgumentError, "postcondition '#{label}' requires a block" unless block
+
+      @postconditions << FlowConditionDef.new(kind: :postcondition, label: label, block: block)
+    end
+
+    def produces_state(&block)
+      raise ArgumentError, "produces_state requires a block" unless block
+
+      @produces_state_block = block
+    end
+
+    private
+
+    def validate_semver!(value, label:)
+      return if value.to_s.match?(SEMVER_RE)
+
+      raise ArgumentError, "#{label} must be MAJOR.MINOR.PATCH (got #{value.inspect})"
+    end
+  end
+
+  def self.flow(name, &block)
+    raise ArgumentError, "Browserctl.flow requires a block" unless block
+
+    Flow.new(name).tap { |f| f.instance_exec(&block) }
+  end
+end

--- a/lib/browserctl/flow.rb
+++ b/lib/browserctl/flow.rb
@@ -1,11 +1,33 @@
 # frozen_string_literal: true
 
+require "timeout"
 require_relative "errors"
+require_relative "secret_resolvers"
 
 module Browserctl
   FlowParamDef    = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
   FlowStepDef     = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
   FlowConditionDef = Struct.new(:kind, :label, :block, keyword_init: true)
+
+  class FlowContext
+    attr_reader :page, :client, :params
+
+    def initialize(page:, params:, client: nil)
+      @page   = page
+      @client = client
+      @params = params
+    end
+
+    def method_missing(name, *args)
+      return @params[name] if args.empty? && @params.key?(name)
+
+      super
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @params.key?(name) || super
+    end
+  end
 
   class Flow
     SEMVER_RE = /\A\d+\.\d+\.\d+\z/
@@ -81,12 +103,86 @@ module Browserctl
       @produces_state_block = block
     end
 
+    def run(page: nil, client: nil, **params)
+      ctx = FlowContext.new(page: page, client: client, params: resolve_params(params))
+
+      run_conditions(ctx, @preconditions, error_class: FlowPreconditionError)
+      run_steps(ctx)
+      run_conditions(ctx, @postconditions, error_class: FlowPostconditionError)
+
+      produce_state(ctx)
+    end
+
     private
 
     def validate_semver!(value, label:)
       return if value.to_s.match?(SEMVER_RE)
 
       raise ArgumentError, "#{label} must be MAJOR.MINOR.PATCH (got #{value.inspect})"
+    end
+
+    def resolve_params(provided)
+      @param_defs.each_with_object({}) do |(name, defn), out|
+        val = if defn.secret_ref
+                SecretResolverRegistry.resolve(defn.secret_ref)
+              elsif provided.key?(name)
+                provided[name]
+              else
+                defn.default
+              end
+
+        raise FlowParamError, "flow '#{@name}' requires param '#{name}'" if defn.required && val.nil?
+
+        out[name] = val
+      end
+    end
+
+    def run_conditions(ctx, conditions, error_class:)
+      conditions.each do |cond|
+        result = ctx.instance_exec(&cond.block)
+        next if result
+
+        raise error_class,
+              "flow '#{@name}' #{cond.kind} '#{cond.label}' returned #{result.inspect}"
+      rescue FlowError
+        raise
+      rescue StandardError => e
+        raise error_class,
+              "flow '#{@name}' #{cond.kind} '#{cond.label}' raised: #{e.message}"
+      end
+    end
+
+    def run_steps(ctx)
+      @steps.each { |defn| run_step(ctx, defn) }
+    end
+
+    def run_step(ctx, defn)
+      last_error = nil
+      (defn.retry_count + 1).times do
+        execute_step_block(ctx, defn)
+        return
+      rescue StandardError => e
+        last_error = e
+      end
+      raise FlowStepError,
+            "flow '#{@name}' step '#{defn.label}' failed: #{last_error.message}"
+    end
+
+    def execute_step_block(ctx, defn)
+      if defn.timeout
+        ::Timeout.timeout(defn.timeout) { ctx.instance_exec(&defn.block) }
+      else
+        ctx.instance_exec(&defn.block)
+      end
+    rescue ::Timeout::Error
+      raise FlowStepError,
+            "flow '#{@name}' step '#{defn.label}' timed out after #{defn.timeout}s"
+    end
+
+    def produce_state(ctx)
+      return nil unless @produces_state_block
+
+      ctx.instance_exec(&@produces_state_block)
     end
   end
 


### PR DESCRIPTION
First PR in WS-1 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md).

## What

`Browserctl::Flow` definition class with the DSL surface:

- `version "1.0.0"` (semver-validated)
- `requires_browserctl "0.10.0"` (minimum gem version, per resolved Q3)
- `desc "..."`
- `param :name, required:, secret:, default:, secret_ref:` — `secret_ref` implies `secret: true`, mirroring the workflow DSL
- `step "label", retry_count:, timeout:` (block stored, not executed yet)
- `precondition` / `postcondition`
- `produces_state` (block stored)

Top-level builder: `Browserctl.flow(name) { ... }` returns a `Flow` instance.

## What this PR explicitly does NOT do

- **No execution.** `Flow#run` lands in WS-1 PR #2.
- **No registry.** Auto-loading from `./.browserctl/flows/*.rb` lands in WS-2 PR #4.
- **No specs.** WS-1 PR #3 — kept separate so this PR is small and reviewable in isolation.

## Plan delta

Three open questions in the plan are now resolved (see `docs/plans/v0.10-flows.md` "Resolved decisions"):

1. Flow versioning — warn on minor mismatch, refuse on major; `--force` CLI override.
2. Origin scope default — auto-detect from navigation chain during `produces_state`; `--origins` overrides.
3. Stdlib discovery — bundled until ~10 flows or a heavy optional dep appears.

ADR numbers renumbered: 0013 (Flow DSL), 0014 (.bctl bundle), 0015 (auth_required). 0012 is already taken by the v0.9 driver ADR.

## Verification

- Smoke-tested the DSL via `ruby -Ilib`: definition, semver guard, missing-block guard, `secret_ref` coercion all behave.
- `bundle exec rspec spec/unit` — 300 examples, 0 failures.
- `bundle exec rubocop lib/browserctl/flow.rb` — clean.