### PR TITLE
feat: stdlib flows — basic_auth, magic_link_email

### DIFF
--- a/docs/guides/stdlib-flows.md
+++ b/docs/guides/stdlib-flows.md
@@ -9,9 +9,11 @@ them by name without copying code into your project.
 | Flow | Purpose |
 |---|---|
 | `totp_2fa` | Generate a TOTP code from a base32 secret and type it into the page |
+| `basic_auth` | Navigate to an HTTP Basic Auth URL with credentials embedded |
+| `magic_link_email` | Pause for a magic link, then navigate to it |
 
-More flows arrive in v0.10 (basic_auth, magic_link_email, oauth_google,
-oauth_github, cloudflare_solve).
+More flows arrive later in v0.10 (oauth_google, oauth_github,
+cloudflare_solve).
 
 ---
 
@@ -99,3 +101,110 @@ bundle exec rspec spec/unit/flows/stdlib/totp_2fa_spec.rb
 If your provider's codes don't match what the flow generates, the
 secret is wrong (most common), or the provider uses non-default
 `digits` or `period` (rare — check your provisioning URI).
+
+---
+
+## `basic_auth`
+
+For sites protected by real HTTP Basic Auth (the browser pops a native
+auth prompt). The flow side-steps the dialog by navigating to the URL
+with credentials in the userinfo portion — Chromium ingests them and
+sends the `Authorization: Basic ...` header on the request.
+
+This is **not** for form-based logins (input fields named "username"
+and "password" in the page). For those, use a workflow that calls
+`page.fill` directly.
+
+### Params
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `url` | string | — | **Required.** Full URL of the protected resource. |
+| `username` | string | — | **Required.** |
+| `password` | string | — | **Required.** Marked `secret: true`. |
+
+The flow URL-encodes both credentials, so `@`, `/`, `:`, and other
+reserved chars in the password are handled correctly.
+
+### From a workflow
+
+```ruby
+Browserctl.workflow "scrape_internal_dashboard" do
+  step "load" do
+    open_page(:main)
+    invoke :basic_auth,
+           page: :main,
+           url: "https://internal.example.com/dashboard",
+           username: "patrick",
+           password: ENV.fetch("DASHBOARD_PASS")
+  end
+end
+```
+
+### From the CLI
+
+```sh
+browserctl flow run basic_auth \
+  --page main \
+  --url https://internal.example.com/ \
+  --username patrick \
+  --password "$DASHBOARD_PASS"
+```
+
+---
+
+## `magic_link_email`
+
+Many SaaS apps (Slack, Notion, Linear, ...) email a one-shot login link
+instead of accepting a password. This flow handles the "click the link
+in your email" step by pausing for the human to paste the link, then
+navigating the page to it.
+
+It does **not** read your inbox — that would require provider-specific
+IMAP/Gmail integration which doesn't belong in stdlib. If you want
+fully automated magic-link login, write a vendor flow that resolves the
+link from your mail provider's API, then call `page.navigate(link)`
+directly.
+
+### Params
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `prompt` | string | "Paste the magic link from your email:" | Override to give the user more context. |
+
+### Behaviour
+
+1. Prints the prompt to **stderr** (so it stays out of any JSON output
+   pipeline you might be scripting around).
+2. Reads one line from stdin.
+3. Validates the line starts with `http://` or `https://`. Refuses
+   `javascript:`, `file:`, etc.
+4. Calls `page.navigate(link)`.
+
+### From a workflow
+
+```ruby
+Browserctl.workflow "linear_login" do
+  step "request link" do
+    open_page(:main, url: "https://linear.app/login")
+    page(:main).fill("input#email", "patrick@example.com")
+    page(:main).click("button[type='submit']")
+  end
+
+  step "open the link" do
+    invoke :magic_link_email,
+           page: :main,
+           prompt: "Paste the Linear sign-in link:"
+  end
+end
+```
+
+### From the CLI
+
+```sh
+browserctl flow run magic_link_email --page main
+# [browserctl] Paste the magic link from your email: <paste>
+```
+
+The shell session must be interactive — the flow reads from stdin
+synchronously.

