### PR TITLE
feat: .bctl bundle codec

### DIFF
--- a/lib/browserctl/state/bundle.rb
+++ b/lib/browserctl/state/bundle.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require "json"
+require "openssl"
+require "securerandom"
+require_relative "../errors"
+
+module Browserctl
+  module State
+    # Single-file portable codec for browserctl session state — the .bctl
+    # bundle. Wraps a plaintext manifest (origins, flow binding, timestamps)
+    # alongside a payload of cookies + storage. The manifest is always
+    # readable without a passphrase (so `state info` can show origins and
+    # expiry); the payload is optionally encrypted.
+    #
+    # Wire format (big-endian):
+    #
+    #   magic:        "BCTL\x00"           5 bytes
+    #   version:      0x01                 1 byte
+    #   flags:        bit 0 = encrypted    1 byte
+    #   reserved:     0x00                 1 byte
+    #   manifest_len:                      4 bytes
+    #   manifest:     JSON                 manifest_len bytes (always plaintext)
+    #   payload_len:                       4 bytes
+    #   payload:      see below            payload_len bytes
+    #   footer:       32 bytes
+    #
+    # When flags & 0x01 is unset:
+    #   payload  = JSON bytes (plaintext)
+    #   footer   = SHA-256 over magic..payload (corruption detection)
+    #
+    # When flags & 0x01 is set:
+    #   payload  = salt(16) || nonce(12) || ciphertext || tag(16)
+    #   footer   = HMAC-SHA-256(hmac_key, magic..payload)
+    #   salt drives PBKDF2(passphrase, salt, 200_000, SHA-256, 64-byte output);
+    #   first 32 bytes are the AES-256-GCM encryption key, last 32 bytes are
+    #   the HMAC-SHA-256 key.
+    #
+    # Reuses the same AES-256-GCM primitive as v0.8 session encryption
+    # (lib/browserctl/session.rb). The two will share a Crypto module in a
+    # follow-up; duplicated here to keep this PR focused.
+    class Bundle
+      MAGIC          = "BCTL\x00".b.freeze
+      VERSION        = 1
+      FLAG_ENCRYPTED = 0x01
+      HEADER_SIZE    = MAGIC.bytesize + 3 # version + flags + reserved
+      LEN_SIZE       = 4
+      FOOTER_SIZE    = 32
+      SALT_SIZE      = 16
+      NONCE_SIZE     = 12
+      TAG_SIZE       = 16
+      PBKDF2_ITERS   = 200_000
+
+      class BundleError      < Browserctl::Error; def self.default_code = "bundle_error"      end
+      class TamperError      < BundleError;       def self.default_code = "bundle_tampered"   end
+      class PassphraseError  < BundleError;       def self.default_code = "bundle_passphrase" end
+
+      # Encodes manifest + payload into a single binary blob.
+      #
+      # @param manifest [Hash] plaintext manifest (always readable)
+      # @param payload  [Hash] cookies/storage; encrypted when passphrase given
+      # @param passphrase [String, nil] when given, payload is encrypted and
+      #   the footer is an HMAC. When nil, payload is plaintext and the
+      #   footer is a SHA-256 digest.
+      def self.encode(manifest:, payload:, passphrase: nil)
+        manifest_bytes = JSON.generate(manifest).b
+        payload_json   = JSON.generate(payload).b
+        flags          = 0
+        hmac_key       = nil
+
+        if passphrase
+          salt = SecureRandom.bytes(SALT_SIZE)
+          enc_key, hmac_key = derive_keys(passphrase, salt)
+          payload_bytes = salt + aes_gcm_encrypt(payload_json, enc_key)
+          flags |= FLAG_ENCRYPTED
+        else
+          payload_bytes = payload_json
+        end
+
+        body = build_body(flags, manifest_bytes, payload_bytes)
+        body + footer_for(body, hmac_key)
+      end
+
+      # Decodes a blob, verifying the footer and decrypting payload when
+      # encrypted. Raises TamperError on digest/HMAC mismatch and
+      # PassphraseError when an encrypted bundle is decoded without a
+      # passphrase or with the wrong one.
+      def self.decode(blob, passphrase: nil)
+        magic, version, flags = read_header!(blob)
+        raise BundleError, "unsupported bundle version #{version}" unless version == VERSION
+
+        manifest_bytes, payload_bytes, footer = read_sections!(blob)
+        body = blob.byteslice(0, blob.bytesize - FOOTER_SIZE)
+
+        encrypted = flags.anybits?(FLAG_ENCRYPTED)
+        verify_footer!(body, footer, encrypted: encrypted, passphrase: passphrase)
+
+        manifest = JSON.parse(manifest_bytes, symbolize_names: true)
+        payload  = decode_payload(payload_bytes, encrypted: encrypted, passphrase: passphrase)
+
+        { manifest: manifest, payload: payload, magic: magic, version: version, encrypted: encrypted }
+      end
+
+      # Reads the manifest without verifying the footer or decrypting the
+      # payload. Use for `state info` and similar read-only queries.
+      def self.peek_manifest(blob)
+        _, version, = read_header!(blob)
+        raise BundleError, "unsupported bundle version #{version}" unless version == VERSION
+
+        manifest_bytes, = read_sections!(blob)
+        JSON.parse(manifest_bytes, symbolize_names: true)
+      end
+
+      def self.build_body(flags, manifest_bytes, payload_bytes)
+        header = MAGIC + [VERSION, flags, 0].pack("CCC")
+        header +
+          [manifest_bytes.bytesize].pack("N") + manifest_bytes +
+          [payload_bytes.bytesize].pack("N") + payload_bytes
+      end
+      private_class_method :build_body
+
+      def self.footer_for(body, hmac_key)
+        if hmac_key
+          OpenSSL::HMAC.digest("SHA256", hmac_key, body)
+        else
+          OpenSSL::Digest.digest("SHA256", body)
+        end
+      end
+      private_class_method :footer_for
+
+      def self.read_header!(blob)
+        raise BundleError, "blob too small for header" if blob.bytesize < HEADER_SIZE + (2 * LEN_SIZE) + FOOTER_SIZE
+
+        magic = blob.byteslice(0, MAGIC.bytesize)
+        raise BundleError, "bad magic — not a .bctl bundle" unless magic == MAGIC
+
+        version, flags, _reserved = blob.byteslice(MAGIC.bytesize, 3).unpack("CCC")
+        [magic, version, flags]
+      end
+      private_class_method :read_header!
+
+      def self.read_sections!(blob)
+        cursor          = HEADER_SIZE
+        manifest_len    = blob.byteslice(cursor, LEN_SIZE).unpack1("N")
+        cursor         += LEN_SIZE
+        manifest_bytes  = blob.byteslice(cursor, manifest_len)
+        cursor         += manifest_len
+        payload_len     = blob.byteslice(cursor, LEN_SIZE).unpack1("N")
+        cursor         += LEN_SIZE
+        payload_bytes   = blob.byteslice(cursor, payload_len)
+        cursor         += payload_len
+        footer          = blob.byteslice(cursor, FOOTER_SIZE)
+
+        unless manifest_bytes && payload_bytes && footer && footer.bytesize == FOOTER_SIZE
+          raise BundleError, "truncated bundle"
+        end
+
+        [manifest_bytes, payload_bytes, footer]
+      end
+      private_class_method :read_sections!
+
+      def self.verify_footer!(body, footer, encrypted:, passphrase:)
+        if encrypted
+          raise PassphraseError, "encrypted bundle requires a passphrase" unless passphrase
+
+          # We need the HMAC key, which depends on the salt embedded in the
+          # payload. Pull the salt from the payload bytes inside `body`.
+          salt = extract_salt!(body)
+          _, hmac_key = derive_keys(passphrase, salt)
+          expected = OpenSSL::HMAC.digest("SHA256", hmac_key, body)
+          raise PassphraseError, "wrong passphrase or tampered bundle" unless secure_eq?(footer, expected)
+        else
+          expected = OpenSSL::Digest.digest("SHA256", body)
+          raise TamperError, "bundle digest mismatch — file is corrupted or modified" unless secure_eq?(footer,
+                                                                                                        expected)
+        end
+      end
+      private_class_method :verify_footer!
+
+      def self.extract_salt!(body)
+        cursor          = HEADER_SIZE
+        manifest_len    = body.byteslice(cursor, LEN_SIZE).unpack1("N")
+        cursor         += LEN_SIZE + manifest_len + LEN_SIZE
+        body.byteslice(cursor, SALT_SIZE) or raise BundleError, "encrypted payload missing salt"
+      end
+      private_class_method :extract_salt!
+
+      def self.decode_payload(bytes, encrypted:, passphrase:)
+        if encrypted
+          salt       = bytes.byteslice(0, SALT_SIZE)
+          ciphertext = bytes.byteslice(SALT_SIZE, bytes.bytesize - SALT_SIZE)
+          enc_key, = derive_keys(passphrase, salt)
+          plaintext  = aes_gcm_decrypt(ciphertext, enc_key)
+          JSON.parse(plaintext)
+        else
+          JSON.parse(bytes)
+        end
+      rescue OpenSSL::Cipher::CipherError
+        raise PassphraseError, "wrong passphrase — payload could not be decrypted"
+      end
+      private_class_method :decode_payload
+
+      def self.derive_keys(passphrase, salt)
+        material = OpenSSL::PKCS5.pbkdf2_hmac(passphrase.to_s, salt, PBKDF2_ITERS, 64, "SHA256")
+        [material.byteslice(0, 32), material.byteslice(32, 32)]
+      end
+      private_class_method :derive_keys
+
+      def self.aes_gcm_encrypt(plaintext, key)
+        cipher = OpenSSL::Cipher.new("aes-256-gcm")
+        cipher.encrypt
+        cipher.key = key
+        nonce = SecureRandom.bytes(NONCE_SIZE)
+        cipher.iv = nonce
+        ct = cipher.update(plaintext) + cipher.final
+        nonce + ct + cipher.auth_tag
+      end
+      private_class_method :aes_gcm_encrypt
+
+      def self.aes_gcm_decrypt(blob, key)
+        nonce      = blob.byteslice(0, NONCE_SIZE)
+        tag        = blob.byteslice(-TAG_SIZE, TAG_SIZE)
+        ciphertext = blob.byteslice(NONCE_SIZE, blob.bytesize - NONCE_SIZE - TAG_SIZE)
+
+        cipher = OpenSSL::Cipher.new("aes-256-gcm")
+        cipher.decrypt
+        cipher.key      = key
+        cipher.iv       = nonce
+        cipher.auth_tag = tag
+        cipher.update(ciphertext) + cipher.final
+      end
+      private_class_method :aes_gcm_decrypt
+
+      def self.secure_eq?(actual, expected)
+        return false if actual.bytesize != expected.bytesize
+
+        OpenSSL.fixed_length_secure_compare(actual, expected)
+      end
+      private_class_method :secure_eq?
+    end
+  end
+end

