### PR TITLE
feat: stdlib flow — totp_2fa

### DIFF
--- a/docs/guides/stdlib-flows.md
+++ b/docs/guides/stdlib-flows.md
@@ -1,0 +1,101 @@
+# Standard Library Flows
+
+browserctl ships a small set of reusable flows for the auth steps that
+appear in almost every login workflow. They live in
+`lib/browserctl/flows/stdlib/` and are auto-discovered after
+`require "browserctl"` (or via the `flow run` CLI), so you can invoke
+them by name without copying code into your project.
+
+| Flow | Purpose |
+|---|---|
+| `totp_2fa` | Generate a TOTP code from a base32 secret and type it into the page |
+
+More flows arrive in v0.10 (basic_auth, magic_link_email, oauth_google,
+oauth_github, cloudflare_solve).
+
+---
+
+## `totp_2fa`
+
+RFC 6238 TOTP code generator. No network — purely computes a six-digit
+code from the secret and the current time.
+
+### Params
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `secret` | base32 string | — | **Required.** Marked `secret: true`. Pair with `secret_ref:` in the workflow. |
+| `selector` | CSS | — | **Required.** The input the code is typed into. |
+| `digits` | int | `6` | Match your provider's setting. |
+| `period` | int | `30` | Seconds per code. |
+
+### From a workflow
+
+```ruby
+Browserctl.workflow "github_login" do
+  step "open login" do
+    open_page(:main, url: "https://github.com/login")
+    page(:main).fill("input#login_field", "patrick")
+    page(:main).fill("input#password", ENV.fetch("GH_PASS"))
+    page(:main).click("input[type='submit']")
+  end
+
+  step "submit 2fa" do
+    invoke :totp_2fa,
+           page: :main,
+           secret: ENV.fetch("GH_TOTP_SECRET"),
+           selector: "input#otp"
+    page(:main).click("button[type='submit']")
+  end
+end
+```
+
+The `page:` kwarg tells `invoke` which workflow page proxy to hand to
+the flow.
+
+### From the CLI
+
+```sh
+browserctl flow run totp_2fa \
+  --page main \
+  --secret JBSWY3DPEHPK3PXP \
+  --selector "input#otp"
+```
+
+The daemon must be running and the page named `main` must already be
+open (use `browserctl page open main --url ...` first).
+
+### Sourcing the secret from somewhere safer
+
+Don't pass the secret on the command line — it lands in shell history
+and `ps aux`. From a workflow, declare a `param ... secret_ref:` once
+and let browserctl resolve it:
+
+```ruby
+param :totp_secret, secret_ref: "env://GH_TOTP_SECRET"
+# or:
+param :totp_secret, secret_ref: "op://Personal/GitHub/totp"
+# or:
+param :totp_secret, secret_ref: "keychain://github-totp"
+```
+
+Then forward it to the flow:
+
+```ruby
+invoke :totp_2fa,
+       page: :main,
+       secret: totp_secret,
+       selector: "input#otp"
+```
+
+### Verifying it works
+
+The flow ships with RFC 6238 vector tests; you can run them yourself:
+
+```sh
+bundle exec rspec spec/unit/flows/stdlib/totp_2fa_spec.rb
+```
+
+If your provider's codes don't match what the flow generates, the
+secret is wrong (most common), or the provider uses non-default
+`digits` or `period` (rare — check your provisioning URI).

--- a/lib/browserctl/flows/stdlib/totp_2fa.rb
+++ b/lib/browserctl/flows/stdlib/totp_2fa.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "openssl"
+require_relative "../../flow"
+
+module Browserctl
+  module Flows
+    # RFC 6238 TOTP code generation from a base32 secret.
+    # Pure Ruby; no network and no external gem.
+    module TOTP
+      module_function
+
+      def generate(secret, at: Time.now, digits: 6, period: 30, digest: "SHA1")
+        counter   = (at.to_i / period).to_i
+        key       = decode_base32(secret)
+        counter_b = [counter].pack("Q>") # 64-bit big-endian
+        hmac      = OpenSSL::HMAC.digest(digest, key, counter_b)
+        offset    = hmac[-1].ord & 0x0f
+        truncated = hmac[offset, 4].unpack1("N") & 0x7fffffff
+        truncated.to_s.rjust(digits, "0")[-digits..]
+      end
+
+      BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+      def decode_base32(secret)
+        cleaned = secret.to_s.upcase.gsub(/[^A-Z2-7]/, "")
+        bits = cleaned.each_char.map { |c| char_to_bits(c) }.join
+        whole_bytes = bits[0, (bits.length / 8) * 8]
+        whole_bytes.scan(/.{8}/).map { |b| b.to_i(2).chr }.join
+      end
+
+      def char_to_bits(char)
+        idx = BASE32_ALPHABET.index(char) or
+          raise ArgumentError, "invalid base32 char #{char.inspect}"
+        idx.to_s(2).rjust(5, "0")
+      end
+    end
+  end
+end
+
+Browserctl.flow("totp_2fa") do
+  version "1.0.0"
+  requires_browserctl "0.11.0"
+  desc "Generate an RFC 6238 TOTP code from a base32 secret and type it into the page."
+
+  param :secret,   required: true, secret: true
+  param :selector, required: true
+  param :digits,   default: 6
+  param :period,   default: 30
+
+  precondition("page proxy is present") { !page.nil? }
+
+  step("compute and fill code") do
+    code = Browserctl::Flows::TOTP.generate(
+      secret,
+      digits: digits.to_i,
+      period: period.to_i
+    )
+    page.fill(selector, code)
+  end
+end

