### PR TITLE
feat: stdlib flows — oauth_google, oauth_github

### DIFF
--- a/docs/guides/stdlib-flows.md
+++ b/docs/guides/stdlib-flows.md
@@ -11,9 +11,10 @@ them by name without copying code into your project.
 | `totp_2fa` | Generate a TOTP code from a base32 secret and type it into the page |
 | `basic_auth` | Navigate to an HTTP Basic Auth URL with credentials embedded |
 | `magic_link_email` | Pause for a magic link, then navigate to it |
+| `oauth_github` | Click the Authorize button on a GitHub OAuth consent screen |
+| `oauth_google` | Click the Continue button on a Google OAuth consent screen |
 
-More flows arrive later in v0.10 (oauth_google, oauth_github,
-cloudflare_solve).
+One more flow arrives later in v0.10 (cloudflare_solve).
 
 ---
 
@@ -208,3 +209,55 @@ browserctl flow run magic_link_email --page main
 
 The shell session must be interactive — the flow reads from stdin
 synchronously.
+
+---
+
+## `oauth_github` and `oauth_google`
+
+Both flows handle only the **consent** step of OAuth — clicking the
+"Authorize" / "Continue" button after the user is already signed in
+and parked on the consent URL. Compose them with whatever you use for
+sign-in (often `magic_link_email`, manual session, or your own
+workflow). They do not enter passwords, pick accounts, or solve 2FA.
+
+### `oauth_github`
+
+| Param | Default |
+|---|---|
+| `authorize_selector` | `button[name="authorize"][value="1"]` |
+
+Precondition: `page.url` contains `/login/oauth/authorize`.
+
+```ruby
+step "consent" do
+  invoke :oauth_github, page: :main
+end
+```
+
+`name="authorize"` has been stable across years of GitHub UI revisions,
+so the default works on github.com. For GitHub Enterprise installs
+with custom templates, override the selector.
+
+### `oauth_google`
+
+| Param | Default |
+|---|---|
+| `continue_selector` | `button[jsname="LgbsSe"]` |
+
+Precondition: `page.url` is on `accounts.google.com` and contains
+`/oauth` or `/signin/oauth`.
+
+```ruby
+step "consent" do
+  invoke :oauth_google, page: :main
+end
+```
+
+Google's consent UI rotates more often than GitHub's. The default
+selector targets the modern Material 3 button; if it stops working,
+override with whatever your account currently sees, then file an issue
+so we can refresh the default.
+
+For repeatable testing, capture a single working selector via DevTools
+("Inspect" the Continue button → "Copy → Copy selector") and pin it as
+a workflow-level constant.

--- a/lib/browserctl/flows/stdlib/oauth_github.rb
+++ b/lib/browserctl/flows/stdlib/oauth_github.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../../flow"
+
+# Clicks the "Authorize <app>" button on a GitHub OAuth consent screen.
+#
+# Assumes the user is already signed in to GitHub and the page is parked
+# on the consent URL — this flow does not handle the credential entry
+# step. Use a separate workflow or flow to land on the consent page first.
+Browserctl.flow("oauth_github") do
+  version "1.0.0"
+  requires_browserctl "0.11.0"
+  desc "Click the Authorize button on a GitHub OAuth consent screen."
+
+  # The default selector targets the green Authorize submit button on
+  # github.com/login/oauth/authorize. GitHub keeps name="authorize" stable
+  # across UI revisions; override only if you're testing against a forked
+  # GitHub Enterprise instance with a customised template.
+  param :authorize_selector, default: 'button[name="authorize"][value="1"]'
+
+  precondition("on a github oauth consent page") do
+    page.url.include?("/login/oauth/authorize")
+  end
+
+  step("click authorize") do
+    page.click(authorize_selector)
+  end
+end

--- a/lib/browserctl/flows/stdlib/oauth_google.rb
+++ b/lib/browserctl/flows/stdlib/oauth_google.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "../../flow"
+
+# Clicks the Continue / Allow button on a Google OAuth consent screen.
+#
+# Assumes the user is already signed in to Google and the page is parked
+# on accounts.google.com showing the consent prompt. This flow does not
+# pick an account from the chooser, enter a password, or solve 2FA —
+# compose those before calling this flow.
+#
+# Google rotates consent UI more often than GitHub, so the default
+# selector is a best-effort match against the modern Material 3 button.
+# Override if your account or app version sees a different layout.
+Browserctl.flow("oauth_google") do
+  version "1.0.0"
+  requires_browserctl "0.11.0"
+  desc "Click the Continue/Allow button on a Google OAuth consent screen."
+
+  param :continue_selector, default: 'button[jsname="LgbsSe"]'
+
+  precondition("on a google oauth consent page") do
+    url = page.url
+    url.include?("accounts.google.com") && (url.include?("/oauth") || url.include?("/signin/oauth"))
+  end
+
+  step("click continue") do
+    page.click(continue_selector)
+  end
+end

