### PR TITLE
docs: state and flows concept pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The daemon shuts itself down after 30 minutes of inactivity.
 |---|---|
 | [Getting Started](docs/getting-started.md) | Install, first session, first snapshot |
 | [Agent Integration](docs/guides/agent-integration.md) | Call browserctl from Python, shell, or Anthropic tool-use agents |
-| [Concepts](docs/concepts/) | Sessions, snapshots, human-in-the-loop |
+| [Concepts](docs/concepts/) | Sessions, snapshots, [state](docs/concepts/state.md), [flows](docs/concepts/flows.md), human-in-the-loop |
 | [Guides](docs/guides/) | Writing workflows, handling challenges, smoke testing |
 | [Examples](examples/) | Runnable scripts: session reuse, Cloudflare HITL, and more |
 | [Command Reference](docs/reference/commands.md) | Every command and flag |

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -1,0 +1,133 @@
+# Flows
+
+A flow is a named, parameterised, secret-aware procedure for getting a browser into a particular state. Logging into GitHub. Solving a Cloudflare challenge. Walking the Google OAuth consent screen. Things that are tedious to write inline, easy to break, and identical from one project to the next.
+
+Flows are the unit you call when you want auth done. State is the unit you save afterward. Together they let one machine pay the cost of logging in once, hand the result to ten others, and let any of them refresh it on demand.
+
+```
+your code  ──▶  flow.run(...)  ──▶  state save ──▶  .bctl bundle
+                                                         │
+                                                         ▼
+                                                   state load on N other machines
+                                                         │
+                                                         ▼ (when expired)
+                                                   state rotate  ──▶  flow.run(...) again
+```
+
+---
+
+## Defining a flow
+
+Flows live in plain `.rb` files. browserctl auto-loads them from, in order, `./.browserctl/flows/`, `~/.browserctl/flows/`, then the bundled stdlib (project files win ties).
+
+```ruby
+Browserctl.flow("github_login") do
+  version "1.0.0"
+  desc "Log into github.com with username + password (no 2FA)"
+
+  param :username, required: true
+  param :password, required: true, secret_ref: "GitHub/password"
+
+  precondition("page is on github.com") { page.url.include?("github.com") }
+
+  step "fill credentials" do
+    page.fill("input[name=login]", username)
+    page.fill("input[name=password]", password)
+  end
+
+  step "submit" do
+    page.click("input[type=submit]")
+  end
+
+  postcondition("logged in") { page.snapshot.elements.any? { |e| e[:role] == "navigation" } }
+
+  produces_state do
+    { origins: ["https://github.com"] }
+  end
+end
+```
+
+What the DSL gives you:
+
+- **`version`** — required semver, used by `state rotate` to detect breaking flow changes.
+- **`desc`** — human description, surfaced by `flow describe` and `flow list`.
+- **`param`** — declared inputs. `secret_ref:` resolves through the secret resolver registry (env, macOS Keychain, 1Password). `default:` is for non-secrets only.
+- **`precondition` / `postcondition`** — predicates evaluated before/after the steps. Returning false (or raising) stops the flow with a typed error.
+- **`step`** — the actual work. Steps run in order; `retry_count:` and `timeout:` are per-step.
+- **`produces_state`** — block that returns metadata (origins, hints) the bundle should carry. Optional but recommended.
+
+---
+
+## Running a flow
+
+From the CLI, against an open page:
+
+```bash
+browserctl page open work --url https://github.com/login
+browserctl flow run github_login --page work --username pat
+```
+
+From inside a workflow:
+
+```ruby
+Browserctl.workflow("daily_smoke") do
+  page :work
+  step("login") { invoke :github_login, username: "pat" }
+end
+```
+
+Programmatically:
+
+```ruby
+flow = Browserctl::FlowRegistry.resolve("github_login")
+flow.run(page: page_proxy, client: client, username: "pat")
+```
+
+Secrets are pulled at run-time, not at parse-time, so a flow file can be loaded on a machine that doesn't have access to its secrets.
+
+---
+
+## Flows and state
+
+A flow run is ephemeral. To persist its result, save state with the flow bound:
+
+```bash
+browserctl state save github --flow github_login
+```
+
+Then `state rotate github` re-runs the bound flow and overwrites the bundle. WS-5 of v0.10 wires `load_state :github` in workflows to call `state rotate` automatically when the daemon detects an expired bundle, so most code never needs to think about rotation explicitly.
+
+---
+
+## Stdlib flows
+
+Bundled inside the gem (will split to `browserctl-flows-stdlib` once the count exceeds ~10 or one needs a heavy optional dependency):
+
+| Flow | What it does |
+|---|---|
+| `totp_2fa` | Generates a TOTP from a secret and submits it |
+| `basic_auth` | Handles HTTP basic-auth prompts |
+| `magic_link_email` | Pauses for a click-through link, navigates when it arrives |
+| `oauth_google` | Drives the Google OAuth consent screen |
+| `oauth_github` | Drives the GitHub OAuth consent screen |
+| `cloudflare_solve` | Pauses + HITL signal; captures the resulting cookie |
+
+`browserctl flow list` shows what's available. `browserctl flow describe <name>` shows params, preconditions, and steps.
+
+---
+
+## Versioning
+
+Each flow declares a semver. The manifest in a `.bctl` bundle records the version that produced it. When `state rotate` runs the new version of the flow:
+
+- **Patch / minor bump** — proceed; the bundle is overwritten with the new `flow_version`.
+- **Major bump** — refuse to rotate without `--force`. Bundles produced by old major versions are typically incompatible (renamed cookies, new origins).
+- **No `flow_version` in the manifest** — pre-v0.10 import; warn once, accept.
+
+---
+
+## See also
+
+- [State](state.md) — what flows produce, what `state rotate` re-runs
+- [Writing Workflows](../guides/writing-workflows.md) — the longer-running orchestration layer that calls flows
+- [Stdlib Flows](../guides/stdlib-flows.md) — concrete invocation examples for each shipped flow

