### PR TITLE
feat: state save/load/list/info/delete

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -25,6 +25,7 @@ require "browserctl/commands/page"
 require "browserctl/commands/cookie"
 require "browserctl/commands/storage"
 require "browserctl/commands/session"
+require "browserctl/commands/state"
 require "browserctl/commands/daemon"
 require "browserctl/commands/workflow"
 require "browserctl/commands/flow"
@@ -96,6 +97,13 @@ def usage
       session export <name> <path>
       session import <path>
 
+    State (.bctl bundles — cookies + storage + flow binding):
+      state save   <name> [--encrypt] [--origins a,b] [--flow NAME]
+      state load   <name>
+      state list
+      state info   <name>
+      state delete <name>
+
     Recording:
       record start <name>
       record stop  [--out PATH]
@@ -153,6 +161,7 @@ else
   when "cookie"   then Browserctl::Commands::Cookie.run(client, args)
   when "storage"  then Browserctl::Commands::Storage.run(client, args)
   when "session"  then Browserctl::Commands::Session.run(client, args)
+  when "state"    then Browserctl::Commands::State.run(client, args)
   when "daemon"   then Browserctl::Commands::Daemon.run(client, args)
   when "navigate" then print_result(client.navigate(args[0], args[1]))
   when "fill"     then Browserctl::Commands::Fill.run(client, args)

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -308,6 +308,28 @@ module Browserctl
       call("session_delete", session_name: session_name)
     end
 
+    # Saves browser state (cookies + storage) into a single .bctl bundle.
+    # @return [Hash] `{ ok:, path:, origins:, cookies:, encrypted: }` or `{ error: }`
+    def state_save(name, origins: nil, flow: nil, flow_version: nil, passphrase: nil)
+      call("state_save",
+           name: name, origins: origins, flow: flow,
+           flow_version: flow_version, passphrase: passphrase)
+    end
+
+    # Restores a .bctl bundle into the running daemon.
+    def state_load(name, passphrase: nil)
+      call("state_load", name: name, passphrase: passphrase)
+    end
+
+    # Lists all stored state bundles (manifest only — no payload decryption).
+    def state_list = call("state_list")
+
+    # Reads a single bundle's manifest.
+    def state_info(name) = call("state_info", name: name)
+
+    # Permanently deletes a state bundle.
+    def state_delete(name) = call("state_delete", name: name)
+
     private
 
     def auto_discover_socket

--- a/lib/browserctl/commands/state.rb
+++ b/lib/browserctl/commands/state.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "io/console"
+require "json"
+require_relative "cli_output"
+
+module Browserctl
+  module Commands
+    # `browserctl state` — top-level command for portable, encrypted, origin-
+    # scoped browser state. Wraps the daemon's state_* RPCs.
+    module State
+      extend CliOutput
+
+      USAGE = "Usage: browserctl state <save|load|list|info|delete> [args]"
+
+      def self.run(client, args)
+        sub = args.shift or abort USAGE
+        case sub
+        when "save"   then run_save(client, args)
+        when "load"   then run_load(client, args)
+        when "list"   then run_list(client)
+        when "info"   then run_info(client, args)
+        when "delete" then run_delete(client, args)
+        else abort "unknown state subcommand '#{sub}'\n#{USAGE}"
+        end
+      end
+
+      def self.run_save(client, args)
+        encrypt = args.delete("--encrypt")
+        origins = extract_value!(args, "--origins")
+        flow    = extract_value!(args, "--flow")
+        name    = args.shift or abort "usage: browserctl state save <name> [--encrypt] " \
+                                      "[--origins a,b] [--flow NAME]"
+
+        passphrase = encrypt ? prompt_passphrase(confirm: true) : nil
+        origin_list = parse_origins(origins)
+
+        print_result(client.state_save(name, origins: origin_list, flow: flow, passphrase: passphrase))
+      end
+
+      def self.parse_origins(value)
+        return nil unless value
+
+        value.split(",").map(&:strip).reject(&:empty?)
+      end
+
+      def self.run_load(client, args)
+        name = args.shift or abort "usage: browserctl state load <name>"
+        passphrase = state_needs_passphrase?(client, name) ? prompt_passphrase : nil
+        print_result(client.state_load(name, passphrase: passphrase))
+      end
+
+      def self.run_list(client)
+        print_result(client.state_list)
+      end
+
+      def self.run_info(client, args)
+        name = args.shift or abort "usage: browserctl state info <name>"
+        print_result(client.state_info(name))
+      end
+
+      def self.run_delete(client, args)
+        name = args.shift or abort "usage: browserctl state delete <name>"
+        print_result(client.state_delete(name))
+      end
+
+      private_class_method :parse_origins
+
+      def self.extract_value!(args, flag)
+        idx = args.index(flag)
+        return nil unless idx
+
+        args.delete_at(idx)
+        args.delete_at(idx) or abort "missing value for #{flag}"
+      end
+      private_class_method :extract_value!
+
+      def self.prompt_passphrase(confirm: false)
+        return ENV["BROWSERCTL_STATE_PASSPHRASE"] if ENV["BROWSERCTL_STATE_PASSPHRASE"]
+
+        $stderr.print "Passphrase: "
+        pass = $stdin.noecho(&:gets).to_s.chomp
+        $stderr.puts
+
+        if confirm
+          $stderr.print "Confirm passphrase: "
+          confirm_pass = $stdin.noecho(&:gets).to_s.chomp
+          $stderr.puts
+          abort "Passphrases do not match." unless pass == confirm_pass
+        end
+
+        pass
+      end
+      private_class_method :prompt_passphrase
+
+      # Peek at the manifest first so we only prompt for a passphrase when needed.
+      def self.state_needs_passphrase?(client, name)
+        info = client.state_info(name)
+        return false if info[:error] || info["error"]
+
+        manifest = info[:info] || info["info"] || {}
+        manifest[:encrypted] || manifest["encrypted"] || false
+      end
+      private_class_method :state_needs_passphrase?
+    end
+  end
+end

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -11,6 +11,7 @@ require_relative "handlers/devtools"
 require_relative "handlers/daemon_control"
 require_relative "handlers/storage"
 require_relative "handlers/session"
