### PR TITLE
feat: flow execution

### DIFF
--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -27,4 +27,10 @@ module Browserctl
 
   class WorkflowError < Error; def self.default_code = "workflow_error" end
   class SecretResolverError < WorkflowError; def self.default_code = "secret_resolver_error" end
+
+  class FlowError < WorkflowError; def self.default_code = "flow_error" end
+  class FlowParamError < FlowError; def self.default_code = "flow_param_error" end
+  class FlowPreconditionError < FlowError; def self.default_code = "flow_precondition_failed" end
+  class FlowStepError < FlowError; def self.default_code = "flow_step_failed" end
+  class FlowPostconditionError < FlowError; def self.default_code = "flow_postcondition_failed" end
 end

--- a/lib/browserctl/flow.rb
+++ b/lib/browserctl/flow.rb
@@ -1,11 +1,33 @@
 # frozen_string_literal: true
 
+require "timeout"
 require_relative "errors"
+require_relative "secret_resolvers"
 
 module Browserctl
   FlowParamDef    = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
   FlowStepDef     = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
   FlowConditionDef = Struct.new(:kind, :label, :block, keyword_init: true)
+
+  class FlowContext
+    attr_reader :page, :client, :params
+
+    def initialize(page:, params:, client: nil)
+      @page   = page
+      @client = client
+      @params = params
+    end
+
+    def method_missing(name, *args)
+      return @params[name] if args.empty? && @params.key?(name)
+
+      super
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @params.key?(name) || super
+    end
+  end
 
   class Flow
     SEMVER_RE = /\A\d+\.\d+\.\d+\z/
@@ -81,12 +103,86 @@ module Browserctl
       @produces_state_block = block
     end
 
+    def run(page: nil, client: nil, **params)
+      ctx = FlowContext.new(page: page, client: client, params: resolve_params(params))
+
+      run_conditions(ctx, @preconditions, error_class: FlowPreconditionError)
+      run_steps(ctx)
+      run_conditions(ctx, @postconditions, error_class: FlowPostconditionError)
+
+      produce_state(ctx)
+    end
+
     private
 
     def validate_semver!(value, label:)
       return if value.to_s.match?(SEMVER_RE)
 
       raise ArgumentError, "#{label} must be MAJOR.MINOR.PATCH (got #{value.inspect})"
+    end
+
+    def resolve_params(provided)
+      @param_defs.each_with_object({}) do |(name, defn), out|
+        val = if defn.secret_ref
+                SecretResolverRegistry.resolve(defn.secret_ref)
+              elsif provided.key?(name)
+                provided[name]
+              else
+                defn.default
+              end
+
+        raise FlowParamError, "flow '#{@name}' requires param '#{name}'" if defn.required && val.nil?
+
+        out[name] = val
+      end
+    end
+
+    def run_conditions(ctx, conditions, error_class:)
+      conditions.each do |cond|
+        result = ctx.instance_exec(&cond.block)
+        next if result
+
+        raise error_class,
+              "flow '#{@name}' #{cond.kind} '#{cond.label}' returned #{result.inspect}"
+      rescue FlowError
+        raise
+      rescue StandardError => e
+        raise error_class,
+              "flow '#{@name}' #{cond.kind} '#{cond.label}' raised: #{e.message}"
+      end
+    end
+
+    def run_steps(ctx)
+      @steps.each { |defn| run_step(ctx, defn) }
+    end
+
+    def run_step(ctx, defn)
+      last_error = nil
+      (defn.retry_count + 1).times do
+        execute_step_block(ctx, defn)
+        return
+      rescue StandardError => e
+        last_error = e
+      end
+      raise FlowStepError,
+            "flow '#{@name}' step '#{defn.label}' failed: #{last_error.message}"
+    end
+
+    def execute_step_block(ctx, defn)
+      if defn.timeout
+        ::Timeout.timeout(defn.timeout) { ctx.instance_exec(&defn.block) }
+      else
+        ctx.instance_exec(&defn.block)
+      end
+    rescue ::Timeout::Error
+      raise FlowStepError,
+            "flow '#{@name}' step '#{defn.label}' timed out after #{defn.timeout}s"
+    end
+
+    def produce_state(ctx)
+      return nil unless @produces_state_block
+
+      ctx.instance_exec(&@produces_state_block)
     end
   end
 


### PR DESCRIPTION
WS-1 PR #2 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md). **Stacked on #82** — base is \`feat/flow-dsl-class\`, retarget to \`main\` once #82 merges.

## What

\`Flow#run(page: nil, client: nil, **params)\` — executable flows.

Execution order:
1. **Resolve params** — \`secret_ref:\` resolved via the existing \`SecretResolverRegistry\` (env / keychain / 1Password). Required-but-missing raises \`FlowParamError\`. Defaults applied when caller doesn't pass the key.
2. **Preconditions** — each block \`instance_exec\`'d against a \`FlowContext\`. Falsey return or raise → \`FlowPreconditionError\`.
3. **Steps** — same context. Honors \`retry_count\` and \`timeout\` (mirrors the workflow runner). Final failure → \`FlowStepError\`.
4. **Postconditions** — same rules as preconditions, raises \`FlowPostconditionError\`.
5. **produces_state** — block result returned from \`#run\`.

\`FlowContext\` exposes \`page\`, \`client\`, \`params\` as accessors and resolves \`@params\` keys via \`method_missing\`, matching the workflow context idiom.

## Typed errors

New hierarchy under \`Browserctl::Error\`:

\`\`\`
WorkflowError
└── FlowError                     code: flow_error
    ├── FlowParamError            code: flow_param_error
    ├── FlowPreconditionError     code: flow_precondition_failed
    ├── FlowStepError             code: flow_step_failed
    └── FlowPostconditionError    code: flow_postcondition_failed
\`\`\`

Codes follow the existing \`Error#code\` convention so they can surface in JSON-RPC responses later (relevant to WS-5's \`AUTH_REQUIRED\`).

## What this PR does NOT do

- **No specs.** WS-1 PR #3 covers param coercion, secret resolution, pre/post short-circuit, error paths, retry/timeout.
- **No registry / auto-loading.** WS-2 PR #4.
- **No real \`page\`.** Default \`page: nil\` keeps \`#run\` callable in unit tests; PR #5 wires it in via the workflow's \`invoke\`.

## Verification

- Smoke-tested via \`ruby -Ilib\`: happy path with mixed plain/secret_ref/default params; missing required; failed precondition; step retry success-on-second; step retry exhausted; step timeout; failed postcondition. All produce the right typed error and code.
- \`bundle exec rspec spec/unit\` — 300/0.
- \`bundle exec rubocop\` — clean.