### PR TITLE
feat: invoke flows from workflow DSL

### DIFF
--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -3,6 +3,7 @@
 require "timeout"
 require_relative "client"
 require_relative "errors"
+require_relative "flow_registry"
 require_relative "secret_resolvers"
 require_relative "session"
 
@@ -94,10 +95,16 @@ module Browserctl
       $stdin.gets.chomp
     end
 
-    def invoke(workflow_name, **override_params)
-      name = workflow_name.to_s
+    def invoke(target_name, page: nil, **override_params)
+      name = target_name.to_s
       guard_circular!(name)
-      track_invoke(name) { run_nested(workflow_name, **override_params) }
+
+      flow = lookup_flow_target(name)
+      if flow
+        track_invoke(name) { run_invoked_flow(flow, page_name: page, **override_params) }
+      else
+        track_invoke(name) { run_nested(target_name, **override_params) }
+      end
     end
 
     def assert(condition, msg = "assertion failed")
@@ -181,6 +188,19 @@ module Browserctl
 
     def run_nested(workflow_name, **override_params)
       Runner.new.run_workflow(workflow_name, **@params, **override_params)
+    end
+
+    def lookup_flow_target(name)
+      Browserctl.lookup_flow(name) || begin
+        FlowRegistry.resolve(name)
+      rescue ArgumentError
+        nil
+      end
+    end
+
+    def run_invoked_flow(flow, page_name:, **params)
+      proxy = page_name ? page(page_name) : nil
+      flow.run(page: proxy, client: @client, **params)
     end
   end
 

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -430,6 +430,86 @@ RSpec.describe Browserctl::WorkflowContext do
       expect { ctx.invoke("loop_a") }.to raise_error(Browserctl::WorkflowError, /circular/)
     end
   end
+
+  describe "#invoke flow dispatch" do
+    before { Browserctl.flow_registry_reset! }
+    after  { Browserctl.flow_registry_reset! }
+
+    it "runs a registered flow when the name resolves to one" do
+      received = nil
+      Browserctl.flow("greet") do
+        param :who
+        step("s") { received = who }
+      end
+
+      ctx = described_class.new({}, client)
+      ctx.invoke("greet", who: "patrick")
+
+      expect(received).to eq("patrick")
+    end
+
+    it "passes the named page proxy to the flow" do
+      seen = nil
+      Browserctl.flow("uses_page") do
+        step("s") { seen = page }
+      end
+
+      ctx = described_class.new({}, client)
+      ctx.invoke("uses_page", page: :main)
+
+      expect(seen).to be_a(Browserctl::PageProxy)
+    end
+
+    it "passes nil page when no page: kwarg given" do
+      seen = :unset
+      Browserctl.flow("no_page") do
+        step("s") { seen = page }
+      end
+
+      described_class.new({}, client).invoke("no_page")
+
+      expect(seen).to be_nil
+    end
+
+    it "exposes the workflow's client to the flow" do
+      seen = nil
+      Browserctl.flow("uses_client") do
+        step("s") { seen = client }
+      end
+
+      described_class.new({}, client).invoke("uses_client")
+
+      expect(seen).to equal(client)
+    end
+
+    it "prefers a registered flow over a registered workflow with the same name" do
+      Browserctl.workflow "shadow" do
+        step("wf") { raise "should not run" }
+      end
+      Browserctl.flow("shadow") { step("flow_step") { :flow_ran } }
+
+      expect { described_class.new({}, client).invoke("shadow") }.not_to raise_error
+    ensure
+      Browserctl.instance_variable_get(:@registry).delete("shadow")
+    end
+
+    it "falls through to workflow invocation when no flow matches" do
+      ctx = described_class.new({}, client)
+      runner = instance_double(Browserctl::Runner, run_workflow: true)
+      allow(Browserctl::Runner).to receive(:new).and_return(runner)
+
+      ctx.invoke("only_a_workflow")
+
+      expect(runner).to have_received(:run_workflow).with("only_a_workflow")
+    end
+
+    it "propagates flow typed errors" do
+      Browserctl.flow("guarded") { precondition("on page") { false } }
+
+      expect { described_class.new({}, client).invoke("guarded") }
+        .to raise_error(Browserctl::FlowPreconditionError)
+    end
+  end
 end
 
 RSpec.describe "WorkflowContext compose guard" do


### PR DESCRIPTION
WS-2 PR #5 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md). Follows #86.

## What

`WorkflowContext#invoke` now dispatches to a registered flow when the name resolves through `Browserctl.lookup_flow` or `FlowRegistry.resolve`, falling back to nested-workflow invocation otherwise.

```ruby
workflow :do_it do
  step "login" do
    open_page :main, url: "https://github.com/login"
    invoke :github_login, page: :main, username: "p"
  end
end
```

## API delta

`invoke` gains `page:` — page name passed through as a `PageProxy` to the flow's `page` attr (nil when omitted). Workflow's `@client` is always passed.

## Dispatch order

1. `Browserctl.lookup_flow(name)` (already-registered)
2. `FlowRegistry.resolve(name)` (lazy load: project → user → stdlib)
3. `Runner.new.run_workflow(name)` (existing path)

If a workflow and flow share a name, **the flow wins** — flows are the more specific concept.

`ArgumentError` from `FlowRegistry.resolve` (unsafe name) is swallowed so dispatch falls through cleanly to the workflow path; workflow's own validator handles invalid names with `WorkflowError`.

## Verification

- `bundle exec rspec` — 340/0 (7 new specs: flow dispatch, page proxy passed, nil page, client passed, flow shadows workflow, fallthrough, typed errors propagate).
- `bundle exec rubocop` — clean.

## Not in this PR

- CLI `flow run/list/describe` (PR #6)
- `on_auth_required` hook (WS-5 PR #18)