+require_relative "handlers/state"
 require_relative "handlers/interaction"
 require_relative "../detectors"
 require_relative "../policy"
@@ -26,6 +27,7 @@ module Browserctl
     include Handlers::DaemonControl
     include Handlers::Storage
     include Handlers::Session
+    include Handlers::State
     include Handlers::Interaction
 
     COMMAND_MAP = {
@@ -66,7 +68,12 @@ module Browserctl
       "session_save" => :cmd_session_save,
       "session_load" => :cmd_session_load,
       "session_list" => :cmd_session_list,
-      "session_delete" => :cmd_session_delete
+      "session_delete" => :cmd_session_delete,
+      "state_save" => :cmd_state_save,
+      "state_load" => :cmd_state_load,
+      "state_list" => :cmd_state_list,
+      "state_info" => :cmd_state_info,
+      "state_delete" => :cmd_state_delete
     }.freeze
 
     SCREENSHOT_DIR   = File.expand_path("~/.browserctl/screenshots").freeze

--- a/lib/browserctl/server/handlers/state.rb
+++ b/lib/browserctl/server/handlers/state.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "../../state"
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      # Top-level state management — collapses cookies + localStorage +
+      # sessionStorage into a single `.bctl` bundle. See lib/browserctl/state.rb.
+      module State
+        private
+
+        def cmd_state_save(req)
+          first_session = @global_mutex.synchronize { @pages.values.first }
+          return { error: "no open pages — open a page before saving state" } unless first_session
+
+          payload, captured_origins = capture_state_payload
+          manifest = Browserctl::State.save(
+            req[:name],
+            payload: payload,
+            origins: req[:origins] || captured_origins,
+            flow: req[:flow],
+            flow_version: req[:flow_version],
+            passphrase: req[:passphrase]
+          )
+
+          {
+            ok: true,
+            path: Browserctl::State.path(req[:name]),
+            origins: manifest[:origins],
+            cookies: payload[:cookies].length,
+            encrypted: manifest[:encrypted]
+          }
+        rescue Browserctl::Error, ArgumentError => e
+          { error: e.message }
+        end
+
+        def cmd_state_load(req)
+          data = Browserctl::State.load(req[:name], passphrase: req[:passphrase])
+          target = @global_mutex.synchronize { @pages.values.first }
+          return { error: "no open pages — open a page before loading state" } unless target
+
+          cookies = pluck(data[:payload], :cookies, default: [])
+          restore_state_cookies(target, cookies)
+          ls_count = restore_local_storage(pluck(data[:payload], :local_storage, default: {}))
+
+          {
+            ok: true,
+            cookies: cookies.length,
+            local_storage_keys: ls_count,
+            origins: data[:manifest][:origins]
+          }
+        rescue Browserctl::State::Bundle::BundleError, Browserctl::Error, ArgumentError, JSON::ParserError => e
+          { error: e.message }
+        end
+
+        def pluck(hash, sym, default:)
+          hash[sym] || hash[sym.to_s] || default
+        end
+
+        def restore_state_cookies(target, cookies)
+          cookies.each do |raw|
+            c = raw.transform_keys(&:to_sym)
+            target.page.cookies.set(**c.slice(:name, :value, :domain, :path))
+          end
+        end
+
+        def cmd_state_list(_req)
+          { ok: true, state: Browserctl::State.all }
+        end
+
+        def cmd_state_info(req)
+          { ok: true, info: Browserctl::State.info(req[:name]) }
+        rescue Browserctl::State::Bundle::BundleError, Browserctl::Error, ArgumentError => e
+          { error: e.message }
+        end
+
+        def cmd_state_delete(req)
+          Browserctl::State.delete(req[:name])
+          { ok: true }
+        rescue ArgumentError => e
+          { error: e.message }
+        end
+
+        def capture_state_payload
+          first = @global_mutex.synchronize { @pages.values.first }
+          cookies = first.page.cookies.all.values.map(&:to_h)
+
+          local_storage   = {}
+          session_storage = {}
+          captured_origins = []
+
+          @global_mutex.synchronize { @pages.dup }.each_value do |session|
+            session.mutex.synchronize do
+              origin    = session.page.evaluate("location.origin")
+              ls_str    = session.page.evaluate("JSON.stringify({...localStorage})") || "{}"
+              ss_str    = session.page.evaluate("JSON.stringify({...sessionStorage})") || "{}"
+              local_storage[origin]   = JSON.parse(ls_str)
+              session_storage[origin] = JSON.parse(ss_str)
+              captured_origins << origin
+            end
+          end
+
+          payload = {
+            cookies: cookies,
+            local_storage: local_storage,
+            session_storage: session_storage
+          }
+          [payload, captured_origins.uniq]
+        end
+
+        def restore_local_storage(local_storage)
+          count = 0
+          local_storage.each do |origin, keys|
+            next if keys.nil? || keys.empty?
+
+            tmp_page = @driver.create_page
+            begin
+              tmp_page.go_to(origin.to_s)
+              keys.each do |k, v|
+                tmp_page.evaluate("localStorage.setItem(#{k.to_json}, #{v.to_json})")
+                count += 1
+              end
+            ensure
+              tmp_page.close
+            end
+          end
+          count
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/state.rb
+++ b/lib/browserctl/state.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "time"
+require_relative "constants"
+require_relative "errors"
+require_relative "version"
+require_relative "state/bundle"
+
+module Browserctl
+  # Top-level state store: a single .bctl bundle per name under
+  # ~/.browserctl/state/<name>.bctl. Wraps the Bundle codec with on-disk
+  # naming, validation, and a small inventory API used by `state list/info`.
+  #
+  # Data shape inside a bundle:
+  #
+  #   manifest = {
+  #     name:        String,
+  #     version:     1,                       # bundle schema version
+  #     producer:    "browserctl/<gem-ver>",
+  #     created_at:  ISO-8601,
+  #     origins:     [String, ...],
+  #     flow:        String | nil,            # bound flow name, for `state rotate`
+  #     flow_version: String | nil,
+  #     expires_at:  ISO-8601 | nil,          # earliest cookie expiry
+  #     encrypted:   Boolean
+  #   }
+  #
+  #   payload = {
+  #     cookies:         [Hash, ...],
+  #     local_storage:   { origin => { key => value } },
+  #     session_storage: { origin => { key => value } }
+  #   }
+  module State
+    BASE_DIR  = File.join(BROWSERCTL_DIR, "state")
+    SAFE_NAME = /\A[a-zA-Z0-9_-]{1,64}\z/
+    EXTENSION = ".bctl"
+    MANIFEST_VERSION = 1
+
+    def self.path(name) = File.join(BASE_DIR, "#{name}#{EXTENSION}")
+    def self.exist?(name) = File.exist?(path(name))
+
+    def self.validate_name!(name)
+      return if SAFE_NAME.match?(name.to_s)
+
+      raise ArgumentError, "invalid state name #{name.inspect} — use letters, digits, _ or - (max 64 chars)"
+    end
+
+    # Persist a bundle. `payload` is { cookies:, local_storage:, session_storage: }.
+    # `manifest_extras` may carry origins (override), flow, flow_version.
+    def self.save(name, payload:, origins: nil, flow: nil, flow_version: nil, passphrase: nil) # rubocop:disable Metrics/ParameterLists
+      validate_name!(name)
+      FileUtils.mkdir_p(BASE_DIR)
+
+      manifest = build_manifest(
+        name: name,
+        origins: origins || derive_origins(payload),
+        flow: flow,
+        flow_version: flow_version,
+        cookies: payload[:cookies] || payload["cookies"] || [],
+        encrypted: !passphrase.nil?
+      )
+
+      blob = Bundle.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+      File.open(path(name), "wb", 0o600) { |f| f.write(blob) }
+      manifest
+    end
+
+    # Load and decode a bundle. Returns { manifest:, payload:, encrypted: }.
+    def self.load(name, passphrase: nil)
+      validate_name!(name)
+      raise Browserctl::Error, "state '#{name}' not found" unless exist?(name)
+
+      Bundle.decode(File.binread(path(name)), passphrase: passphrase)
+    end
+
+    def self.delete(name)
+      validate_name!(name)
+      FileUtils.rm_f(path(name))
+    end
+
+    # Read manifests for all stored bundles. Errors on a single file are
+    # surfaced via { error: "...", path: "..." } rather than aborting the list.
+    def self.all
+      return [] unless Dir.exist?(BASE_DIR)
+
+      Dir[File.join(BASE_DIR, "*#{EXTENSION}")].map do |file|
+        info_for(file)
+      end
+    end
+
+    # Inspect a single bundle without decrypting the payload.
+    def self.info(name)
+      validate_name!(name)
+      raise Browserctl::Error, "state '#{name}' not found" unless exist?(name)
+
+      info_for(path(name))
+    end
+
+    def self.info_for(file)
+      blob     = File.binread(file)
+      manifest = Bundle.peek_manifest(blob)
+      manifest.merge(
+        path: file,
+        size: blob.bytesize
+      )
+    rescue Bundle::BundleError => e
+      { name: File.basename(file, EXTENSION), path: file, error: e.message }
+    end
+    private_class_method :info_for
+
+    def self.build_manifest(name:, origins:, flow:, flow_version:, cookies:, encrypted:) # rubocop:disable Metrics/ParameterLists
+      {
+        name: name,
+        version: MANIFEST_VERSION,
+        producer: "browserctl/#{Browserctl::VERSION}",
+        created_at: Time.now.utc.iso8601,
+        origins: Array(origins).compact.uniq,
+        flow: flow,
+        flow_version: flow_version,
+        expires_at: earliest_expiry(cookies),
+        encrypted: encrypted
+      }
+    end
+    private_class_method :build_manifest
+
+    # Origins captured from the payload itself when not overridden. Pulls from
+    # cookie domains and storage keys to cover both navigation-tracked and
+    # cookie-only auth.
+    def self.derive_origins(payload)
+      cookies = fetch_either(payload, :cookies, "cookies", default: [])
+      ls      = fetch_either(payload, :local_storage, "local_storage", default: {})
+      ss      = fetch_either(payload, :session_storage, "session_storage", default: {})
+
+      (origins_from_cookies(cookies) + ls.keys.map(&:to_s) + ss.keys.map(&:to_s)).uniq
+    end
+    private_class_method :derive_origins
+
+    def self.origins_from_cookies(cookies)
+      cookies.filter_map do |c|
+        domain = (c[:domain] || c["domain"]).to_s
+        next if domain.empty?
+
+        domain.start_with?(".") ? "https://#{domain[1..]}" : "https://#{domain}"
+      end
+    end
+    private_class_method :origins_from_cookies
+
+    def self.fetch_either(hash, sym_key, str_key, default:)
+      hash[sym_key] || hash[str_key] || default
+    end
+    private_class_method :fetch_either
+
+    def self.earliest_expiry(cookies)
+      times = cookies.filter_map do |c|
+        v = c[:expires] || c["expires"] || c[:expiresAt] || c["expiresAt"]
+        v&.to_f&.positive? ? Time.at(v.to_f).utc.iso8601 : nil
+      end
+      times.min
+    end
+    private_class_method :earliest_expiry
+  end
+end