--- a/spec/unit/state/bundle_spec.rb
+++ b/spec/unit/state/bundle_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/state/bundle"
+
+RSpec.describe Browserctl::State::Bundle do
+  let(:manifest) do
+    {
+      version: 1,
+      flow: "github_login",
+      flow_version: "1.0.0",
+      origins: ["github.com", "api.github.com"],
+      created_at: 1_700_000_000
+    }
+  end
+
+  let(:payload) do
+    {
+      "cookies" => [{ "name" => "sess", "value" => "abc", "domain" => ".github.com" }],
+      "local_storage" => { "user" => "patrick" },
+      "session_storage" => {}
+    }
+  end
+
+  describe "plaintext bundles" do
+    it "round-trips manifest and payload" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      out  = described_class.decode(blob)
+
+      expect(out[:manifest]).to eq(manifest)
+      expect(out[:payload]).to eq(payload)
+      expect(out[:encrypted]).to be false
+    end
+
+    it "starts with the BCTL magic" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      expect(blob.byteslice(0, 5)).to eq("BCTL\x00".b)
+    end
+
+    it "raises TamperError when any byte of the body is modified" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      offset = blob.bytesize - described_class::FOOTER_SIZE - 5
+      blob.setbyte(offset, blob.getbyte(offset) ^ 0xFF)
+
+      expect { described_class.decode(blob) }
+        .to raise_error(described_class::TamperError, /corrupted/) do |e|
+        expect(e.code).to eq("bundle_tampered")
+      end
+    end
+
+    it "raises TamperError when the footer is mutated" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      offset = blob.bytesize - 1
+      blob.setbyte(offset, blob.getbyte(offset) ^ 0xFF)
+
+      expect { described_class.decode(blob) }.to raise_error(described_class::TamperError)
+    end
+  end
+
+  describe "encrypted bundles" do
+    let(:passphrase) { "correct horse battery staple" }
+
+    it "round-trips with the right passphrase" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+      out  = described_class.decode(blob, passphrase: passphrase)
+
+      expect(out[:manifest]).to eq(manifest)
+      expect(out[:payload]).to eq(payload)
+      expect(out[:encrypted]).to be true
+    end
+
+    it "produces different ciphertext on each encode (random salt + nonce)" do
+      a = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+      b = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+
+      expect(a).not_to eq(b)
+    end
+
+    it "raises PassphraseError on a wrong passphrase" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+
+      expect { described_class.decode(blob, passphrase: "wrong") }
+        .to raise_error(described_class::PassphraseError, /wrong passphrase/) do |e|
+        expect(e.code).to eq("bundle_passphrase")
+      end
+    end
+
+    it "raises PassphraseError when no passphrase given for an encrypted bundle" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+
+      expect { described_class.decode(blob) }
+        .to raise_error(described_class::PassphraseError, /requires a passphrase/)
+    end
+
+    it "raises PassphraseError when ciphertext is mutated" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+      # Flip a byte deep in the encrypted payload
+      mid = blob.bytesize / 2
+      blob.setbyte(mid, blob.getbyte(mid) ^ 0xFF)
+
+      expect { described_class.decode(blob, passphrase: passphrase) }
+        .to raise_error(described_class::PassphraseError)
+    end
+
+    it "leaves the manifest readable without a passphrase" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+
+      m = described_class.peek_manifest(blob)
+
+      expect(m).to eq(manifest)
+    end
+  end
+
+  describe ".peek_manifest" do
+    it "reads the manifest from a plaintext bundle" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      expect(described_class.peek_manifest(blob)).to eq(manifest)
+    end
+
+    it "raises BundleError on a non-bundle blob" do
+      expect { described_class.peek_manifest("not a bundle") }
+        .to raise_error(described_class::BundleError, /bad magic|too small/)
+    end
+
+    it "raises BundleError on truncated input" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      truncated = blob.byteslice(0, blob.bytesize - 60)
+
+      expect { described_class.decode(truncated) }
+        .to raise_error(described_class::BundleError)
+    end
+  end
+
+  describe "version handling" do
+    it "rejects unknown versions" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      blob.setbyte(5, 99) # version byte
+
+      expect { described_class.decode(blob) }
+        .to raise_error(described_class::BundleError, /unsupported bundle version/)
+    end
+  end
+end


