### PR TITLE
feat: AUTH_REQUIRED structured error code

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -33,9 +33,10 @@ require "browserctl/commands/dialog"
 require "browserctl/commands/ask"
 
 def print_result(res)
-  if res.is_a?(Hash) && res[:error]
-    warn "Error: #{res[:error]}"
-    exit 1
+  if res.is_a?(Hash) && (res[:error] || res["error"])
+    warn "Error: #{res[:error] || res['error']}"
+    puts res.to_json
+    exit((res[:code] || res["code"]) == "AUTH_REQUIRED" ? 7 : 1)
   end
   puts res.to_json
 end
@@ -96,6 +97,10 @@ def usage
       session delete <name>
       session export <name> <path>
       session import <path>
+
+    Auth detection:
+      auth-check <page> [--cookies] [--state NAME] [--flow NAME]
+        # Exits 7 with code: AUTH_REQUIRED when the page needs login.
 
     State (.bctl bundles — cookies + storage + flow binding):
       state save   <name> [--encrypt] [--origins a,b] [--flow NAME]
@@ -166,6 +171,21 @@ else
   when "session"  then Browserctl::Commands::Session.run(client, args)
   when "state"    then Browserctl::Commands::State.run(client, args)
   when "daemon"   then Browserctl::Commands::Daemon.run(client, args)
+  when "auth-check"
+    page_name = args.shift or abort "usage: browserctl auth-check <page> [--cookies] [--state NAME] [--flow NAME]"
+    include_cookies = args.delete("--cookies") ? true : false
+    state_idx = args.index("--state")
+    state_arg = if state_idx
+                  (args.delete_at(state_idx)
+                   args.delete_at(state_idx))
+                end
+    flow_idx  = args.index("--flow")
+    flow_arg  = if flow_idx
+                  (args.delete_at(flow_idx)
+                   args.delete_at(flow_idx))
+                end
+    print_result(client.auth_check(page_name, include_cookies: include_cookies,
+                                              state: state_arg, suggested_flow: flow_arg))
   when "navigate" then print_result(client.navigate(args[0], args[1]))
   when "fill"     then Browserctl::Commands::Fill.run(client, args)
   when "click"    then Browserctl::Commands::Click.run(client, args)

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -330,6 +330,22 @@ module Browserctl
     # Permanently deletes a state bundle.
     def state_delete(name) = call("state_delete", name: name)
 
+    # Runs the auth_required detector against a named page. Returns either
+    # `{ ok: true, auth_required: false }` or an AUTH_REQUIRED error response.
+    # @param name [String] page name
+    # @param include_cookies [Boolean] also feed the page's current cookies
+    #   into the detector (catches expired-cookie auth)
+    # @param state [String, nil] bundle name the caller was working with;
+    #   passed back verbatim so callers can recover without bookkeeping
+    # @param suggested_flow [String, nil] flow name to surface when triggered
+    def auth_check(name, include_cookies: false, state: nil, suggested_flow: nil)
+      call("auth_check",
+           name: name,
+           include_cookies: include_cookies,
+           state: state,
+           suggested_flow: suggested_flow)
+    end
+
     private
 
     def auto_discover_socket

--- a/lib/browserctl/commands/cli_output.rb
+++ b/lib/browserctl/commands/cli_output.rb
@@ -1,14 +1,27 @@
 # frozen_string_literal: true
 
+require_relative "../errors"
+
 module Browserctl
   module Commands
     module CliOutput
+      AUTH_REQUIRED_EXIT_CODE = Browserctl::AuthRequiredError::AUTH_REQUIRED_EXIT_CODE
+
       def print_result(res)
-        if res.is_a?(Hash) && res[:error]
-          warn "Error: #{res[:error]}"
-          exit 1
+        if res.is_a?(Hash) && (res[:error] || res["error"])
+          warn "Error: #{res[:error] || res['error']}"
+          puts res.to_json
+          exit exit_code_for(res)
         end
         puts res.to_json