--- a/docs/concepts/state.md
+++ b/docs/concepts/state.md
@@ -1,0 +1,149 @@
+# State
+
+A browser session is more than a tab. It's the cookies the server set, the tokens the page wrote into `localStorage`, the CSRF salt cached in `sessionStorage`, and the chain of origins those things belong to. Lose any one of them and the next request looks like a stranger.
+
+browserctl treats all of that as one thing: **state**. One verb saves it, one loads it, one bundle on disk holds it.
+
+```
+~/.browserctl/state/<name>.bctl
+```
+
+A `.bctl` is a single, portable file: a plaintext manifest (origins, flow binding, expiry) plus a payload (cookies + storage), HMAC-signed and optionally passphrase-encrypted. You can copy it between machines, push it to S3, hand it to a teammate over 1Password — and the receiving side validates it byte-for-byte.
+
+---
+
+## The verb
+
+```bash
+browserctl state save   <name> [--encrypt] [--origins a,b] [--flow NAME]
+browserctl state load   <name>
+browserctl state list
+browserctl state info   <name>
+browserctl state delete <name>
+browserctl state rotate <name> [--params FILE] [--key value ...]
+browserctl state export <name> <destination>     # file path, s3://..., op://Vault/Item
+browserctl state import <source> [--name NAME]
+```
+
+That's the whole surface. Everything below is just what each verb does and why.
+
+---
+
+## Save
+
+```bash
+browserctl page open work --url https://github.com
+# ...log in by hand, or via a flow...
+browserctl state save github --flow github_login
+```
+
+What gets captured:
+
+| | Source | Why |
+|---|---|---|
+| Cookies | All cookies from all open pages | The default auth currency for most sites |
+| `localStorage` | Per-origin, all open pages | Tokens, feature flags, persisted UI state |
+| `sessionStorage` | Per-origin, all open pages | CSRF salts, ephemeral tokens — kept for completeness; not all sites restore cleanly |
+| Origins | Auto-detected from cookie domains + `location.origin` of every open page | Used by `state info`, lets `state load` know where to seed `localStorage` |
+| Flow binding | `--flow NAME` | Tells `state rotate` and (in v0.10+) `load_state` how to refresh the bundle when it expires |
+
+`--encrypt` adds a passphrase. The payload is encrypted with AES-256-GCM; the manifest stays plaintext so `state info` can show origins and expiry without prompting.
+
+`--origins a,b` overrides auto-detection. Use it when the default is wrong (cookieless auth, single-page apps that talk to many origins from one tab).
+
+---
+
+## Load
+
+```bash
+browserctl state load github
+```
+
+Restores cookies on the current page, then visits each origin once and replays its `localStorage` keys. `sessionStorage` is **not** restored — it's tab-scoped by spec and most sites that depend on it tolerate it being empty after a fresh tab.
+
+If the bundle was encrypted, you'll be prompted for the passphrase (or set `BROWSERCTL_STATE_PASSPHRASE`).
+
+---
+
+## Info
+
+```bash
+$ browserctl state info github
+{
+  "ok": true,
+  "info": {
+    "name": "github",
+    "version": 1,
+    "producer": "browserctl/0.10.0",
+    "created_at": "2026-05-09T08:30:00Z",
+    "origins": ["https://github.com", "https://api.github.com"],
+    "flow": "github_login",
+    "expires_at": "2026-08-07T08:30:00Z",
+    "encrypted": false,
+    "size": 2048
+  }
+}
+```
+
+Reads the manifest only. No passphrase needed even for encrypted bundles — that's the point of keeping the manifest plaintext.
+
+`expires_at` is the **earliest** cookie expiry. When the daemon detects an `AUTH_REQUIRED` (v0.10+ WS-5), the soonest-expired cookie is usually why.
+
+---
+
+## Rotate
+
+```bash
+browserctl state rotate github
+```
+
+Looks up the bound flow from the manifest, runs it against the daemon, and re-saves the bundle with the same origins and a refreshed `flow_version`. This is what `load_state` calls under the hood when it finds an expired bundle (v0.10+ WS-5).
+
+Errors when:
+- the manifest has no flow binding — re-save with `state save --flow NAME`
+- the bound flow isn't in the registry — `browserctl flow list` to confirm
+
+---
+
+## Export and import
+
+`.bctl` is a single file — moving it is `cp`. The transports give you that as a CLI verb and add cloud destinations:
+
+```bash
+browserctl state export github ./github.bctl
+browserctl state export github s3://my-bucket/states/github.bctl
+browserctl state export github op://Engineering/github-state
+
+browserctl state import ./github.bctl
+browserctl state import s3://my-bucket/states/github.bctl --name github-prod
+```
+
+Bundle bytes go over the wire verbatim — no re-encoding — so the receiving side validates the original HMAC/digest. Imports check the magic header before persisting; an invalid blob never lands in your state directory.
+
+Add your own transport by registering a class with `Browserctl::State::Transport.register` (see `lib/browserctl/state/transport.rb`).
+
+---
+
+## State vs session vs cookie
+
+You'll see three commands in the help text. Reach for them in this order:
+
+1. **`state *`** — what you want 99% of the time. One file, all the auth pieces, encryption optional, transports built in, refresh via flow binding.
+2. **`session *`** — the v0.8 ancestor. Per-name directory under `~/.browserctl/sessions/` with split files for cookies, localStorage, sessionStorage, and metadata. Still works, still supported, but `state` is what new code should use. (v0.10 deprecation warning; removal not before v0.12.)
+3. **`cookie *` and `storage *`** — escape hatches. Reach for these when you need to set a single cookie, dump localStorage to JSON for an external diff tool, or otherwise operate below the bundle layer. Most workflows shouldn't touch them.
+
+---
+
+## When `.bctl` isn't enough
+
+- **State the site refuses to expose to JS** — HTTP-only cookies are captured (CDP gives them up), but anything stored in IndexedDB isn't yet. Tracked under v0.10 WS-4 follow-ups.
+- **Cross-profile bundles** — a bundle is tied to the origins it captured. Loading a github.com bundle into a daemon that's about to talk to gitlab.com is harmless but useless.
+- **Long-lived secrets you'd rather not have on disk** — encrypt with `--encrypt` (passphrase via env or stdin), or export to `op://` and re-import on demand.
+
+---
+
+## See also
+
+- [Flows](flows.md) — what produces state, what `state rotate` re-runs
+- [Sessions and Pages](sessions-and-pages.md) — the daemon model the state lives inside
+- [`docs/architecture/decisions/0014-bctl-bundle-format.md`](../architecture/decisions/) — wire format, encryption, transport interface (after WS-4 lands)


### PR DESCRIPTION
## Summary
WS-4 / PR 15 of the [v0.10 flows plan](docs/plans/v0.10-flows.md). Closes the documentation half of WS-4 by introducing two top-level concept pages and explicitly demoting the cookie/storage commands.

- \`docs/concepts/state.md\` — what state is, full verb surface, encryption, transports, and the rules for when to reach for \`session *\` or \`cookie *\` / \`storage *\` instead
- \`docs/concepts/flows.md\` — flow DSL, flows-vs-state, stdlib catalogue, semver/rotation rules
- \`README.md\` — documentation table now links both new pages

## What's not in this PR

- CHANGELOG breaking-changes section — release-please owns CHANGELOG.md and generates it from conventional-commit footers; the breaking notes will land via the WS-5 commits that introduce the deprecation warnings
- Deprecation runtime warnings on \`cookie *\` / \`storage *\` and on workflow \`load_session fallback:\` — those are code changes, scheduled with WS-5

## Test plan
- [x] Markdown renders cleanly on GitHub (preview locally)
- [x] No code changed; \`bundle exec rspec spec/unit\` still 428/0; \`bundle exec rubocop\` still clean