--- a/lib/browserctl/flows/stdlib/basic_auth.rb
+++ b/lib/browserctl/flows/stdlib/basic_auth.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "uri"
+require_relative "../../flow"
+
+# Authenticates with an HTTP Basic Auth-protected URL by navigating to it
+# with credentials embedded in the URL. This avoids the native auth
+# dialog entirely; Chromium ingests the userinfo and supplies it on the
+# request without prompting.
+#
+# Use for sites where the auth challenge is real HTTP Basic. For form-
+# based "username + password" logins, use a workflow with `page.fill`.
+Browserctl.flow("basic_auth") do
+  version "1.0.0"
+  requires_browserctl "0.11.0"
+  desc "Navigate to an HTTP Basic Auth URL using credentials embedded in the URL."
+
+  param :url,      required: true
+  param :username, required: true
+  param :password, required: true, secret: true
+
+  precondition("page proxy is present") { !page.nil? }
+
+  step("navigate with embedded credentials") do
+    parsed = URI.parse(url)
+    parsed.user     = URI.encode_www_form_component(username)
+    parsed.password = URI.encode_www_form_component(password)
+    page.navigate(parsed.to_s)
+  end
+end

--- a/lib/browserctl/flows/stdlib/magic_link_email.rb
+++ b/lib/browserctl/flows/stdlib/magic_link_email.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../../flow"
+
+# HITL flow for magic-link login: pauses, asks the human to paste the
+# link they received via email, then navigates the page to it.
+#
+# Does NOT read the email mailbox; that would require provider-specific
+# IMAP/Gmail integration which belongs in a vendor flow, not stdlib.
+Browserctl.flow("magic_link_email") do
+  version "1.0.0"
+  requires_browserctl "0.11.0"
+  desc "Wait for the human to paste a magic link from their email, then navigate to it."
+
+  param :prompt, default: "Paste the magic link from your email:"
+
+  precondition("page proxy is present") { !page.nil? }
+
+  step("prompt and navigate") do
+    $stderr.print("[browserctl] #{prompt} ")
+    link = $stdin.gets&.strip
+    raise "no magic link provided" if link.nil? || link.empty?
+
+    raise "magic link must start with http:// or https:// (got #{link.inspect})" unless link.match?(%r{\Ahttps?://}i)
+
+    page.navigate(link)
+  end
+end

--- a/spec/unit/flows/stdlib/basic_auth_spec.rb
+++ b/spec/unit/flows/stdlib/basic_auth_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/flows/stdlib/basic_auth"
+
+RSpec.describe "stdlib flow: basic_auth" do
+  let(:page) { instance_double(Browserctl::PageProxy) }
+
+  before do
+    Browserctl.flow_registry_reset!
+    load File.expand_path("../../../../lib/browserctl/flows/stdlib/basic_auth.rb", __dir__)
+  end
+  after { Browserctl.flow_registry_reset! }
+
+  let(:flow) { Browserctl.lookup_flow("basic_auth") }
+
+  it "registers under 'basic_auth' with the right metadata" do
+    expect(flow).to be_a(Browserctl::Flow)
+    expect(flow.version_string).to eq("1.0.0")
+    expect(flow.min_browserctl_version).to eq("0.11.0")
+    expect(flow.param_defs[:password].secret).to be true
+  end
+
+  it "navigates with userinfo embedded in the URL" do
+    expect(page).to receive(:navigate).with("https://alice:s3cret@example.com/")
+    flow.run(page: page, url: "https://example.com/", username: "alice", password: "s3cret")
+  end
+
+  it "URL-encodes special characters in credentials" do
+    expect(page).to receive(:navigate) do |url|
+      expect(url).to start_with("https://")
+      expect(url).to include("a%40b")     # @ encoded
+      expect(url).to include("p%2Fass")   # / encoded
+      expect(url).to include("@example.com/")
+    end
+    flow.run(page: page, url: "https://example.com/", username: "a@b", password: "p/ass")
+  end
+
+  it "raises a precondition error without a page proxy" do
+    expect { flow.run(url: "https://example.com/", username: "a", password: "b") }
+      .to raise_error(Browserctl::FlowPreconditionError, /page proxy/)
+  end
+
+  it "requires url, username, and password" do
+    %i[url username password].each do |missing|
+      args = { page: page, url: "https://x.test/", username: "u", password: "p" }
+      args.delete(missing)
+      expect { flow.run(**args) }.to raise_error(Browserctl::FlowParamError, /#{missing}/)
+    end
+  end
+end

--- a/spec/unit/flows/stdlib/magic_link_email_spec.rb
+++ b/spec/unit/flows/stdlib/magic_link_email_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "stringio"
+require "browserctl/flows/stdlib/magic_link_email"
+
+RSpec.describe "stdlib flow: magic_link_email" do
+  let(:page) { instance_double(Browserctl::PageProxy) }
+
+  before do
+    Browserctl.flow_registry_reset!
+    load File.expand_path("../../../../lib/browserctl/flows/stdlib/magic_link_email.rb", __dir__)
+  end
+  after { Browserctl.flow_registry_reset! }
+
+  let(:flow) { Browserctl.lookup_flow("magic_link_email") }
+
+  def with_stdin(input)
+    original = $stdin
+    $stdin = StringIO.new(input)
+    yield
+  ensure
+    $stdin = original
+  end
+
+  def silence_stderr
+    original = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original
+  end
+
+  it "registers under 'magic_link_email'" do
+    expect(flow).to be_a(Browserctl::Flow)
+    expect(flow.version_string).to eq("1.0.0")
+  end
+
+  it "prompts the human and navigates to the pasted link" do
+    expect(page).to receive(:navigate).with("https://app.example.com/auth/abc123")
+    out = silence_stderr do
+      with_stdin("https://app.example.com/auth/abc123\n") { flow.run(page: page) }
+    end
+    expect(out).to include("[browserctl]")
+    expect(out).to include("Paste the magic link")
+  end
+
+  it "uses a custom prompt when given" do
+    allow(page).to receive(:navigate)
+    out = silence_stderr do
+      with_stdin("https://x.test/\n") { flow.run(page: page, prompt: "Magic link?") }
+    end
+    expect(out).to include("Magic link?")
+  end
+
+  it "fails when the user provides an empty line" do
+    silence_stderr do
+      with_stdin("\n") do
+        expect { flow.run(page: page) }.to raise_error(Browserctl::FlowStepError, /no magic link/)
+      end
+    end
+  end
+
+  it "fails when the link is not http(s)" do
+    silence_stderr do
+      with_stdin("javascript:alert(1)\n") do
+        expect { flow.run(page: page) }
+          .to raise_error(Browserctl::FlowStepError, /must start with http/)
+      end
+    end
+  end
+
+  it "raises a precondition error without a page proxy" do
+    expect { flow.run }.to raise_error(Browserctl::FlowPreconditionError, /page proxy/)
+  end
+end


### PR DESCRIPTION
WS-3 PR #8 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md). **Stacked on #90** — base is \`feat/stdlib-totp-2fa\`. Retarget to \`main\` once #90 lands.

## What

Two more stdlib flows, both ~25 LoC, both with no network dependency.

### \`basic_auth\`

Navigates to an HTTP Basic Auth URL with credentials embedded in the userinfo:

\`\`\`
https://alice:s3cret@example.com/
\`\`\`

Chromium ingests the userinfo and sends \`Authorization: Basic ...\` on the request — no native auth dialog appears. Both username and password are URL-encoded so \`@\`, \`/\`, \`:\` and friends round-trip.

| Param | Required | Notes |
|---|---|---|
| \`url\` | yes | |
| \`username\` | yes | |
| \`password\` | yes | \`secret: true\` |

### \`magic_link_email\`

HITL flow for the "click the link in your email" step. Prompts via stderr, reads stdin, validates http(s), navigates.

\`\`\`
[browserctl] Paste the magic link from your email: <paste>
\`\`\`

Refuses \`javascript:\`, \`file:\`, etc. Refuses empty input.

| Param | Required | Default |
|---|---|---|
| \`prompt\` | no | "Paste the magic link from your email:" |

Does **not** read the user's inbox — that's provider-specific (Gmail/IMAP) and belongs in a vendor flow, not stdlib.

## Verification

- \`bundle exec rspec\` — 368/0 (11 new specs across both flows: registration metadata, navigate calls, URL-encoding round-trip, custom prompt, empty input → step error, non-http link rejected, missing-page precondition, missing required params).
- \`bundle exec rubocop\` — clean.

## Docs

\`docs/guides/stdlib-flows.md\` gains sections for both flows, including:
- a steer-away note for \`basic_auth\` users who actually want form-based login (use \`page.fill\`, not this flow);
- the explicit inbox-vs-stdlib boundary for \`magic_link_email\`.