### PR TITLE
feat: auth_required detector

### DIFF
--- a/lib/browserctl/detectors.rb
+++ b/lib/browserctl/detectors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "detectors/auth_required"
+
 module Browserctl
   module Detectors
     CLOUDFLARE_SIGNALS = [

--- a/lib/browserctl/detectors/auth_required.rb
+++ b/lib/browserctl/detectors/auth_required.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Detectors
+    # Detects "you need to log in again" — the signal that flips a workflow's
+    # `load_state` into `state rotate` territory. Lives alongside the older
+    # `Detectors.cloudflare?` and follows the same `(page) -> Result` shape.
+    #
+    # Three independent checks, evaluated in order. The first to fire wins:
+    #
+    #   1. URL → login path. The page is currently sitting on /login,
+    #      /signin, /auth/login, or a similar canonical login route. This
+    #      catches redirect-based auth ("we noticed you're not logged in").
+    #   2. Recent HTTP 401 / 403. The most recent network response on this
+    #      page was an auth challenge from the backend.
+    #   3. Cookie ledger. A caller-supplied list of cookies contains entries
+    #      that have already expired. Useful when the daemon is preflighting
+    #      a bundle before navigating.
+    #
+    # Each check is pure — no daemon dependencies — so the same detector
+    # runs server-side (handlers/observation.rb) and client-side (workflow
+    # `load_state` hook).
+    module AuthRequired
+      Result = Struct.new(:triggered, :code, :reason, :suggested_flow, keyword_init: true) do
+        def to_h
+          { triggered: triggered, code: code, reason: reason, suggested_flow: suggested_flow }.compact
+        end
+      end
+
+      LOGIN_PATH_RE = %r{(?:^|/)(login|signin|sign[-_]in|auth/(?:login|signin)|account/login)(?:/|$|\?)}i
+
+      AUTH_HTTP_STATUSES = [401, 403].freeze
+
+      class << self
+        # Run every check; return the first triggered Result, or a non-
+        # triggered Result if all pass.
+        #
+        # @param page  [#current_url] anything quacking like a Page
+        # @param recent_responses [Array<Hash>] each `{ status:, url: }`; the
+        #   caller is responsible for collecting these (e.g. via Ferrum's
+        #   network.traffic). Empty by default so callers without traffic
+        #   instrumentation still get the URL/cookie checks.
+        # @param cookies [Array<Hash>, nil] each `{ name:, expires: }`;
+        #   `expires` is a unix timestamp. nil to skip the cookie check.
+        # @param suggested_flow [String, nil] flow name to surface when the
+        #   detector fires — populated by callers from the bundle manifest.
+        # @return [Result]
+        def detect(page, recent_responses: [], cookies: nil, suggested_flow: nil)
+          [
+            check_url(page, suggested_flow),
+            check_responses(recent_responses, suggested_flow),
+            check_cookies(cookies, suggested_flow)
+          ].find(&:triggered) || negative
+        end
+
+        # Convenience predicate matching the existing `Detectors.cloudflare?`
+        # style. Callers that just need a boolean can use this.
+        def triggered?(page, **)
+          detect(page, **).triggered
+        end
+
+        private
+
+        def check_url(page, suggested_flow)
+          url = safe_call(page, :current_url).to_s
+          match = LOGIN_PATH_RE.match(url)
+          return negative unless match
+
+          Result.new(triggered: true, code: "redirect_login",
+                     reason: "url '#{url}' matches login path", suggested_flow: suggested_flow)
+        end
+
+        def check_responses(recent_responses, suggested_flow)
+          response = Array(recent_responses).reverse_each.find do |r|
+            AUTH_HTTP_STATUSES.include?(r[:status] || r["status"])
+          end
+          return negative unless response
+
+          status = response[:status] || response["status"]
+          url    = response[:url] || response["url"]
+          Result.new(triggered: true, code: "http_#{status}",
+                     reason: "recent #{status} from #{url}", suggested_flow: suggested_flow)
+        end
+
+        def check_cookies(cookies, suggested_flow)
+          return negative if cookies.nil?
+
+          expired = expired_cookies(cookies)
+          return negative if expired.empty?
+
+          names = expired.map { |c| c[:name] || c["name"] }.compact.join(", ")
+          Result.new(triggered: true, code: "cookie_expired",
+                     reason: "expired cookies: #{names}", suggested_flow: suggested_flow)
+        end
+
+        def expired_cookies(cookies)
+          now = Time.now.to_f
+          Array(cookies).select { |c| cookie_expired?(c, now) }
+        end
+
+        def cookie_expired?(cookie, now)
+          exp = cookie[:expires] || cookie["expires"]
+          return false unless exp
+
+          float = exp.to_f
+          float.positive? && float < now
+        end
+
+        def negative
+          Result.new(triggered: false, code: nil, reason: nil, suggested_flow: nil)
+        end
+
+        def safe_call(obj, method)
+          obj.respond_to?(method) ? obj.public_send(method) : nil
+        end
+      end
+    end
+
+    # Module-level shorthand so callers match the existing `Detectors.cloudflare?` style.
+    def self.auth_required?(page, **)
+      AuthRequired.triggered?(page, **)
+    end
+
+    def self.auth_required(page, **)
+      AuthRequired.detect(page, **)
+    end
+  end
+end

--- a/spec/unit/detectors/auth_required_spec.rb
+++ b/spec/unit/detectors/auth_required_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "browserctl/detectors"
+
+RSpec.describe Browserctl::Detectors::AuthRequired do
+  let(:page) { double("Page", current_url: url) }
+  let(:url)  { "https://app.example.com/dashboard" }
+
+  describe ".detect — URL check" do
+    %w[
+      https://app.example.com/login
+      https://app.example.com/login/
+      https://app.example.com/login?next=/dash
+      https://app.example.com/signin
+      https://app.example.com/sign-in
+      https://app.example.com/sign_in
+      https://app.example.com/auth/login
+      https://app.example.com/auth/signin
+      https://example.com/account/login
+    ].each do |login_url|
+      it "fires for #{login_url}" do
+        result = described_class.detect(double(current_url: login_url))
+        expect(result.triggered).to be(true)
+        expect(result.code).to eq("redirect_login")
+      end
+    end
+
+    it "does not fire for /loginhelp or /signing-up" do
+      expect(described_class.detect(double(current_url: "https://x/loginhelp")).triggered).to be(false)
+      expect(described_class.detect(double(current_url: "https://x/signing-up")).triggered).to be(false)
+    end
+  end
+
+  describe ".detect — recent responses" do
+    it "fires on the most recent 401" do
+      responses = [
+        { status: 200, url: "https://api/me" },
+        { status: 401, url: "https://api/secret" }
+      ]
+      result = described_class.detect(page, recent_responses: responses)
+      expect(result.triggered).to be(true)
+      expect(result.code).to eq("http_401")
+      expect(result.reason).to include("https://api/secret")
+    end
+
+    it "fires on 403" do
+      result = described_class.detect(page, recent_responses: [{ status: 403, url: "https://api/x" }])
+      expect(result.code).to eq("http_403")
+    end
+
+    it "ignores 200/404/500" do
+      result = described_class.detect(page, recent_responses: [
+                                        { status: 200, url: "https://x" },
+                                        { status: 404, url: "https://x" }
+                                      ])
+      expect(result.triggered).to be(false)
+    end
+
+    it "tolerates string-keyed hashes" do
+      result = described_class.detect(page,
+                                      recent_responses: [{ "status" => 401, "url" => "https://api/x" }])
+      expect(result.triggered).to be(true)
+    end
+  end
+
+  describe ".detect — cookie expiry" do
+    let(:past)   { (Time.now - 86_400).to_i }
+    let(:future) { (Time.now + 86_400).to_i }
+
+    it "fires when any cookie has expired" do
+      result = described_class.detect(page, cookies: [
+                                        { name: "fresh", expires: future },
+                                        { name: "stale", expires: past }
+                                      ])
+      expect(result.triggered).to be(true)
+      expect(result.code).to eq("cookie_expired")
+      expect(result.reason).to include("stale")
+    end
+
+    it "skips when cookies is nil (caller opted out)" do
+      result = described_class.detect(page, cookies: nil)
+      expect(result.triggered).to be(false)
+    end
+
+    it "ignores session cookies (expires <= 0)" do
+      result = described_class.detect(page, cookies: [{ name: "session", expires: 0 }])
+      expect(result.triggered).to be(false)
+    end
+  end
+
+  describe ".detect — passthrough" do
+    it "carries suggested_flow into the result" do
+      result = described_class.detect(double(current_url: "https://x/login"), suggested_flow: "site_login")
+      expect(result.suggested_flow).to eq("site_login")
+    end
+
+    it "returns a non-triggered Result when nothing matches" do
+      result = described_class.detect(page)
+      expect(result.triggered).to be(false)
+      expect(result.code).to be_nil
+    end
+  end
+
+  describe "module-level shortcuts" do
+    it "Detectors.auth_required? returns the boolean" do
+      expect(Browserctl::Detectors.auth_required?(double(current_url: "https://x/login"))).to be(true)
+      expect(Browserctl::Detectors.auth_required?(double(current_url: "https://x/dash"))).to be(false)
+    end
+
+    it "Detectors.auth_required returns the Result" do
+      result = Browserctl::Detectors.auth_required(double(current_url: "https://x/login"))
+      expect(result).to be_a(Browserctl::Detectors::AuthRequired::Result)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
WS-5 / PR 16 of the [v0.10 flows plan](docs/plans/v0.10-flows.md). Adds the pure-Ruby detector that later WS-5 PRs wire into the daemon error response (#17) and the workflow \`load_state\` hook (#18).

## Surface

\`\`\`ruby
Browserctl::Detectors.auth_required?(page) # => Boolean
Browserctl::Detectors.auth_required(page,
  recent_responses: [...], cookies: [...], suggested_flow: "github_login")
# => Result(triggered:, code:, reason:, suggested_flow:)
\`\`\`

## Signals (first match wins)

1. URL on a canonical login path — \`/login\`, \`/signin\`, \`/sign-in\`, \`/sign_in\`, \`/auth/login\`, \`/auth/signin\`, \`/account/login\` (intentionally narrow — \`/loginhelp\` and \`/signing-up\` don't trigger).
2. Most recent network response was 401 or 403.
3. Caller-supplied cookie ledger contains expired entries.

## Why pure functions

No daemon dependency, no I/O, no mutable state — the same detector runs server-side in observation handlers and client-side in the workflow hook. Callers decide what to feed it (Ferrum's \`network.traffic\`, the cookies they just read off the bundle, etc.).

## What's not in this PR

- Wiring into snapshot/observation responses → PR 17
- Workflow \`load_state\` auto re-run + \`on_auth_required\` hook → PR 18

## Test plan
- [x] \`bundle exec rspec spec/unit\` — 449 examples, 0 failures (21 new in \`detectors/auth_required_spec.rb\`)
- [x] \`bundle exec rubocop\` — 160 files, 0 offenses