### PR TITLE
feat: stdlib flow — cloudflare_solve

### DIFF
--- a/docs/guides/stdlib-flows.md
+++ b/docs/guides/stdlib-flows.md
@@ -13,8 +13,7 @@ them by name without copying code into your project.
 | `magic_link_email` | Pause for a magic link, then navigate to it |
 | `oauth_github` | Click the Authorize button on a GitHub OAuth consent screen |
 | `oauth_google` | Click the Continue button on a Google OAuth consent screen |
-
-One more flow arrives later in v0.10 (cloudflare_solve).
+| `cloudflare_solve` | Pause for a human to solve a Cloudflare challenge, verify it cleared, optionally save state |
 
 ---
 
@@ -261,3 +260,71 @@ so we can refresh the default.
 For repeatable testing, capture a single working selector via DevTools
 ("Inspect" the Continue button → "Copy → Copy selector") and pin it as
 a workflow-level constant.
+
+---
+
+## `cloudflare_solve`
+
+Cloudflare's interstitials (Turnstile, "Just a moment...", interactive
+checkbox) are designed to be unsolvable by automation. The pragmatic
+answer is to put a human in the loop: pause, let them solve it, then
+continue.
+
+This flow:
+
+1. Detects the challenge (reuses `Browserctl::Detectors.cloudflare?`,
+   the same logic the daemon already uses for v0.8 challenge
+   notifications).
+2. Prints a prompt to **stderr** and blocks on stdin.
+3. After the human presses Enter, re-runs detection. If the challenge
+   is still showing, raises a step error so the workflow can react.
+4. Optionally saves the post-solve session under a name you can reload
+   later — the whole point of solving the challenge in the first place.
+
+### Params
+
+| Name | Default | Notes |
+|---|---|---|
+| `prompt` | "Cloudflare challenge detected. Solve it in the browser, then press Enter to continue." | |
+| `state_name` | `nil` | When set, calls `client.session_save(state_name)` after the challenge clears. |
+
+### From a workflow
+
+```ruby
+Browserctl.workflow "scrape_with_cf_protection" do
+  step "open" do
+    open_page(:main, url: "https://protected.example.com/feed")
+  end
+
+  step "solve if needed" do
+    invoke :cloudflare_solve,
+           page: :main,
+           state_name: "protected_example_com"
+  end
+
+  step "scrape" do
+    puts page(:main).snapshot(format: "html")
+  end
+end
+```
+
+The `state_name` ties this flow to the v0.10 state command — once
+saved, you can `browserctl state load protected_example_com` on a
+fresh daemon and skip the challenge entirely until cookies expire.
+
+### From the CLI
+
+```sh
+browserctl flow run cloudflare_solve --page main --state-name protected_example_com
+# [browserctl] Cloudflare challenge detected. Solve it in the browser, then press Enter to continue.
+```
+
+The shell session must be interactive — the flow blocks on stdin.
+
+### Why pause + verify, not auto-bypass?
+
+Auto-solvers (changing user-agent, spoofing canvas, etc.) get caught,
+break frequently, and put your IP on Cloudflare's penalty list. A
+single human-in-the-loop solve produces a session cookie that's good
+for hours-to-days; saving it via `state_name` lets the rest of your
+automation skip the challenge entirely on subsequent runs.