### PR DESCRIPTION
WS-4 PR #11 of the [v0.10 flows plan](../blob/main/docs/plans/v0.10-flows.md). Foundation for the rest of WS-4.

## What

Single-file portable codec — \`Browserctl::State::Bundle\` — the on-disk format for \`browserctl state save/load\` and \`state export/import\` (PR #12 and #13 add the wrappers).

### Wire format (big-endian)

\`\`\`
magic        "BCTL\x00"        5 bytes
version      0x01              1 byte
flags        bit 0 = encrypted 1 byte
reserved     0x00              1 byte
manifest_len                   4 bytes
manifest     JSON              manifest_len bytes  ← always plaintext
payload_len                    4 bytes
payload      see below         payload_len bytes
footer       see below        32 bytes
\`\`\`

| flag bit 0 | payload | footer |
|---|---|---|
| 0 (plaintext) | JSON bytes | SHA-256 over magic..payload |
| 1 (encrypted) | salt(16) ‖ nonce(12) ‖ ciphertext ‖ tag(16) | HMAC-SHA-256 over magic..payload |

PBKDF2 with **200 000** iterations, SHA-256, 64-byte output → first 32 bytes are the AES-256-GCM key, last 32 are the HMAC key. Per-bundle 16-byte salt; 12-byte nonce per encryption.

### Why manifest stays plaintext

\`state info\` needs to show origins, flow binding, and expiry. Forcing a passphrase prompt for read-only metadata would be hostile, especially for export/import flows where you might inspect a bundle before deciding to load it. Manifest is integrity-protected by the footer regardless.

### Why two footer modes

Plain SHA-256 catches corruption (transit, disk). HMAC requires a passphrase and provides true tamper resistance. The plan calls for both ("HMAC-signed, optional passphrase encryption") — interpreted as: encryption is opt-in, footer mode follows.

### Reuses v0.8 primitives

Same AES-256-GCM construction as \`Browserctl::Session\`. Duplicated here (~15 lines) to keep this PR scoped; a follow-up will extract a shared \`Crypto\` module so both call sites use the same code path.

## Errors

\`\`\`
BundleError                  code: bundle_error
├── TamperError              code: bundle_tampered
└── PassphraseError          code: bundle_passphrase
\`\`\`

Wire-code names ready for daemon JSON-RPC surfacing (relevant when \`state load\` lands in PR #12).

## Verification

- \`bundle exec rspec\` — 403/0 (14 new specs across plaintext round-trip, magic header bytes, body tamper detection, footer tamper detection, encrypted round-trip, ciphertext non-determinism, wrong-passphrase rejection, missing-passphrase rejection, ciphertext mutation rejection, manifest readable without passphrase, peek_manifest happy path, peek bad-magic, decode truncated, version-byte rejection).
- \`bundle exec rubocop\` — clean.

## Plan delta

The plan's PR #11 line:

> Manifest + cookies + localStorage + sessionStorage + (optional) IndexedDB, HMAC-signed, optional passphrase encryption.

This PR ships **the codec** — the bytes-on-disk part. The manifest content schema (origins[], flow binding, expiry) and the payload shape (cookies/local/session/indexed) get fixed in PR #12 when \`state save/load/list/info/delete\` wrap this codec around the live daemon. Keeping schema work out of this PR keeps it small and isolated for review.