### PR TITLE
feat: browserctl flow run/list/describe CLI

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -27,6 +27,7 @@ require "browserctl/commands/storage"
 require "browserctl/commands/session"
 require "browserctl/commands/daemon"
 require "browserctl/commands/workflow"
+require "browserctl/commands/flow"
 require "browserctl/commands/dialog"
 require "browserctl/commands/ask"
 
@@ -105,6 +106,11 @@ def usage
       workflow list
       workflow describe <name>
 
+    Flow:
+      flow run      <name|file> [--page NAME] [--params file] [--key value ...]
+      flow list
+      flow describe <name>
+
     Daemon:
       daemon start  [--headed] [--name NAME]
       daemon stop
@@ -142,6 +148,7 @@ else
   client = Browserctl::Client.new(Browserctl.socket_path(daemon_name))
 
   case cmd
+  when "flow"     then Browserctl::Commands::Flow.run(client, args)
   when "page"     then Browserctl::Commands::Page.run(client, args)
   when "cookie"   then Browserctl::Commands::Cookie.run(client, args)
   when "storage"  then Browserctl::Commands::Storage.run(client, args)

--- a/lib/browserctl/commands/flow.rb
+++ b/lib/browserctl/commands/flow.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "cli_output"
+require_relative "../flow_registry"
+require_relative "../runner"
+
+module Browserctl
+  module Commands
+    module Flow
+      extend CliOutput
+
+      USAGE = "Usage: browserctl flow <run|list|describe> [args]"
+
+      def self.run(client, args)
+        sub = args.shift or abort USAGE
+        case sub
+        when "run"      then run_flow(client, args)
+        when "list"     then run_list
+        when "describe" then run_describe(args)
+        else abort "unknown flow subcommand '#{sub}'\n#{USAGE}"
+        end
+      end
+
+      def self.run_flow(client, args)
+        name = args.shift or
+          abort "usage: browserctl flow run <name|file> [--page NAME] [--params FILE] [--key value ...]"
+
+        flow = resolve(name)
+        page_name, params = parse_run_args(args)
+        page_proxy = page_name ? Browserctl::PageProxy.new(page_name, client) : nil
+
+        result = flow.run(page: page_proxy, client: client, **params)
+        puts JSON.generate(ok: true, flow: flow.name, result: serialisable(result))
+      rescue Browserctl::FlowError => e
+        warn "Error: #{e.message}"
+        puts JSON.generate(ok: false, code: e.code, error: e.message)
+        exit 1
+      end
+
+      def self.run_list
+        entries = Browserctl::FlowRegistry.list
+        puts JSON.generate(flows: entries)
+      end
+
+      def self.run_describe(args)
+        name = args.shift or abort "usage: browserctl flow describe <name>"
+        flow = resolve(name)
+        puts JSON.pretty_generate(
+          name: flow.name,
+          desc: flow.description,
+          version: flow.version_string,
+          requires_browserctl: flow.min_browserctl_version,
+          params: format_params(flow),
+          preconditions: flow.preconditions.map(&:label),
+          steps: flow.steps.map(&:label),
+          postconditions: flow.postconditions.map(&:label),
+          produces_state: !flow.produces_state_block.nil?
+        )
+      end
+
+      def self.resolve(name_or_path)
+        if File.exist?(name_or_path)
+          before = Browserctl.flow_registry_snapshot.keys
+          load File.expand_path(name_or_path)
+          new_name = (Browserctl.flow_registry_snapshot.keys - before).first
+          new_name ||= File.basename(name_or_path, ".rb")
+          flow = Browserctl.lookup_flow(new_name)
+        else
+          flow = Browserctl::FlowRegistry.resolve(name_or_path)
+        end
+        flow or abort "flow '#{name_or_path}' not found"
+      end
+
+      def self.parse_run_args(args)
+        page_name = take_option(args, "--page")
+        params_path = take_option(args, "--params")
+        file_params = params_path ? load_params_file(params_path) : {}
+        cli_params = pair_args(args)
+        [page_name, file_params.merge(cli_params)]
+      end
+
+      def self.take_option(args, flag)
+        idx = args.index(flag)
+        return nil unless idx
+
+        value = args.delete_at(idx + 1)
+        args.delete_at(idx)
+        value
+      end
+
+      def self.load_params_file(path)
+        Browserctl::Runner.load_params_file(path)
+      rescue StandardError => e
+        abort "Error loading params file: #{e.message}"
+      end
+
+      def self.pair_args(args)
+        out = {}
+        args.each_slice(2) do |flag, val|
+          out[flag.sub(/\A--/, "").to_sym] = val
+        end
+        out
+      end
+
+      def self.format_params(flow)
+        flow.param_defs.transform_values do |p|
+          entry = { required: p.required, secret: p.secret, default: p.default }
+          entry[:secret_ref] = p.secret_ref if p.secret_ref
+          entry
+        end
+      end
+
+      def self.serialisable(value)
+        case value
+        when nil, true, false, Numeric, String, Hash, Array then value
+        when Symbol then value.to_s
+        else value.respond_to?(:to_h) ? value.to_h : value.to_s
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/commands_flow_spec.rb
+++ b/spec/unit/commands_flow_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+require "browserctl/commands/flow"
+
+RSpec.describe Browserctl::Commands::Flow do
+  let(:client) { instance_double(Browserctl::Client) }
+
+  before { Browserctl.flow_registry_reset! }
+  after  { Browserctl.flow_registry_reset! }
+
+  describe ".run_list" do
+    it "prints registered flows as JSON" do
+      Browserctl.flow("alpha") do
+        version "1.2.3"
+        desc "first"
+      end
+      allow(Browserctl::FlowRegistry).to receive(:list)
+        .and_return([{ name: "alpha", desc: "first", version: "1.2.3" }])
+
+      out = capture_stdout { described_class.run(client, ["list"]) }
+      payload = JSON.parse(out)
+
+      expect(payload["flows"]).to eq([{ "name" => "alpha", "desc" => "first", "version" => "1.2.3" }])
+    end
+  end
+
+  describe ".run_describe" do
+    it "prints flow shape as pretty JSON" do
+      Browserctl.flow("alpha") do
+        version "2.0.0"
+        desc "alpha"
+        param :who, required: true
+        precondition("on page") { true }
+        step("greet") { nil }
+        postcondition("done") { true }
+        produces_state { :state }
+      end
+
+      out = capture_stdout { described_class.run(client, %w[describe alpha]) }
+      payload = JSON.parse(out)
+
+      expect(payload).to include(
+        "name" => "alpha",
+        "version" => "2.0.0",
+        "desc" => "alpha",
+        "preconditions" => ["on page"],
+        "steps" => ["greet"],
+        "postconditions" => ["done"],
+        "produces_state" => true
+      )
+      expect(payload["params"]["who"]).to include("required" => true, "secret" => false)
+    end
+
+    it "exits when the flow is not found" do
+      expect { described_class.run(client, %w[describe missing]) }
+        .to raise_error(SystemExit)
+    end
+  end
+
+  describe ".run_flow" do
+    it "runs the named flow with kwargs and prints success JSON" do
+      Browserctl.flow("alpha") do
+        param :who
+        step("s") { params[:who] }
+      end
+
+      out = capture_stdout { described_class.run(client, %w[run alpha --who patrick]) }
+      payload = JSON.parse(out)
+
+      expect(payload).to eq("ok" => true, "flow" => "alpha", "result" => nil)
+    end
+
+    it "passes a PageProxy when --page is given" do
+      seen = nil
+      Browserctl.flow("alpha") { step("s") { seen = page } }
+
+      capture_stdout { described_class.run(client, %w[run alpha --page main]) }
+
+      expect(seen).to be_a(Browserctl::PageProxy)
+    end
+
+    it "exits 1 with error JSON on FlowError" do
+      Browserctl.flow("alpha") do
+        param :who, required: true
+        step("s") { nil }
+      end
+
+      original = $stdout
+      $stdout = StringIO.new
+      expect { described_class.run(client, %w[run alpha]) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      payload = JSON.parse($stdout.string)
+      $stdout = original
+      expect(payload).to include("ok" => false, "code" => "flow_param_error")
+    end
+
+    it "loads a flow from a file path" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "fileflow.rb")
+        File.write(path, "Browserctl.flow('fileflow') { desc 'from file'; step('s') { nil } }\n")
+
+        out = capture_stdout { described_class.run(client, ["run", path]) }
+        payload = JSON.parse(out)
+
+        expect(payload).to include("ok" => true, "flow" => "fileflow")
+      end
+    end
+
+    it "merges --params file values with --key value pairs" do
+      seen = {}
+      Browserctl.flow("alpha") do
+        param :a
+        param :b
+        step("s") do
+          seen[:a] = params[:a]
+          seen[:b] = params[:b]
+        end
+      end
+
+      Dir.mktmpdir do |dir|
+        params_path = File.join(dir, "p.json")
+        File.write(params_path, JSON.generate(a: "from_file"))
+
+        capture_stdout do
+          described_class.run(client, ["run", "alpha", "--params", params_path, "--b", "from_cli"])
+        end
+
+        expect(seen).to eq(a: "from_file", b: "from_cli")
+      end
+    end
+  end
+
+  describe "subcommand dispatch" do
+    it "aborts with usage when no subcommand given" do
+      expect { described_class.run(client, []) }.to raise_error(SystemExit)
+    end
+
+    it "aborts on unknown subcommand" do
+      expect { described_class.run(client, %w[zorp]) }.to raise_error(SystemExit)
+    end
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+end