+      end
+
+      # Maps a daemon error response onto a process exit code. Defaults to 1;
+      # special-cased only for codes that callers programmatically branch on.
+      def exit_code_for(res)
+        return AUTH_REQUIRED_EXIT_CODE if (res[:code] || res["code"]) == "AUTH_REQUIRED"
+
+        1
       end
     end
   end

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -25,6 +25,36 @@ module Browserctl
   class DaemonUnavailableError < Error; def self.default_code = "daemon_unavailable" end
   class BrowserNotFound < Error; def self.default_code = "browser_not_found" end
 
+  # Raised when the daemon detects that the current page needs authentication —
+  # the canonical signal that a workflow's `load_state` should rotate the bound
+  # flow. Carries the bundle name (when a state load was in progress) and a
+  # suggested flow (from the bundle manifest) so callers can recover without
+  # additional lookups. The CLI maps this code to exit status 7.
+  class AuthRequiredError < Error
+    def self.default_code = "AUTH_REQUIRED"
+
+    AUTH_REQUIRED_EXIT_CODE = 7
+
+    attr_reader :state, :suggested_flow, :reason
+
+    def initialize(msg = "authentication required", state: nil, suggested_flow: nil, reason: nil)
+      super(msg)
+      @state          = state
+      @suggested_flow = suggested_flow
+      @reason         = reason
+    end
+
+    def to_response
+      {
+        error: message,
+        code: self.class.default_code,
+        state: state,
+        suggested_flow: suggested_flow,
+        reason: reason
+      }.compact
+    end
+  end
+
   class WorkflowError < Error; def self.default_code = "workflow_error" end
   class SecretResolverError < WorkflowError; def self.default_code = "secret_resolver_error" end
 

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -38,6 +38,7 @@ module Browserctl
       "navigate" => :cmd_navigate,
       "wait" => :cmd_wait,
       "snapshot" => :cmd_snapshot,
+      "auth_check" => :cmd_auth_check,
       "evaluate" => :cmd_evaluate,
       "fill" => :cmd_fill,
       "click" => :cmd_click,

--- a/lib/browserctl/server/handlers/observation.rb
+++ b/lib/browserctl/server/handlers/observation.rb
@@ -12,6 +12,30 @@ module Browserctl
           with_page(req[:name]) { |session| take_snapshot(session, req[:format], req[:diff]) }
         end
 
+        # Runs the auth_required detector against the page and returns either a
+        # plain `{ ok: true, auth_required: false }` response or a structured
+        # `{ error:, code: "AUTH_REQUIRED", state:, suggested_flow:, reason: }`
+        # error. Callers feed in cookies / suggested_flow when they have a
+        # bundle in hand (see PR 18); without them, only the URL signal fires.
+        def cmd_auth_check(req)
+          with_page(req[:name]) do |session|
+            cookies = session.page.cookies.all.values.map(&:to_h) if req[:include_cookies]
+            result = Browserctl::Detectors.auth_required(
+              session.page,
+              cookies: cookies,
+              suggested_flow: req[:suggested_flow]
+            )
+            next { ok: true, auth_required: false } unless result.triggered
+
+            Browserctl::AuthRequiredError.new(
+              result.reason,
+              state: req[:state],
+              suggested_flow: result.suggested_flow,
+              reason: result.reason
+            ).to_response
+          end
+        end
+
         def take_snapshot(session, format, diff)
           nonce     = SecureRandom.hex(8)
           challenge = Detectors.cloudflare?(session.page)

--- a/spec/unit/auth_required_error_spec.rb
+++ b/spec/unit/auth_required_error_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "browserctl/errors"
+
+RSpec.describe Browserctl::AuthRequiredError do
+  it "carries AUTH_REQUIRED as its code" do
+    expect(described_class.default_code).to eq("AUTH_REQUIRED")
+    expect(described_class.new.code).to eq("AUTH_REQUIRED")
+  end
+
+  it "exposes exit code 7" do
+    expect(described_class::AUTH_REQUIRED_EXIT_CODE).to eq(7)
+  end
+
+  it "to_response carries error/code/state/suggested_flow/reason" do
+    err = described_class.new("login required",
+                              state: "github", suggested_flow: "github_login",
+                              reason: "redirect_login")
+    response = err.to_response
+    expect(response[:error]).to eq("login required")
+    expect(response[:code]).to eq("AUTH_REQUIRED")
+    expect(response[:state]).to eq("github")
+    expect(response[:suggested_flow]).to eq("github_login")
+    expect(response[:reason]).to eq("redirect_login")
+  end
+
+  it "omits nil fields from to_response" do
+    response = described_class.new("login").to_response
+    expect(response.keys).to contain_exactly(:error, :code)
+  end
+end