--- a/spec/unit/flows/stdlib/oauth_github_spec.rb
+++ b/spec/unit/flows/stdlib/oauth_github_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/flows/stdlib/oauth_github"
+
+RSpec.describe "stdlib flow: oauth_github" do
+  let(:page) { instance_double(Browserctl::PageProxy) }
+
+  before do
+    Browserctl.flow_registry_reset!
+    load File.expand_path("../../../../lib/browserctl/flows/stdlib/oauth_github.rb", __dir__)
+  end
+  after { Browserctl.flow_registry_reset! }
+
+  let(:flow) { Browserctl.lookup_flow("oauth_github") }
+
+  it "registers under 'oauth_github' with version 1.0.0" do
+    expect(flow).to be_a(Browserctl::Flow)
+    expect(flow.version_string).to eq("1.0.0")
+  end
+
+  it "clicks the default authorize selector when on the consent URL" do
+    allow(page).to receive(:url).and_return("https://github.com/login/oauth/authorize?client_id=abc")
+    expect(page).to receive(:click).with('button[name="authorize"][value="1"]')
+
+    flow.run(page: page)
+  end
+
+  it "honors a custom authorize_selector" do
+    allow(page).to receive(:url).and_return("https://ghe.example.com/login/oauth/authorize")
+    expect(page).to receive(:click).with(".enterprise-authorize")
+
+    flow.run(page: page, authorize_selector: ".enterprise-authorize")
+  end
+
+  it "raises a precondition error when not on a consent URL" do
+    allow(page).to receive(:url).and_return("https://github.com/repos/")
+
+    expect { flow.run(page: page) }
+      .to raise_error(Browserctl::FlowPreconditionError, /consent/)
+  end
+
+  it "raises a precondition error without a page proxy" do
+    # The pre runs first, fails on page.url for nil page
+    expect { flow.run }
+      .to raise_error(Browserctl::FlowPreconditionError)
+  end
+end

--- a/spec/unit/flows/stdlib/oauth_google_spec.rb
+++ b/spec/unit/flows/stdlib/oauth_google_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/flows/stdlib/oauth_google"
+
+RSpec.describe "stdlib flow: oauth_google" do
+  let(:page) { instance_double(Browserctl::PageProxy) }
+
+  before do
+    Browserctl.flow_registry_reset!
+    load File.expand_path("../../../../lib/browserctl/flows/stdlib/oauth_google.rb", __dir__)
+  end
+  after { Browserctl.flow_registry_reset! }
+
+  let(:flow) { Browserctl.lookup_flow("oauth_google") }
+
+  it "registers under 'oauth_google' with version 1.0.0" do
+    expect(flow).to be_a(Browserctl::Flow)
+    expect(flow.version_string).to eq("1.0.0")
+  end
+
+  it "clicks the default continue selector when on a consent URL" do
+    allow(page).to receive(:url)
+      .and_return("https://accounts.google.com/signin/oauth/consent?client_id=abc")
+    expect(page).to receive(:click).with('button[jsname="LgbsSe"]')
+
+    flow.run(page: page)
+  end
+
+  it "matches /oauth path variants too" do
+    allow(page).to receive(:url).and_return("https://accounts.google.com/o/oauth2/auth")
+    expect(page).to receive(:click)
+
+    flow.run(page: page)
+  end
+
+  it "honors a custom continue_selector" do
+    allow(page).to receive(:url).and_return("https://accounts.google.com/signin/oauth/consent")
+    expect(page).to receive(:click).with("[data-test='allow']")
+
+    flow.run(page: page, continue_selector: "[data-test='allow']")
+  end
+
+  it "raises a precondition error when not on accounts.google.com" do
+    allow(page).to receive(:url).and_return("https://example.com/")
+
+    expect { flow.run(page: page) }
+      .to raise_error(Browserctl::FlowPreconditionError, /consent/)
+  end
+
+  it "raises a precondition error on accounts.google.com without an oauth path" do
+    allow(page).to receive(:url).and_return("https://accounts.google.com/Logout")
+
+    expect { flow.run(page: page) }
+      .to raise_error(Browserctl::FlowPreconditionError, /consent/)
+  end
+end


### PR DESCRIPTION
WS-3 PR #9 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md). **Stacked on #91** — base is \`feat/stdlib-basic-auth-magic-link\`. Retarget after #91 merges.

## Scope

Both flows handle only the **consent** step — clicking Authorize/Continue after the user is already signed in and parked on the consent URL. They explicitly do not:

- enter passwords (use a workflow with \`page.fill\`)
- pick accounts from the chooser (compose a separate step)
- solve 2FA (use \`totp_2fa\`)

This matches the unix-philosophy split the plan calls out — small composable flows, not monolithic per-provider login.

## \`oauth_github\`

| Param | Default |
|---|---|
| \`authorize_selector\` | \`button[name="authorize"][value="1"]\` |

Precondition: \`page.url\` contains \`/login/oauth/authorize\`.

GitHub's \`name="authorize"\` has been stable across years of UI revisions, so the default works on github.com. Override for GitHub Enterprise with custom templates.

## \`oauth_google\`

| Param | Default |
|---|---|
| \`continue_selector\` | \`button[jsname="LgbsSe"]\` |

Precondition: on \`accounts.google.com\` with \`/oauth\` or \`/signin/oauth\` in the path.

Google rotates the consent UI more often. Default targets the modern Material 3 button; override if it stops matching, then the doc invites the user to file an issue so we can refresh.

## Verification

- \`bundle exec rspec\` — 379/0 (11 new specs across both flows: registration metadata, default selector click, custom selector override, URL variant matching, precondition failures for wrong host / wrong path / no page).
- \`bundle exec rubocop\` — clean.

Specs use mocked navigation per the plan: stub \`page.url\`, assert \`click\` is called with the right selector.

## Docs

\`docs/guides/stdlib-flows.md\` gains a combined section for both, framing them as consent-only and explicitly steering users to compose for the rest of the OAuth dance.