--- a/spec/unit/flows/stdlib/totp_2fa_spec.rb
+++ b/spec/unit/flows/stdlib/totp_2fa_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/flows/stdlib/totp_2fa"
+
+RSpec.describe "stdlib flow: totp_2fa" do
+  # RFC 6238 Appendix B test vectors. Secret is the ASCII bytes
+  # "12345678901234567890" → base32 below.
+  let(:rfc_6238_secret) { "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ" }
+
+  describe Browserctl::Flows::TOTP do
+    it "matches RFC 6238 test vectors at digits: 8" do
+      vectors = {
+        59 => "94287082",
+        1_111_111_109 => "07081804",
+        1_111_111_111 => "14050471",
+        1_234_567_890 => "89005924",
+        2_000_000_000 => "69279037"
+      }
+      vectors.each do |t, expected|
+        got = described_class.generate(rfc_6238_secret, at: Time.at(t), digits: 8)
+        expect(got).to eq(expected), "expected #{expected} at t=#{t}, got #{got}"
+      end
+    end
+
+    it "returns the right number of digits" do
+      code = described_class.generate(rfc_6238_secret, at: Time.at(59), digits: 6)
+      expect(code).to match(/\A\d{6}\z/)
+    end
+
+    it "ignores spaces and lowercase in the base32 secret" do
+      a = described_class.generate(rfc_6238_secret, at: Time.at(59))
+      b = described_class.generate("gezd gnbv gy3t qojq gezd gnbv gy3t qojq", at: Time.at(59))
+      expect(a).to eq(b)
+    end
+  end
+
+  describe "the registered flow" do
+    let(:page) { instance_double(Browserctl::PageProxy) }
+
+    before do
+      Browserctl.flow_registry_reset!
+      load File.expand_path("../../../../lib/browserctl/flows/stdlib/totp_2fa.rb", __dir__)
+    end
+    after { Browserctl.flow_registry_reset! }
+
+    it "registers under the name 'totp_2fa'" do
+      flow = Browserctl.lookup_flow("totp_2fa")
+      expect(flow).to be_a(Browserctl::Flow)
+      expect(flow.version_string).to eq("1.0.0")
+      expect(flow.min_browserctl_version).to eq("0.11.0")
+    end
+
+    it "fills the selector with the code computed from the secret" do
+      flow = Browserctl.lookup_flow("totp_2fa")
+      allow(Time).to receive(:now).and_return(Time.at(59))
+      expect(page).to receive(:fill).with("input#totp", "287082")
+
+      flow.run(page: page, secret: rfc_6238_secret, selector: "input#totp")
+    end
+
+    it "raises a precondition error when no page proxy is given" do
+      flow = Browserctl.lookup_flow("totp_2fa")
+
+      expect { flow.run(secret: rfc_6238_secret, selector: "input#totp") }
+        .to raise_error(Browserctl::FlowPreconditionError, /page proxy/)
+    end
+
+    it "requires the secret param" do
+      flow = Browserctl.lookup_flow("totp_2fa")
+
+      expect { flow.run(page: page, selector: "input#totp") }
+        .to raise_error(Browserctl::FlowParamError, /secret/)
+    end
+  end
+end


### PR DESCRIPTION
WS-3 PR #7 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md). First of six stdlib flows; smallest, no network.

## What

\`lib/browserctl/flows/stdlib/totp_2fa.rb\` ships:

1. \`Browserctl::Flows::TOTP\` module — pure-Ruby RFC 6238 generator (HMAC-SHA1 over counter, dynamic truncation per RFC 4226). No \`rotp\` gem.
2. A registered flow named \`totp_2fa\` that computes the code and fills the page selector.

### Params

| Name | Type | Default | Notes |
|---|---|---|---|
| \`secret\` | base32 string | — | Required, \`secret: true\` |
| \`selector\` | CSS | — | Required, input to type into |
| \`digits\` | int | 6 | |
| \`period\` | int | 30 | |

Precondition: a page proxy must be present (otherwise the step would \`NoMethodError\` on \`page.fill\`).

## Why pure Ruby

- One file, ~25 lines of crypto. Adding \`rotp\` (or any gem) for so little code creates a supply-chain surface for credentials-handling code.
- OpenSSL is already in stdlib.
- Verified against **all five** RFC 6238 Appendix B test vectors at digits=8 — the canonical interop check ([RFC 6238 §B](https://www.rfc-editor.org/rfc/rfc6238#appendix-B)).

## Verification

- \`bundle exec rspec\` — 357/0 (7 new specs: RFC vectors, digit count, whitespace/case tolerance, registers under right name + version, fills with correct code at frozen time, missing-page precondition error, missing-secret param error).
- \`bundle exec rubocop\` — clean.
- Smoke verified manually:
  \`\`\`
  $ ruby -Ilib -e 'require "browserctl/flows/stdlib/totp_2fa"; puts Browserctl::Flows::TOTP.generate("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ", at: Time.at(1234567890), digits: 8)'
  89005924
  \`\`\`

## Docs

\`docs/guides/stdlib-flows.md\` — new file, frames the stdlib catalog and gives totp_2fa examples for workflow invoke, CLI use, and pairing with \`secret_ref:\` (env / 1Password / keychain). Subsequent stdlib PRs (#8–10) will append their own sections.

## Plan acceptance

Per the v0.10 plan: "every stdlib flow has a unit spec + a documented invocation example in docs/guides/." ✓