--- a/spec/unit/cli_output_spec.rb
+++ b/spec/unit/cli_output_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "stringio"
+require "browserctl/commands/cli_output"
+
+RSpec.describe Browserctl::Commands::CliOutput do
+  let(:host) { Class.new { extend Browserctl::Commands::CliOutput } }
+
+  describe "#exit_code_for" do
+    it "returns 7 for AUTH_REQUIRED" do
+      expect(host.exit_code_for(error: "x", code: "AUTH_REQUIRED")).to eq(7)
+    end
+
+    it "returns 7 for string-keyed AUTH_REQUIRED" do
+      expect(host.exit_code_for("error" => "x", "code" => "AUTH_REQUIRED")).to eq(7)
+    end
+
+    it "returns 1 for any other error" do
+      expect(host.exit_code_for(error: "x", code: "page_not_found")).to eq(1)
+      expect(host.exit_code_for(error: "x")).to eq(1)
+    end
+  end
+
+  describe "#print_result" do
+    it "prints OK responses as JSON without exiting" do
+      out = capture_stdout { host.print_result(ok: true, value: 42) }
+      expect(out).to include('"ok":true')
+      expect(out).to include('"value":42')
+    end
+
+    it "exits 7 with the body still printed for AUTH_REQUIRED" do
+      out = capture_stdout do
+        expect { host.print_result(error: "login", code: "AUTH_REQUIRED", suggested_flow: "f") }
+          .to raise_error(SystemExit) { |e| expect(e.status).to eq(7) }
+      end
+      expect(out).to include('"code":"AUTH_REQUIRED"')
+      expect(out).to include('"suggested_flow":"f"')
+    end
+
+    it "exits 1 for plain errors" do
+      capture_stdout do
+        expect { host.print_result(error: "oops") }
+          .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      end
+    end
+  end
+
+  def capture_stdout
+    original_stdout = $stdout
+    original_stderr = $stderr
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+    $stderr = original_stderr
+  end
+end


### PR DESCRIPTION
## Summary
WS-5 / PR 17 of the [v0.10 flows plan](docs/plans/v0.10-flows.md). Wires the detector from #99 into a structured error response and a process-level exit code that #18 (workflow auto-recovery) and #19/#20 (agent skill loop) pattern-match on.

## Pieces

### Error class
\`\`\`ruby
Browserctl::AuthRequiredError.new("login required",
  state: "github", suggested_flow: "github_login", reason: "redirect_login")
# code = "AUTH_REQUIRED"
# .to_response = { error:, code:, state:, suggested_flow:, reason: }
\`\`\`

### Daemon command \`auth_check\`
Runs \`Detectors.auth_required\` against a named page. Returns either \`{ ok: true, auth_required: false }\` or the full AUTH_REQUIRED response. \`--cookies\` opts the cookie-expiry signal in.

### CLI \`auth-check\`
\`\`\`
browserctl auth-check <page> [--cookies] [--state NAME] [--flow NAME]
\`\`\`
Surface for exercising the detector end-to-end before #18 wires it into \`load_state\`.

### Exit code 7
Both \`bin/browserctl\` and \`Browserctl::Commands::CliOutput.print_result\` map AUTH_REQUIRED → exit 7. Generic errors stay at 1. Body is still printed as JSON so wrappers can read \`state\` and \`suggested_flow\`.

## Test plan
- [x] \`bundle exec rspec spec/unit\` — 459 examples, 0 failures (10 new across error-class and CliOutput specs)
- [x] \`bundle exec rubocop\` — 162 files, 0 offenses
- [ ] Manual smoke against a real login redirect (will run before merge)