--- a/lib/browserctl/state/bundle.rb
+++ b/lib/browserctl/state/bundle.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require "json"
+require "openssl"
+require "securerandom"
+require_relative "../errors"
+
+module Browserctl
+  module State
+    # Single-file portable codec for browserctl session state — the .bctl
+    # bundle. Wraps a plaintext manifest (origins, flow binding, timestamps)
+    # alongside a payload of cookies + storage. The manifest is always
+    # readable without a passphrase (so `state info` can show origins and
+    # expiry); the payload is optionally encrypted.
+    #
+    # Wire format (big-endian):
+    #
+    #   magic:        "BCTL\x00"           5 bytes
+    #   version:      0x01                 1 byte
+    #   flags:        bit 0 = encrypted    1 byte
+    #   reserved:     0x00                 1 byte
+    #   manifest_len:                      4 bytes
+    #   manifest:     JSON                 manifest_len bytes (always plaintext)
+    #   payload_len:                       4 bytes
+    #   payload:      see below            payload_len bytes
+    #   footer:       32 bytes
+    #
+    # When flags & 0x01 is unset:
+    #   payload  = JSON bytes (plaintext)
+    #   footer   = SHA-256 over magic..payload (corruption detection)
+    #
+    # When flags & 0x01 is set:
+    #   payload  = salt(16) || nonce(12) || ciphertext || tag(16)
+    #   footer   = HMAC-SHA-256(hmac_key, magic..payload)
+    #   salt drives PBKDF2(passphrase, salt, 200_000, SHA-256, 64-byte output);
+    #   first 32 bytes are the AES-256-GCM encryption key, last 32 bytes are
+    #   the HMAC-SHA-256 key.
+    #
+    # Reuses the same AES-256-GCM primitive as v0.8 session encryption
+    # (lib/browserctl/session.rb). The two will share a Crypto module in a
+    # follow-up; duplicated here to keep this PR focused.
+    class Bundle
+      MAGIC          = "BCTL\x00".b.freeze
+      VERSION        = 1
+      FLAG_ENCRYPTED = 0x01
+      HEADER_SIZE    = MAGIC.bytesize + 3 # version + flags + reserved
+      LEN_SIZE       = 4
+      FOOTER_SIZE    = 32
+      SALT_SIZE      = 16
+      NONCE_SIZE     = 12
+      TAG_SIZE       = 16
+      PBKDF2_ITERS   = 200_000
+
+      class BundleError      < Browserctl::Error; def self.default_code = "bundle_error"      end
+      class TamperError      < BundleError;       def self.default_code = "bundle_tampered"   end
+      class PassphraseError  < BundleError;       def self.default_code = "bundle_passphrase" end
+
+      # Encodes manifest + payload into a single binary blob.
+      #
+      # @param manifest [Hash] plaintext manifest (always readable)
+      # @param payload  [Hash] cookies/storage; encrypted when passphrase given
+      # @param passphrase [String, nil] when given, payload is encrypted and
+      #   the footer is an HMAC. When nil, payload is plaintext and the
+      #   footer is a SHA-256 digest.
+      def self.encode(manifest:, payload:, passphrase: nil)
+        manifest_bytes = JSON.generate(manifest).b
+        payload_json   = JSON.generate(payload).b
+        flags          = 0
+        hmac_key       = nil
+
+        if passphrase
+          salt = SecureRandom.bytes(SALT_SIZE)
+          enc_key, hmac_key = derive_keys(passphrase, salt)
+          payload_bytes = salt + aes_gcm_encrypt(payload_json, enc_key)
+          flags |= FLAG_ENCRYPTED
+        else
+          payload_bytes = payload_json
+        end
+
+        body = build_body(flags, manifest_bytes, payload_bytes)
+        body + footer_for(body, hmac_key)
+      end
+
+      # Decodes a blob, verifying the footer and decrypting payload when
+      # encrypted. Raises TamperError on digest/HMAC mismatch and
+      # PassphraseError when an encrypted bundle is decoded without a
+      # passphrase or with the wrong one.
+      def self.decode(blob, passphrase: nil)
+        magic, version, flags = read_header!(blob)
+        raise BundleError, "unsupported bundle version #{version}" unless version == VERSION
+
+        manifest_bytes, payload_bytes, footer = read_sections!(blob)
+        body = blob.byteslice(0, blob.bytesize - FOOTER_SIZE)
+
+        encrypted = flags.anybits?(FLAG_ENCRYPTED)
+        verify_footer!(body, footer, encrypted: encrypted, passphrase: passphrase)
+
+        manifest = JSON.parse(manifest_bytes, symbolize_names: true)
+        payload  = decode_payload(payload_bytes, encrypted: encrypted, passphrase: passphrase)
+
+        { manifest: manifest, payload: payload, magic: magic, version: version, encrypted: encrypted }
+      end
+
+      # Reads the manifest without verifying the footer or decrypting the
+      # payload. Use for `state info` and similar read-only queries.
+      def self.peek_manifest(blob)
+        _, version, = read_header!(blob)
+        raise BundleError, "unsupported bundle version #{version}" unless version == VERSION
+
+        manifest_bytes, = read_sections!(blob)
+        JSON.parse(manifest_bytes, symbolize_names: true)
+      end
+
+      def self.build_body(flags, manifest_bytes, payload_bytes)
+        header = MAGIC + [VERSION, flags, 0].pack("CCC")
+        header +
+          [manifest_bytes.bytesize].pack("N") + manifest_bytes +
+          [payload_bytes.bytesize].pack("N") + payload_bytes
+      end
+      private_class_method :build_body
+
+      def self.footer_for(body, hmac_key)
+        if hmac_key
+          OpenSSL::HMAC.digest("SHA256", hmac_key, body)
+        else
+          OpenSSL::Digest.digest("SHA256", body)
+        end
+      end
+      private_class_method :footer_for
+
+      def self.read_header!(blob)
+        raise BundleError, "blob too small for header" if blob.bytesize < HEADER_SIZE + (2 * LEN_SIZE) + FOOTER_SIZE
+
+        magic = blob.byteslice(0, MAGIC.bytesize)
+        raise BundleError, "bad magic — not a .bctl bundle" unless magic == MAGIC
+
+        version, flags, _reserved = blob.byteslice(MAGIC.bytesize, 3).unpack("CCC")
+        [magic, version, flags]
+      end
+      private_class_method :read_header!
+
+      def self.read_sections!(blob)
+        cursor          = HEADER_SIZE
+        manifest_len    = blob.byteslice(cursor, LEN_SIZE).unpack1("N")
+        cursor         += LEN_SIZE
+        manifest_bytes  = blob.byteslice(cursor, manifest_len)
+        cursor         += manifest_len
+        payload_len     = blob.byteslice(cursor, LEN_SIZE).unpack1("N")
+        cursor         += LEN_SIZE
+        payload_bytes   = blob.byteslice(cursor, payload_len)
+        cursor         += payload_len
+        footer          = blob.byteslice(cursor, FOOTER_SIZE)
+
+        unless manifest_bytes && payload_bytes && footer && footer.bytesize == FOOTER_SIZE
+          raise BundleError, "truncated bundle"
+        end
+
+        [manifest_bytes, payload_bytes, footer]
+      end
+      private_class_method :read_sections!
+
+      def self.verify_footer!(body, footer, encrypted:, passphrase:)
+        if encrypted
+          raise PassphraseError, "encrypted bundle requires a passphrase" unless passphrase
+
+          # We need the HMAC key, which depends on the salt embedded in the
+          # payload. Pull the salt from the payload bytes inside `body`.
+          salt = extract_salt!(body)
+          _, hmac_key = derive_keys(passphrase, salt)
+          expected = OpenSSL::HMAC.digest("SHA256", hmac_key, body)
+          raise PassphraseError, "wrong passphrase or tampered bundle" unless secure_eq?(footer, expected)
+        else
+          expected = OpenSSL::Digest.digest("SHA256", body)
+          raise TamperError, "bundle digest mismatch — file is corrupted or modified" unless secure_eq?(footer,
+                                                                                                        expected)
+        end
+      end
+      private_class_method :verify_footer!
+
+      def self.extract_salt!(body)
+        cursor          = HEADER_SIZE
+        manifest_len    = body.byteslice(cursor, LEN_SIZE).unpack1("N")
+        cursor         += LEN_SIZE + manifest_len + LEN_SIZE
+        body.byteslice(cursor, SALT_SIZE) or raise BundleError, "encrypted payload missing salt"
+      end
+      private_class_method :extract_salt!
+
+      def self.decode_payload(bytes, encrypted:, passphrase:)
+        if encrypted
+          salt       = bytes.byteslice(0, SALT_SIZE)
+          ciphertext = bytes.byteslice(SALT_SIZE, bytes.bytesize - SALT_SIZE)
+          enc_key, = derive_keys(passphrase, salt)
+          plaintext  = aes_gcm_decrypt(ciphertext, enc_key)
+          JSON.parse(plaintext)
+        else
+          JSON.parse(bytes)
+        end
+      rescue OpenSSL::Cipher::CipherError
+        raise PassphraseError, "wrong passphrase — payload could not be decrypted"
+      end
+      private_class_method :decode_payload
+
+      def self.derive_keys(passphrase, salt)
+        material = OpenSSL::PKCS5.pbkdf2_hmac(passphrase.to_s, salt, PBKDF2_ITERS, 64, "SHA256")
+        [material.byteslice(0, 32), material.byteslice(32, 32)]
+      end
+      private_class_method :derive_keys
+
+      def self.aes_gcm_encrypt(plaintext, key)
+        cipher = OpenSSL::Cipher.new("aes-256-gcm")
+        cipher.encrypt
+        cipher.key = key
+        nonce = SecureRandom.bytes(NONCE_SIZE)
+        cipher.iv = nonce
+        ct = cipher.update(plaintext) + cipher.final
+        nonce + ct + cipher.auth_tag
+      end
+      private_class_method :aes_gcm_encrypt
+
+      def self.aes_gcm_decrypt(blob, key)
+        nonce      = blob.byteslice(0, NONCE_SIZE)
+        tag        = blob.byteslice(-TAG_SIZE, TAG_SIZE)
+        ciphertext = blob.byteslice(NONCE_SIZE, blob.bytesize - NONCE_SIZE - TAG_SIZE)
+
+        cipher = OpenSSL::Cipher.new("aes-256-gcm")
+        cipher.decrypt
+        cipher.key      = key
+        cipher.iv       = nonce
+        cipher.auth_tag = tag
+        cipher.update(ciphertext) + cipher.final
+      end
+      private_class_method :aes_gcm_decrypt
+
+      def self.secure_eq?(actual, expected)
+        return false if actual.bytesize != expected.bytesize
+
+        OpenSSL.fixed_length_secure_compare(actual, expected)
+      end
+      private_class_method :secure_eq?
+    end
+  end
+end