### PR DESCRIPTION
WS-2 PR #6 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md). **Closes WS-2.** Follows #88.

## What

Adds the third top-level multi-verb CLI command, mirroring \`workflow\`:

\`\`\`
flow run <name|file> [--page NAME] [--params FILE] [--key val ...]
flow list
flow describe <name>
\`\`\`

### \`flow run\`

Resolves via \`FlowRegistry\` (by name) or by file path. With \`--page main\`, builds a \`PageProxy("main", client)\` and passes it as the flow's \`page\` attr; without, the flow gets nil. Output:

- success → \`{"ok":true,"flow":"...","result":...}\` exit 0
- \`FlowError\` → \`{"ok":false,"code":"flow_param_error","error":"..."}\` exit 1, message also printed to stderr

\`--params FILE\` (JSON or YAML, reuses \`Runner.load_params_file\`) merges with \`--key value\` CLI pairs; CLI wins on collision — same shape as \`workflow run\`.

### \`flow list\` / \`flow describe\`

\`list\` returns \`{"flows":[{name,desc,version},...]}\` from \`FlowRegistry.list\`.

\`describe\` prints \`name, desc, version, requires_browserctl, params, preconditions, steps, postconditions, produces_state\` (boolean) as pretty JSON.

## Smoke (manual)

\`\`\`
$ browserctl flow list
{"flows":[{"name":"demo","desc":"A demo flow","version":"1.0.0"}]}

$ browserctl flow describe demo
{ "name": "demo", "version": "1.0.0", ... }

$ browserctl flow run demo --who patrick
{"ok":true,"flow":"demo","result":null}

$ browserctl flow run demo
Error: flow 'demo' requires param 'who'
{"ok":false,"code":"flow_param_error","error":"flow 'demo' requires param 'who'"}
$ echo $?
1
\`\`\`

## Verification

- \`bundle exec rspec\` — 350/0 (10 new specs: list shape, describe shape, missing flow exits, run happy path, --page builds PageProxy, FlowError exits 1 with JSON, file path loading, --params + --key merge, no-subcommand abort, unknown-subcommand abort).
- \`bundle exec rubocop\` — clean.

## Plan acceptance

WS-2 acceptance: "browserctl flow list shows a stdlib flow; browserctl flow run github_login works against a live page." Stdlib flows arrive in WS-3 (PRs #7-10) — until then, list is empty and \`flow run\` works against project/user-defined flows. The CLI plumbing is fully in place; WS-3 will fill the registry without further CLI changes.