### PR TITLE
feat: state rotate

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -103,6 +103,7 @@ def usage
       state list
       state info   <name>
       state delete <name>
+      state rotate <name> [--page NAME] [--params FILE] [--key value ...]
       state export <name> <destination>     # file path, s3://..., op://Vault/Item
       state import <source> [--name NAME]
 

--- a/lib/browserctl/commands/state.rb
+++ b/lib/browserctl/commands/state.rb
@@ -11,11 +11,11 @@ module Browserctl
     module State
       extend CliOutput
 
-      USAGE = "Usage: browserctl state <save|load|list|info|delete|export|import> [args]"
+      USAGE = "Usage: browserctl state <save|load|list|info|delete|rotate|export|import> [args]"
 
       DAEMON_SUBCOMMANDS = {
         "save" => :run_save, "load" => :run_load, "list" => :run_list,
-        "info" => :run_info, "delete" => :run_delete
+        "info" => :run_info, "delete" => :run_delete, "rotate" => :run_rotate
       }.freeze
 
       LOCAL_SUBCOMMANDS = { "export" => :run_export, "import" => :run_import }.freeze
@@ -70,6 +70,61 @@ module Browserctl
         name = args.shift or abort "usage: browserctl state delete <name>"
         print_result(client.state_delete(name))
       end
+
+      # Re-runs the flow bound to <name> and re-saves the bundle. The flow is
+      # read from the manifest (set when the bundle was originally produced
+      # via `state save --flow ...`). Params come from --params or k=v pairs.
+      def self.run_rotate(client, args)
+        require "browserctl/flow_registry"
+        page_name   = extract_value!(args, "--page")
+        params_path = extract_value!(args, "--params")
+        name        = args.shift or abort "usage: browserctl state rotate <name> " \
+                                          "[--page NAME] [--params FILE] [--key value ...]"
+
+        manifest = read_manifest!(client, name)
+        flow     = resolve_bound_flow!(manifest)
+        params   = build_rotate_params(params_path, args)
+        page_proxy = page_name ? Browserctl::PageProxy.new(page_name, client) : nil
+
+        flow.run(page: page_proxy, client: client, **params)
+
+        save_result = client.state_save(name,
+                                        flow: flow.name,
+                                        flow_version: flow.version_string,
+                                        origins: manifest[:origins])
+        print_result(save_result.merge(rotated_flow: flow.name))
+      rescue Browserctl::FlowError => e
+        warn "Error: #{e.message}"
+        exit 1
+      end
+
+      def self.read_manifest!(client, name)
+        info = client.state_info(name)
+        abort "Error: #{info[:error] || info['error']}" if info[:error] || info["error"]
+
+        info[:info] || info["info"] || {}
+      end
+      private_class_method :read_manifest!
+
+      def self.resolve_bound_flow!(manifest)
+        flow_name = manifest[:flow] || manifest["flow"]
+        abort "Error: state has no bound flow — re-save with `state save --flow NAME` first" if flow_name.nil? ||
+                                                                                                flow_name.to_s.empty?
+
+        flow = Browserctl::FlowRegistry.resolve(flow_name)
+        abort "Error: flow '#{flow_name}' not found in registry" unless flow
+
+        flow
+      end
+      private_class_method :resolve_bound_flow!
+
+      def self.build_rotate_params(params_path, args)
+        require "browserctl/runner"
+        file_params = params_path ? Browserctl::Runner.load_params_file(params_path) : {}
+        cli_params  = args.each_slice(2).to_h { |flag, val| [flag.to_s.sub(/\A--/, "").to_sym, val] }
+        file_params.merge(cli_params)
+      end
+      private_class_method :build_rotate_params
 
       def self.run_export(args)
         name        = args.shift or abort "usage: browserctl state export <name> <destination>"

--- a/spec/unit/commands_state_rotate_spec.rb
+++ b/spec/unit/commands_state_rotate_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "stringio"
+require "browserctl/commands/state"
+
+RSpec.describe Browserctl::Commands::State do
+  let(:client) { instance_double(Browserctl::Client) }
+
+  before { Browserctl.flow_registry_reset! }
+  after  { Browserctl.flow_registry_reset! }
+
+  describe ".run rotate" do
+    it "runs the bound flow and re-saves the bundle" do
+      flow_ran = false
+      Browserctl.flow("github_login") do
+        version "1.2.3"
+        param :username, required: true
+        step("noop") { flow_ran = true }
+      end
+
+      manifest = { flow: "github_login", origins: ["https://github.com"] }
+      allow(client).to receive(:state_info).with("github").and_return(ok: true, info: manifest)
+      allow(client).to receive(:state_save).with("github",
+                                                 flow: "github_login",
+                                                 flow_version: "1.2.3",
+                                                 origins: ["https://github.com"])
+                                           .and_return(ok: true, path: "/tmp/x.bctl")
+
+      out = capture_stdout do
+        described_class.run(client, %w[rotate github --username pat])
+      end
+
+      payload = JSON.parse(out)
+      expect(payload["ok"]).to be(true)
+      expect(payload["rotated_flow"]).to eq("github_login")
+      expect(flow_ran).to be(true)
+    end
+
+    it "aborts when the manifest has no bound flow" do
+      allow(client).to receive(:state_info).with("github").and_return(ok: true, info: { origins: [] })
+
+      expect { described_class.run(client, %w[rotate github]) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+
+    it "aborts when the bound flow is not registered" do
+      allow(client).to receive(:state_info).with("github")
+                                           .and_return(ok: true, info: { flow: "missing_flow" })
+
+      expect { described_class.run(client, %w[rotate github]) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+
+    it "surfaces an error from state_info" do
+      allow(client).to receive(:state_info).with("github").and_return(error: "state 'github' not found")
+
+      expect { described_class.run(client, %w[rotate github]) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+end


### PR DESCRIPTION
## Summary
WS-4 / PR 14 of the [v0.10 flows plan](docs/plans/v0.10-flows.md). Adds:

```
browserctl state rotate <name> [--page NAME] [--params FILE] [--key value ...]
```

Reads the bound flow from the bundle's manifest, runs it against the daemon (standard `Flow` + `PageProxy` path), and re-saves the bundle with the same origins and a refreshed `flow_version`.

This sets up the WS-5 auto re-auth path: `load_state` will reuse the same `client.state_save` plumbing once the daemon detects an expired bundle.

## Errors

- Manifest has no flow binding → "re-save with `state save --flow NAME` first"
- Bound flow isn't in the registry → "flow 'X' not found in registry"
- Underlying `Flow` raises (FlowParamError, FlowStepError, etc.)

## Test plan
- [x] `bundle exec rspec spec/unit` — 428 examples, 0 failures (4 new in `commands_state_rotate_spec.rb`)
- [x] `bundle exec rubocop` — 158 files, 0 offenses
- [ ] Manual smoke: bind a flow, expire its cookie, run `state rotate <name>` (will run before merge)