### PR TITLE
feat: load_state auto re-run + on_auth_required hook

### DIFF
--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -316,9 +316,13 @@ module Browserctl
            flow_version: flow_version, passphrase: passphrase)
     end
 
-    # Restores a .bctl bundle into the running daemon.
-    def state_load(name, passphrase: nil)
-      call("state_load", name: name, passphrase: passphrase)
+    # Restores a .bctl bundle into the running daemon. The daemon runs the
+    # auth_required detector against the bundle's cookies before applying;
+    # callers that have already verified the bundle (e.g. workflow
+    # `load_state` after a successful rotate) can pass `skip_auth_check: true`
+    # to bypass it.
+    def state_load(name, passphrase: nil, skip_auth_check: false)
+      call("state_load", name: name, passphrase: passphrase, skip_auth_check: skip_auth_check)
     end
 
     # Lists all stored state bundles (manifest only — no payload decryption).

--- a/lib/browserctl/server/handlers/state.rb
+++ b/lib/browserctl/server/handlers/state.rb
@@ -42,6 +42,21 @@ module Browserctl
           return { error: "no open pages — open a page before loading state" } unless target
 
           cookies = pluck(data[:payload], :cookies, default: [])
+
+          unless req[:skip_auth_check]
+            auth = Browserctl::Detectors.auth_required(
+              target.page, cookies: cookies, suggested_flow: data[:manifest][:flow]
+            )
+            if auth.triggered
+              return Browserctl::AuthRequiredError.new(
+                auth.reason,
+                state: req[:name],
+                suggested_flow: auth.suggested_flow,
+                reason: auth.reason
+              ).to_response
+            end
+          end
+
           restore_state_cookies(target, cookies)
           ls_count = restore_local_storage(pluck(data[:payload], :local_storage, default: {}))
 

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -69,7 +69,39 @@ module Browserctl
       res
     end
 
+    # Persists the daemon's current cookies + storage as a .bctl bundle.
+    # Optional flow binding lets `load_state` auto-rotate when the bundle
+    # is detected as needing authentication.
+    def save_state(name, flow: nil, origins: nil, encrypt: false)
+      passphrase = encrypt ? ENV.fetch("BROWSERCTL_STATE_PASSPHRASE", nil) : nil
+      res = @client.state_save(name.to_s,
+                               flow: flow&.to_s, origins: origins, passphrase: passphrase)
+      raise WorkflowError, res[:error] if res[:error]
+
+      res
+    end
+
+    # Restores a .bctl bundle. When the daemon detects AUTH_REQUIRED before
+    # applying (e.g. expired cookies in the payload), this rotates the bound
+    # flow and retries — no caller code change required.
+    #
+    # @param on_auth_required [Proc, nil] override the auto-rotate path. The
+    #   block runs in the workflow context, in lieu of invoking the manifest's
+    #   bound flow. Use this when the recovery procedure is bespoke.
+    def load_state(name, on_auth_required: nil)
+      res = @client.state_load(name.to_s)
+      return res unless auth_required_response?(res)
+
+      recover_auth_required_state(name.to_s, res, on_auth_required)
+    end
+    DEPRECATED_LOAD_SESSION_FALLBACK = <<~MSG
+      [browserctl] DEPRECATION: `load_session(name, fallback:, expired_if:)` is superseded by
+      `load_state(name)` with a flow-bound bundle (`save_state(name, flow: :name)`).
+      `load_session` will be removed in v0.12. See docs/concepts/state.md.
+    MSG
+
     def load_session(session_name, fallback: nil, expired_if: nil)
+      warn DEPRECATED_LOAD_SESSION_FALLBACK if fallback || expired_if
       validate_expired_if!(expired_if)
       fallback_name = fallback&.to_s
       res = @client.session_load(session_name)
@@ -118,6 +150,33 @@ module Browserctl
     end
 
     private
+
+    def auth_required_response?(res)
+      (res[:code] || res["code"]) == "AUTH_REQUIRED"
+    end
+
+    def recover_auth_required_state(name, initial_res, on_auth_required)
+      if on_auth_required
+        on_auth_required.call
+      else
+        flow_name = initial_res[:suggested_flow] || initial_res["suggested_flow"]
+        unless flow_name && !flow_name.to_s.empty?
+          raise WorkflowError,
+                "state '#{name}' needs auth but bundle has no bound flow — " \
+                "save with `save_state('#{name}', flow: :NAME)` or pass on_auth_required:"
+        end
+
+        invoke(flow_name)
+      end
+
+      after_save = @client.state_save(name)
+      raise WorkflowError, after_save[:error] if after_save[:error]
+
+      retry_res = @client.state_load(name, skip_auth_check: true)
+      raise WorkflowError, retry_res[:error] if retry_res[:error]
+
+      retry_res.merge(rotated: true)
+    end
 
     def validate_expired_if!(expired_if)
       return unless expired_if