--- a/spec/unit/state/bundle_spec.rb
+++ b/spec/unit/state/bundle_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/state/bundle"
+
+RSpec.describe Browserctl::State::Bundle do
+  let(:manifest) do
+    {
+      version: 1,
+      flow: "github_login",
+      flow_version: "1.0.0",
+      origins: ["github.com", "api.github.com"],
+      created_at: 1_700_000_000
+    }
+  end
+
+  let(:payload) do
+    {
+      "cookies" => [{ "name" => "sess", "value" => "abc", "domain" => ".github.com" }],
+      "local_storage" => { "user" => "patrick" },
+      "session_storage" => {}
+    }
+  end
+
+  describe "plaintext bundles" do
+    it "round-trips manifest and payload" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      out  = described_class.decode(blob)
+
+      expect(out[:manifest]).to eq(manifest)
+      expect(out[:payload]).to eq(payload)
+      expect(out[:encrypted]).to be false
+    end
+
+    it "starts with the BCTL magic" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      expect(blob.byteslice(0, 5)).to eq("BCTL\x00".b)
+    end
+
+    it "raises TamperError when any byte of the body is modified" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      offset = blob.bytesize - described_class::FOOTER_SIZE - 5
+      blob.setbyte(offset, blob.getbyte(offset) ^ 0xFF)
+
+      expect { described_class.decode(blob) }
+        .to raise_error(described_class::TamperError, /corrupted/) do |e|
+        expect(e.code).to eq("bundle_tampered")
+      end
+    end
+
+    it "raises TamperError when the footer is mutated" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      offset = blob.bytesize - 1
+      blob.setbyte(offset, blob.getbyte(offset) ^ 0xFF)
+
+      expect { described_class.decode(blob) }.to raise_error(described_class::TamperError)
+    end
+  end
+
+  describe "encrypted bundles" do
+    let(:passphrase) { "correct horse battery staple" }
+
+    it "round-trips with the right passphrase" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+      out  = described_class.decode(blob, passphrase: passphrase)
+
+      expect(out[:manifest]).to eq(manifest)
+      expect(out[:payload]).to eq(payload)
+      expect(out[:encrypted]).to be true
+    end
+
+    it "produces different ciphertext on each encode (random salt + nonce)" do
+      a = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+      b = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+
+      expect(a).not_to eq(b)
+    end
+
+    it "raises PassphraseError on a wrong passphrase" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+
+      expect { described_class.decode(blob, passphrase: "wrong") }
+        .to raise_error(described_class::PassphraseError, /wrong passphrase/) do |e|
+        expect(e.code).to eq("bundle_passphrase")
+      end
+    end
+
+    it "raises PassphraseError when no passphrase given for an encrypted bundle" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+
+      expect { described_class.decode(blob) }
+        .to raise_error(described_class::PassphraseError, /requires a passphrase/)
+    end
+
+    it "raises PassphraseError when ciphertext is mutated" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+      # Flip a byte deep in the encrypted payload
+      mid = blob.bytesize / 2
+      blob.setbyte(mid, blob.getbyte(mid) ^ 0xFF)
+
+      expect { described_class.decode(blob, passphrase: passphrase) }
+        .to raise_error(described_class::PassphraseError)
+    end
+
+    it "leaves the manifest readable without a passphrase" do
+      blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+
+      m = described_class.peek_manifest(blob)
+
+      expect(m).to eq(manifest)
+    end
+  end
+
+  describe ".peek_manifest" do
+    it "reads the manifest from a plaintext bundle" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      expect(described_class.peek_manifest(blob)).to eq(manifest)
+    end
+
+    it "raises BundleError on a non-bundle blob" do
+      expect { described_class.peek_manifest("not a bundle") }
+        .to raise_error(described_class::BundleError, /bad magic|too small/)
+    end
+
+    it "raises BundleError on truncated input" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      truncated = blob.byteslice(0, blob.bytesize - 60)
+
+      expect { described_class.decode(truncated) }
+        .to raise_error(described_class::BundleError)
+    end
+  end
+
+  describe "version handling" do
+    it "rejects unknown versions" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      blob.setbyte(5, 99) # version byte
+
+      expect { described_class.decode(blob) }
+        .to raise_error(described_class::BundleError, /unsupported bundle version/)
+    end
+  end
+end

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "json"
+require "browserctl/state"
+
+RSpec.describe Browserctl::State do
+  before do
+    @tmpdir = Dir.mktmpdir
+    stub_const("Browserctl::State::BASE_DIR", @tmpdir)
+  end
+
+  after { FileUtils.rm_rf(@tmpdir) }
+
+  let(:cookies) do
+    [{ name: "sess", value: "abc", domain: ".example.com", path: "/", expires: future_ts }]
+  end
+  let(:local_storage)   { { "https://example.com" => { "theme" => "dark" } } }
+  let(:session_storage) { {} }
+  let(:payload) do
+    { cookies: cookies, local_storage: local_storage, session_storage: session_storage }
+  end
+
+  def future_ts = (Time.now + 86_400).to_i
+
+  describe ".validate_name!" do
+    it "accepts safe names" do
+      expect { described_class.validate_name!("github_prod-1") }.not_to raise_error
+    end
+
+    it "rejects unsafe names" do
+      expect { described_class.validate_name!("../oops") }.to raise_error(ArgumentError)
+      expect { described_class.validate_name!("with space") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe ".save / .load" do
+    it "round-trips a plaintext bundle and writes to disk with 0600" do
+      manifest = described_class.save("github", payload: payload, flow: "github_login")
+      expect(manifest[:flow]).to eq("github_login")
+      expect(manifest[:origins]).to include("https://example.com")
+      expect(manifest[:expires_at]).not_to be_nil
+      expect(manifest[:encrypted]).to be(false)
+
+      file = described_class.path("github")
+      expect(File.exist?(file)).to be(true)
+      expect(File.stat(file).mode & 0o777).to eq(0o600)
+
+      out = described_class.load("github")
+      expect(out[:manifest][:flow]).to eq("github_login")
+      expect(out[:payload]["cookies"].first["name"]).to eq("sess")
+    end
+
+    it "encrypts when a passphrase is provided and refuses to load without it" do
+      described_class.save("github", payload: payload, passphrase: "hunter2")
+
+      expect { described_class.load("github") }
+        .to raise_error(Browserctl::State::Bundle::PassphraseError)
+
+      out = described_class.load("github", passphrase: "hunter2")
+      expect(out[:encrypted]).to be(true)
+      expect(out[:payload]["cookies"].first["value"]).to eq("abc")
+    end
+
+    it "raises when loading a missing bundle" do
+      expect { described_class.load("missing") }.to raise_error(Browserctl::Error)
+    end
+
+    it "honours an explicit --origins override" do
+      manifest = described_class.save("multi",
+                                      payload: payload,
+                                      origins: %w[https://a.test https://b.test])
+      expect(manifest[:origins]).to eq(%w[https://a.test https://b.test])
+    end
+  end
+
+  describe ".info / .all" do
+    before do
+      described_class.save("github", payload: payload, flow: "github_login")
+      described_class.save("private", payload: payload, passphrase: "p")
+    end
+
+    it "info returns manifest plus path and size, without needing passphrase" do
+      info = described_class.info("private")
+      expect(info[:encrypted]).to be(true)
+      expect(info[:size]).to be > 0
+      expect(info[:path]).to end_with("private.bctl")
+    end
+
+    it "all lists every stored bundle" do
+      names = described_class.all.map { |m| m[:name] }
+      expect(names).to contain_exactly("github", "private")
+    end
+
+    it "all surfaces a per-file error rather than raising on a corrupt bundle" do
+      File.binwrite(described_class.path("broken"), "garbage")
+      entry = described_class.all.find { |m| m[:path].end_with?("broken.bctl") }
+      expect(entry[:error]).to be_a(String).and(satisfy { |s| !s.empty? })
+    end
+  end
+
+  describe ".delete" do
+    it "removes the file, no-ops when absent" do
+      described_class.save("github", payload: payload)
+      expect(described_class.exist?("github")).to be(true)
+
+      described_class.delete("github")
+      expect(described_class.exist?("github")).to be(false)
+      expect { described_class.delete("github") }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary
WS-4 / PR 12 of the [v0.10 flows plan](docs/plans/v0.10-flows.md). Wraps the `.bctl` bundle codec from #94 with a top-level `browserctl state` verb that collapses cookie + storage management into a single bundle per name.

Stacked on `feat/bctl-bundle` (#94) — merge that first, then this rebases onto `main`.

## Surface

```
browserctl state save   <name> [--encrypt] [--origins a,b] [--flow NAME]
browserctl state load   <name>
browserctl state list
browserctl state info   <name>
browserctl state delete <name>
```

- Bundles live at \`~/.browserctl/state/<name>.bctl\` (0600).
- Manifest is always plaintext — \`state info\` reports origins, expiry, source flow, and size without prompting for a passphrase.
- Payload is optionally encrypted; passphrase from \`BROWSERCTL_STATE_PASSPHRASE\` or stdin.
- \`--origins\` overrides the auto-detected list (cookie domains + captured \`location.origin\` from open pages); WS-5's nav-chain capture during \`produces_state\` will refine the auto path.

## What's not in this PR

- \`state export/import\` with transports → PR 13
- \`state rotate\` → PR 14
- Concept docs (\`docs/concepts/state.md\`) and deprecation note for \`cookie *\` / \`storage *\` → PR 15

The existing \`session\` commands remain functional and untouched; \`state\` stacks alongside.

## Test plan
- [x] \`bundle exec rspec spec/unit\` — 413 examples, 0 failures (10 new in \`state_spec.rb\`)
- [x] \`bundle exec rubocop\` — 152 files, 0 offenses
- [ ] Manual smoke: \`state save github && state info github && state load github\` against a live daemon (will run before merge)