### PR TITLE
feat: flow registry

### DIFF
--- a/lib/browserctl/flow.rb
+++ b/lib/browserctl/flow.rb
@@ -186,9 +186,30 @@ module Browserctl
     end
   end
 
+  @flow_registry_mutex = Mutex.new
+  @flow_registry       = {}
+
   def self.flow(name, &block)
     raise ArgumentError, "Browserctl.flow requires a block" unless block
 
-    Flow.new(name).tap { |f| f.instance_exec(&block) }
+    flow = Flow.new(name).tap { |f| f.instance_exec(&block) }
+    register_flow(flow)
+    flow
+  end
+
+  def self.register_flow(flow)
+    @flow_registry_mutex.synchronize { @flow_registry[flow.name] = flow }
+  end
+
+  def self.lookup_flow(name)
+    @flow_registry_mutex.synchronize { @flow_registry[name.to_s] }
+  end
+
+  def self.flow_registry_snapshot
+    @flow_registry_mutex.synchronize { @flow_registry.dup }
+  end
+
+  def self.flow_registry_reset!
+    @flow_registry_mutex.synchronize { @flow_registry.clear }
   end
 end

--- a/lib/browserctl/flow_registry.rb
+++ b/lib/browserctl/flow_registry.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "flow"
+
+module Browserctl
+  # Discovers and loads flow files from project, user, and bundled stdlib
+  # locations. Project flows shadow user flows, which shadow stdlib flows.
+  #
+  # Files are plain Ruby; loading them is expected to invoke
+  # `Browserctl.flow(name) { ... }`, which registers the flow in the global
+  # registry. Filename should match the registered name (validated lazily —
+  # mismatches are allowed but discouraged).
+  class FlowRegistry
+    SAFE_NAME = /\A[a-zA-Z0-9_-]+\z/
+
+    # Search order: highest-precedence last so later registrations
+    # overwrite earlier ones in the global registry.
+    def self.bundled_dir = File.expand_path("flows/stdlib", __dir__)
+    def self.user_dir    = File.expand_path("~/.browserctl/flows")
+    def self.project_dir = "./.browserctl/flows"
+
+    def self.search_paths
+      [bundled_dir, user_dir, project_dir]
+    end
+
+    # Loads every flow file from every search path. Lower-precedence dirs
+    # run first; project files load last and win on name collisions.
+    def self.load_all
+      search_paths.each do |dir|
+        next unless Dir.exist?(dir)
+
+        Dir.glob(File.join(dir, "*.rb")).each { |f| load f }
+      end
+      Browserctl.flow_registry_snapshot
+    end
+
+    # Resolves a name to a registered flow, loading from disk on demand.
+    # Searches in precedence order: project → user → stdlib. The first
+    # matching file is loaded and the flow returned via the global registry.
+    def self.resolve(name)
+      validate_name!(name)
+      existing = Browserctl.lookup_flow(name)
+      return existing if existing
+
+      search_paths.reverse_each do |dir|
+        candidate = File.join(dir, "#{name}.rb")
+        next unless File.exist?(candidate)
+
+        load candidate
+        flow = Browserctl.lookup_flow(name)
+        return flow if flow
+      end
+      nil
+    end
+
+    def self.list
+      load_all.map { |n, f| { name: n, desc: f.description, version: f.version_string } }
+    end
+
+    def self.validate_name!(name)
+      return if SAFE_NAME.match?(name.to_s)
+
+      raise ArgumentError, "invalid flow name: #{name.inspect} — use letters, digits, _ and - only"
+    end
+  end
+end