--- a/spec/unit/workflow_load_state_spec.rb
+++ b/spec/unit/workflow_load_state_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/workflow"
+
+RSpec.describe "WorkflowContext#load_state" do
+  let(:client) { instance_double(Browserctl::Client) }
+  let(:ctx)    { Browserctl::WorkflowContext.new({}, client) }
+
+  it "returns the load result when the bundle is fresh" do
+    allow(client).to receive(:state_load).with("github").and_return(ok: true, cookies: 4)
+    expect(ctx.load_state("github")).to eq(ok: true, cookies: 4)
+  end
+
+  it "auto-rotates via the bundle's bound flow when AUTH_REQUIRED is returned" do
+    auth_response = {
+      error: "expired cookies",
+      code: "AUTH_REQUIRED",
+      state: "github",
+      suggested_flow: "github_login"
+    }
+    fresh_response = { ok: true, cookies: 4 }
+
+    allow(client).to receive(:state_load).with("github").and_return(auth_response)
+    allow(client).to receive(:state_load).with("github", skip_auth_check: true).and_return(fresh_response)
+    allow(client).to receive(:state_save).with("github").and_return(ok: true)
+    allow(ctx).to receive(:invoke).with("github_login")
+
+    result = ctx.load_state("github")
+
+    expect(ctx).to have_received(:invoke).with("github_login")
+    expect(client).to have_received(:state_save).with("github")
+    expect(result).to include(rotated: true, ok: true, cookies: 4)
+  end
+
+  it "honours an explicit on_auth_required: hook over the auto path" do
+    auth_response = { error: "expired", code: "AUTH_REQUIRED", suggested_flow: "ignored_flow" }
+    allow(client).to receive(:state_load).with("github").and_return(auth_response)
+    allow(client).to receive(:state_load).with("github", skip_auth_check: true).and_return(ok: true)
+    allow(client).to receive(:state_save).with("github").and_return(ok: true)
+    allow(ctx).to receive(:invoke)
+
+    custom_ran = false
+    ctx.load_state("github", on_auth_required: -> { custom_ran = true })
+
+    expect(custom_ran).to be(true)
+    expect(ctx).not_to have_received(:invoke)
+  end
+
+  it "raises a WorkflowError when AUTH_REQUIRED hits and no flow is bound" do
+    allow(client).to receive(:state_load).with("github")
+                                         .and_return(error: "expired", code: "AUTH_REQUIRED")
+    expect { ctx.load_state("github") }
+      .to raise_error(Browserctl::WorkflowError, /no bound flow/)
+  end
+
+  it "raises when the rotated flow still fails the auth check" do
+    allow(client).to receive(:state_load).with("github")
+                                         .and_return(error: "expired", code: "AUTH_REQUIRED",
+                                                     suggested_flow: "github_login")
+    allow(client).to receive(:state_save).with("github").and_return(ok: true)
+    allow(client).to receive(:state_load).with("github", skip_auth_check: true)
+                                         .and_return(error: "still bad")
+    allow(ctx).to receive(:invoke).with("github_login")
+
+    expect { ctx.load_state("github") }
+      .to raise_error(Browserctl::WorkflowError, /still bad/)
+  end
+end
+
+RSpec.describe "WorkflowContext#save_state" do
+  let(:client) { instance_double(Browserctl::Client) }
+  let(:ctx)    { Browserctl::WorkflowContext.new({}, client) }
+
+  it "calls state_save with the flow binding" do
+    expect(client).to receive(:state_save).with("github", flow: "github_login",
+                                                          origins: nil, passphrase: nil)
+                                          .and_return(ok: true)
+    ctx.save_state("github", flow: :github_login)
+  end
+
+  it "raises when the daemon returns an error" do
+    allow(client).to receive(:state_save).and_return(error: "not allowed")
+    expect { ctx.save_state("github") }.to raise_error(Browserctl::WorkflowError, "not allowed")
+  end
+end
+
+RSpec.describe "WorkflowContext#load_session deprecation" do
+  let(:client) { instance_double(Browserctl::Client) }
+  let(:ctx)    { Browserctl::WorkflowContext.new({}, client) }
+
+  it "warns when fallback: is used" do
+    allow(client).to receive(:session_load).with("my-session").and_return(ok: true)
+    expect { ctx.load_session("my-session", fallback: :setup) }
+      .to output(/DEPRECATION.*load_state/m).to_stderr
+  end
+
+  it "does not warn when called without fallback / expired_if" do
+    allow(client).to receive(:session_load).with("my-session").and_return(ok: true)
+    expect { ctx.load_session("my-session") }.not_to output(/DEPRECATION/).to_stderr
+  end
+end


### PR DESCRIPTION
## Summary
WS-5 / PR 18 of the [v0.10 flows plan](docs/plans/v0.10-flows.md). Closes the auth-recovery loop: a workflow calling \`load_state\` on an expired bundle now rotates the bound flow, re-saves, and continues — no caller code change required.

This is what makes the v0.10 acceptance criterion ("expired GitHub auth recovers automatically") true.

## Pieces

### Server — \`cmd_state_load\` preflight
Before applying cookies/storage, runs \`Detectors.auth_required\` against the bundle's payload cookies with the manifest's bound flow as \`suggested_flow\`. Triggered → returns the AUTH_REQUIRED response from #100. \`skip_auth_check: true\` bypasses on retry so we don't loop.

### WorkflowContext#load_state(name, on_auth_required: nil)
\`\`\`ruby
def load_state(name, on_auth_required: nil)
  res = client.state_load(name)
  return res unless auth_required?(res)
  on_auth_required ? on_auth_required.call : invoke(res[:suggested_flow])
  client.state_save(name)
  client.state_load(name, skip_auth_check: true).merge(rotated: true)
end
\`\`\`

### WorkflowContext#save_state(name, flow:, origins:, encrypt:)
Workflow-level wrapper around \`client.state_save\` so saving carries the flow binding inline with the matching \`load_state\`.

## Deprecation

\`load_session(name, fallback:, expired_if:)\` now emits a stderr DEPRECATION warning when \`fallback:\` or \`expired_if:\` is passed. Bare \`load_session(name)\` is unchanged. Removal in v0.12, documented in \`docs/concepts/state.md\` (#98).

## Test plan
- [x] \`bundle exec rspec spec/unit\` — 468 examples, 0 failures (9 new in \`workflow_load_state_spec.rb\`)
- [x] \`bundle exec rubocop\` — 163 files, 0 offenses
- [ ] Manual smoke: workflow that loads a bundle with deliberately expired cookie, watches it rotate (will run before merge)