--- a/lib/browserctl/flows/stdlib/cloudflare_solve.rb
+++ b/lib/browserctl/flows/stdlib/cloudflare_solve.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "../../detectors"
+require_relative "../../flow"
+
+# Pauses for a human to solve a Cloudflare challenge (Turnstile, "Just a
+# moment...", interactive checkbox), then verifies the challenge cleared
+# before returning. Optionally saves the post-solve session under a name
+# you can reload later with `state load` or `session_load`.
+#
+# Reuses Browserctl::Detectors.cloudflare? — the server-side detector
+# already shipped in v0.8 — by adapting the client-facing PageProxy to
+# the duck-typed (current_url, body) interface the detector expects.
+module Browserctl
+  module Flows
+    PageDetectorAdapter = Struct.new(:current_url, :body)
+
+    module CloudflareSolve
+      module_function
+
+      def detect?(page_proxy)
+        body = page_proxy.evaluate("document.body && document.body.innerText || ''").to_s
+        adapter = PageDetectorAdapter.new(page_proxy.url, body)
+        Browserctl::Detectors.cloudflare?(adapter)
+      end
+    end
+  end
+end
+
+Browserctl.flow("cloudflare_solve") do
+  version "1.0.0"
+  requires_browserctl "0.11.0"
+  desc "Pause for a human to solve a Cloudflare challenge; verify it cleared; optionally capture state."
+
+  param :prompt,
+        default: "Cloudflare challenge detected. Solve it in the browser, then press Enter to continue."
+  param :state_name # optional — if set, session_save is called after the challenge clears
+
+  precondition("page proxy is present") { !page.nil? }
+  precondition("cloudflare challenge is present") do
+    Browserctl::Flows::CloudflareSolve.detect?(page)
+  end
+
+  step("wait for human signal") do
+    warn "[browserctl] #{prompt}"
+    line = $stdin.gets
+    raise "stdin closed before user signaled" if line.nil?
+  end
+
+  step("verify challenge cleared") do
+    raise "cloudflare challenge still detected after human signal" if Browserctl::Flows::CloudflareSolve.detect?(page)
+  end
+
+  produces_state do
+    next nil unless state_name && client
+
+    client.session_save(state_name)
+  end
+end