--- a/spec/unit/flow_registry_spec.rb
+++ b/spec/unit/flow_registry_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+require "browserctl/flow_registry"
+
+RSpec.describe Browserctl::FlowRegistry do
+  around do |ex|
+    Dir.mktmpdir do |project_root|
+      Dir.mktmpdir do |home|
+        @project_root = project_root
+        @home = home
+        @user_dir = File.join(home, ".browserctl/flows")
+        @stdlib_dir = File.join(project_root, "_stdlib")
+        FileUtils.mkdir_p(File.join(project_root, ".browserctl/flows"))
+        FileUtils.mkdir_p(@user_dir)
+        FileUtils.mkdir_p(@stdlib_dir)
+        Dir.chdir(project_root) { ex.run }
+      end
+    end
+  end
+
+  before do
+    Browserctl.flow_registry_reset!
+    allow(described_class).to receive_messages(user_dir: @user_dir, bundled_dir: @stdlib_dir)
+  end
+
+  def write_flow(dir, name, body = "step('s') { nil }")
+    path = File.join(dir, "#{name}.rb")
+    File.write(path, "Browserctl.flow(#{name.inspect}) do\n  desc 'from #{File.basename(dir)}'\n  #{body}\nend\n")
+    path
+  end
+
+  describe ".resolve" do
+    it "loads and returns a flow from the project dir" do
+      write_flow("./.browserctl/flows", "alpha")
+
+      flow = described_class.resolve("alpha")
+
+      expect(flow).to be_a(Browserctl::Flow)
+      expect(flow.name).to eq("alpha")
+    end
+
+    it "falls back to the user dir when project has no match" do
+      write_flow(@user_dir, "userflow")
+
+      flow = described_class.resolve("userflow")
+
+      expect(flow.description).to eq("from flows")
+    end
+
+    it "falls back to the stdlib dir when project and user have no match" do
+      write_flow(@stdlib_dir, "stdflow")
+
+      flow = described_class.resolve("stdflow")
+
+      expect(flow.description).to eq("from _stdlib")
+    end
+
+    it "returns nil when no file matches" do
+      expect(described_class.resolve("missing")).to be_nil
+    end
+
+    it "returns the already-registered flow without re-loading" do
+      Browserctl.flow("inmemory") { desc "live" }
+
+      flow = described_class.resolve("inmemory")
+
+      expect(flow.description).to eq("live")
+    end
+
+    it "rejects unsafe flow names" do
+      expect { described_class.resolve("../etc/passwd") }
+        .to raise_error(ArgumentError, /invalid flow name/)
+    end
+
+    it "prefers the project file when both project and stdlib define the same name" do
+      write_flow(@stdlib_dir, "shared", "desc 'stdlib version'")
+      write_flow("./.browserctl/flows", "shared", "desc 'project version'")
+
+      flow = described_class.resolve("shared")
+
+      expect(flow.description).to eq("project version")
+    end
+  end
+
+  describe ".load_all" do
+    it "loads every flow from every search dir, project winning collisions" do
+      write_flow(@stdlib_dir, "shared", "desc 'stdlib'")
+      write_flow(@user_dir, "shared", "desc 'user'")
+      write_flow("./.browserctl/flows", "shared", "desc 'project'")
+      write_flow(@user_dir, "user_only")
+      write_flow(@stdlib_dir, "std_only")
+
+      snapshot = described_class.load_all
+
+      expect(snapshot.keys).to contain_exactly("shared", "user_only", "std_only")
+      expect(snapshot["shared"].description).to eq("project")
+    end
+
+    it "returns an empty snapshot when no dirs have flows" do
+      expect(described_class.load_all).to be_empty
+    end
+  end
+
+  describe ".list" do
+    it "returns name, desc, and version for each flow" do
+      File.write(
+        "./.browserctl/flows/listed.rb",
+        "Browserctl.flow('listed') do\n  version '2.1.0'\n  desc 'L'\n  step('s') { nil }\nend\n"
+      )
+
+      entry = described_class.list.find { |h| h[:name] == "listed" }
+
+      expect(entry).to eq(name: "listed", desc: "L", version: "2.1.0")
+    end
+  end
+end


### PR DESCRIPTION
WS-2 PR #4 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md).

## What

\`Browserctl::FlowRegistry\` discovers and loads flow files from three search paths, in precedence order:

1. \`./.browserctl/flows\` — project (highest)
2. \`~/.browserctl/flows\` — user
3. \`lib/browserctl/flows/stdlib\` — bundled (lowest)

Lower-precedence dirs are loaded *first*, so later registrations from higher-precedence dirs overwrite them in the global registry. Project always wins ties.

## API

| Method | Use |
|---|---|
| \`Browserctl.flow(name) { ... }\` | DSL builder (now registers, mirroring \`Browserctl.workflow\`) |
| \`Browserctl.lookup_flow(name)\` | Reads the global registry |
| \`Browserctl.register_flow(flow)\` | Direct registration (for non-DSL callers) |
| \`Browserctl.flow_registry_snapshot\` | Dup of the registry hash |
| \`Browserctl.flow_registry_reset!\` | Test hook |
| \`FlowRegistry.resolve(name)\` | Lazy load by name (project → user → stdlib), validates name with \`/\\A[a-zA-Z0-9_-]+\\z/\` |
| \`FlowRegistry.load_all\` | Eagerly loads every flow file, returns snapshot |
| \`FlowRegistry.list\` | \`{name:, desc:, version:}\` triples for the CLI in PR #6 |

Search paths are exposed as class methods (\`bundled_dir\`, \`user_dir\`, \`project_dir\`) rather than constants — keeps test setup clean (stub the methods) and avoids \`stub_const\` lifecycle issues.

## What this PR does NOT do

- **No \`invoke :flow_name\` from workflow DSL** — that's PR #5.
- **No CLI** — \`browserctl flow run/list/describe\` is PR #6.
- **No actual stdlib flows** — \`lib/browserctl/flows/stdlib/.keep\` only. WS-3 (PRs #7–10) populate it.

## Verification

- \`bundle exec rspec\` — 333/0 (10 new flow_registry specs cover lazy resolve from each dir, fallback chain, in-memory hit avoids re-load, unsafe-name guard, project-wins-on-collision, \`load_all\` precedence, empty case, \`list\` shape).
- \`bundle exec rubocop\` — clean.