--- a/spec/unit/flows/stdlib/cloudflare_solve_spec.rb
+++ b/spec/unit/flows/stdlib/cloudflare_solve_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "stringio"
+require "browserctl/flows/stdlib/cloudflare_solve"
+
+RSpec.describe "stdlib flow: cloudflare_solve" do
+  let(:page) { instance_double(Browserctl::PageProxy) }
+  let(:client) { instance_double(Browserctl::Client) }
+
+  before do
+    Browserctl.flow_registry_reset!
+    load File.expand_path("../../../../lib/browserctl/flows/stdlib/cloudflare_solve.rb", __dir__)
+  end
+  after { Browserctl.flow_registry_reset! }
+
+  let(:flow) { Browserctl.lookup_flow("cloudflare_solve") }
+
+  def silence_stderr
+    original = $stderr
+    $stderr = StringIO.new
+    [yield, $stderr.string]
+  ensure
+    $stderr = original
+  end
+
+  def with_stdin(input)
+    original = $stdin
+    $stdin = StringIO.new(input)
+    yield
+  ensure
+    $stdin = original
+  end
+
+  it "registers under 'cloudflare_solve' with version 1.0.0" do
+    expect(flow).to be_a(Browserctl::Flow)
+    expect(flow.version_string).to eq("1.0.0")
+  end
+
+  describe Browserctl::Flows::CloudflareSolve do
+    it "detects via challenge URL" do
+      proxy = instance_double(Browserctl::PageProxy,
+                              url: "https://example.com/cdn-cgi/challenge-platform/...",
+                              evaluate: "")
+      expect(described_class.detect?(proxy)).to be true
+    end
+
+    it "detects via body signal" do
+      proxy = instance_double(Browserctl::PageProxy,
+                              url: "https://example.com/",
+                              evaluate: "Just a moment...")
+      expect(described_class.detect?(proxy)).to be true
+    end
+
+    it "returns false on a clean page" do
+      proxy = instance_double(Browserctl::PageProxy,
+                              url: "https://example.com/dashboard",
+                              evaluate: "Welcome back")
+      expect(described_class.detect?(proxy)).to be false
+    end
+  end
+
+  describe "#run" do
+    it "raises a precondition error when no challenge is detected" do
+      allow(page).to receive_messages(url: "https://x.test/", evaluate: "all clear")
+
+      expect { flow.run(page: page) }
+        .to raise_error(Browserctl::FlowPreconditionError, /cloudflare/)
+    end
+
+    it "prompts via stderr, waits for stdin, verifies cleared" do
+      # Challenge present at first; clear after the human presses Enter.
+      url_calls = ["https://x.test/cdn-cgi/challenge-platform/", "https://x.test/dashboard"]
+      eval_calls = ["Just a moment...", "Welcome"]
+      allow(page).to receive(:url) { url_calls.shift }
+      allow(page).to receive(:evaluate) { eval_calls.shift }
+
+      _, out = silence_stderr do
+        with_stdin("\n") { flow.run(page: page) }
+      end
+
+      expect(out).to include("Cloudflare challenge detected")
+    end
+
+    it "raises a step error when challenge is still present after the signal" do
+      allow(page).to receive_messages(url: "https://x.test/cdn-cgi/challenge-platform/",
+                                      evaluate: "Just a moment...")
+
+      silence_stderr do
+        with_stdin("\n") do
+          expect { flow.run(page: page) }
+            .to raise_error(Browserctl::FlowStepError, /still detected/)
+        end
+      end
+    end
+
+    it "saves the session under state_name when given" do
+      url_calls = ["https://x.test/cdn-cgi/challenge-platform/", "https://x.test/dashboard"]
+      eval_calls = ["Just a moment...", "Welcome"]
+      allow(page).to receive(:url) { url_calls.shift }
+      allow(page).to receive(:evaluate) { eval_calls.shift }
+      expect(client).to receive(:session_save).with("post_cf").and_return({ ok: true })
+
+      result, = silence_stderr do
+        with_stdin("\n") { flow.run(page: page, client: client, state_name: "post_cf") }
+      end
+
+      expect(result).to eq(ok: true)
+    end
+
+    it "skips session_save when no state_name is given" do
+      url_calls = ["https://x.test/cdn-cgi/challenge-platform/", "https://x.test/dashboard"]
+      eval_calls = ["Just a moment...", "Welcome"]
+      allow(page).to receive(:url) { url_calls.shift }
+      allow(page).to receive(:evaluate) { eval_calls.shift }
+      expect(client).not_to receive(:session_save)
+
+      result, = silence_stderr do
+        with_stdin("\n") { flow.run(page: page, client: client) }
+      end
+
+      expect(result).to be_nil
+    end
+
+    it "raises when stdin closes before the user signals" do
+      allow(page).to receive_messages(url: "https://x.test/cdn-cgi/challenge-platform/",
+                                      evaluate: "Just a moment...")
+
+      silence_stderr do
+        with_stdin("") do
+          expect { flow.run(page: page) }
+            .to raise_error(Browserctl::FlowStepError, /stdin closed/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
WS-3 PR #10 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md). **Closes WS-3.** Final stdlib flow.

## What

Pause-then-verify HITL flow for Cloudflare challenges (Turnstile, "Just a moment…", interactive checkbox).

Pipeline:

1. **Detect** — reuses \`Browserctl::Detectors.cloudflare?\` (the v0.8 server-side detector) by adapting \`PageProxy\` through a small \`PageDetectorAdapter(current_url, body)\` struct. \`body\` comes from \`page.evaluate("document.body.innerText")\`.
2. **Wait for human** — \`warn\` prompt to stderr, \`$stdin.gets\` blocks. Custom prompt via param.
3. **Verify** — re-runs detection; raises \`FlowStepError\` if the challenge is still up.
4. **Optionally save state** — \`produces_state\` calls \`client.session_save(state_name)\` when the \`state_name\` param is set. Returns \`nil\` otherwise.

## Why HITL, not auto-bypass

Auto-solvers (canvas spoofing, custom UA, residential-proxy gymnastics) get caught, break frequently, and put your IP on Cloudflare's penalty list. A single human solve produces a session cookie good for hours-to-days. \`state_name\` ties this flow into the upcoming v0.10 state command — so subsequent runs reload the session and skip the challenge entirely until cookies expire.

## Verification

- \`bundle exec rspec\` — 389/0 (10 new specs: registration, detect via URL, detect via body, no detection on clean page, precondition fails on clean page, prompt + verify, still-detected → step error, session_save with state_name, no session_save without state_name, stdin-closed → step error).
- \`bundle exec rubocop\` — clean.

## Detector reuse note

Did NOT modify \`lib/browserctl/detectors.rb\`. The flow adapts \`PageProxy\` to the existing detector's duck-typed interface so the same signal list (\`cf-challenge-running\`, \`cf_chl_opt\`, \`__cf_chl_f_tk\`, "Just a moment...", \`challenge-platform\` URL) is the single source of truth.

## Plan acceptance

WS-3 acceptance: "every stdlib flow has a unit spec + a documented invocation example in docs/guides/." ✓ — six flows total (totp_2fa, basic_auth, magic_link_email, oauth_github, oauth_google, cloudflare_solve), each with specs and a doc section.