### PR TITLE
docs(adr): ADR-0013/0014/0015 for v0.10 flows, .bctl, auth_required

### DIFF
--- a/docs/architecture/decisions/0013-flow-dsl.md
+++ b/docs/architecture/decisions/0013-flow-dsl.md
@@ -1,0 +1,103 @@
+# ADR-0013: Flow DSL — Separate Registry, Lifetime, and Stdlib Split
+
+**Date**: 2026-05-09
+**Status**: accepted
+**Extends**: ADR-0005 (Ruby DSL for workflows). Flows are a sibling concept, not a replacement.
+**Deciders**: Patrick
+
+## Context
+
+v0.10 introduces *flows* — small, parameterised, secret-aware sequences whose job is to put the browser into an authenticated (or otherwise gated) state. The need came from three pain points in v0.8/v0.9:
+
+1. Login was duplicated in every workflow that touched a service.
+2. `load_session(name, fallback: "...")` solved the recovery loop but tied recovery to a workflow file the caller had to write and maintain.
+3. There was no shared place for stdlib auth surfaces (TOTP, magic link, Google/GitHub OAuth, Cloudflare).
+
+A flow is just "the smallest replayable thing that produces a usable browser state". Workflows are "the script that does the actual job after that state exists". Treating them as the same primitive would make either too small to be useful or too big to be reusable.
+
+## Decision
+
+Add `Browserctl::Flow` and `Browserctl::FlowRegistry` as a separate first-class concept living next to workflows.
+
+### A separate registry from workflows
+
+`FlowRegistry` and `WorkflowRegistry` are two different stores with two different search paths. A flow is *not* a workflow with a different filename.
+
+Reasons:
+
+- **Different purpose, different signature.** Flows return *state* (cookies + storage + manifest); workflows return *task completion*. Mixing them in one registry would force one signature to dominate.
+- **Different lifetime.** A flow runs to produce a bundle, then exits. A workflow runs the user's script. The auto-rotate path (`load_state` → AUTH_REQUIRED → invoke flow → save → continue) needs a registry it can look up by short name without colliding with a workflow that happens to be named `github_login`.
+- **Different invocation surface.** Flows are invocable from CLI (`browserctl flow run`), from inside workflows (`invoke :flow_name`), and from the daemon's auto-rotate path. Workflows are invoked from CLI and `compose`/`invoke`. Sharing the registry would require disambiguation rules at every call site.
+- **Stdlib only makes sense for flows.** A "stdlib workflow" has no meaning — workflows are user-specific scripts. A "stdlib flow" (TOTP, OAuth) is something every project benefits from.
+
+### Lifetime semantics
+
+A flow's lifetime is bounded by `Flow#run(params)`:
+
+- `precondition` block runs first; raises `FlowPreconditionFailed` to short-circuit before any browser action.
+- `step` blocks run in order; each carries optional `retry_count:` and `timeout:` matching the workflow DSL.
+- `produces_state` block (optional) runs last and tells the daemon what origins were touched during the flow — used as the default `origins[]` in the bundle manifest unless the caller passes `--origins`.
+- `postcondition` block validates the resulting browser state; failure raises `FlowPostconditionFailed`.
+
+There is no per-step state shared across runs. A flow that needs intermediate values uses local variables in its `Flow#run` closure; cross-flow state goes through `state save`/`state load`.
+
+### Stdlib gem-split trigger
+
+Stdlib flows ship in the core `browserctl` gem until **either** of:
+
+1. Flow count exceeds ~10. Six ship in v0.10 (`totp_2fa`, `basic_auth`, `magic_link_email`, `oauth_google`, `oauth_github`, `cloudflare_solve`). Room for ~4 more before the threshold.
+2. A flow needs a heavy optional dependency the core gem should not require (e.g. an IMAP client for email-based magic links beyond the current minimal implementation).
+
+When triggered, stdlib flows move to a new gem `browserctl-flows-stdlib`. The core gem keeps the registry and search-path logic; the stdlib gem only provides flow files. Each stdlib flow declares `min_browserctl_version` in its DSL header so a future split can reject mismatched cores cleanly.
+
+### Versioning runtime check
+
+Each flow declares `version "X.Y.Z"`. When a bundle's manifest names a flow:
+
+- **Patch mismatch** — silently accepted.
+- **Minor mismatch** — warn on stderr, run.
+- **Major mismatch** — refuse; CLI `--force` overrides; no workflow-level override (the auto-rotate path will surface AUTH_REQUIRED instead).
+- **No `flow_version` in manifest** (pre-v0.10 imports) — warn once, accept.
+
+This is a runtime check on the consuming side, not a registry-level filter. A flow at v2.0.0 still loads — the check fires only when paired with an old bundle.
+
+## Alternatives Considered
+
+### One registry, "kind:" tag on each entry
+- **Pros**: Single search path; one `list` command.
+- **Cons**: Forces every call site to filter; defeats the point of the separation.
+- **Why not**: The two kinds have different invocation contracts; merging them creates ambiguity at every lookup.
+
+### Flows as workflows with a `produces_state` flag
+- **Pros**: Reuses the workflow DSL verbatim.
+- **Cons**: Workflows can have multiple steps that return values, share state across `compose`, and persist across invocations. Flows are meant to be small, atomic, and side-effect-on-browser-only. Conflating them would push workflow complexity into stdlib auth files.
+- **Why not**: The two have different shapes. A flow is a function returning state; a workflow is a procedure with side effects.
+
+### Inline flows in workflow files
+- **Pros**: No new file type.
+- **Cons**: No reuse across projects; no stdlib; `state rotate` has nothing to invoke.
+- **Why not**: Reusability across projects (and from the daemon's rotate path) is the whole reason flows exist.
+
+### Ship stdlib as a separate gem from day one
+- **Pros**: Cleaner dependency surface.
+- **Cons**: Six small files don't justify a release pipeline split; users with only `browserctl` installed would have a worse onboarding experience.
+- **Why not**: The split is cheap to do later; doing it early is a sunk cost on every release.
+
+## Consequences
+
+### Positive
+
+- Auto-rotate (`load_state` → AUTH_REQUIRED → invoke bound flow) has a clean lookup target.
+- Stdlib auth surfaces are shared across projects without copying.
+- `flow run` works as a standalone CLI verb for one-off authenticated sessions, independent of any workflow.
+- Versioning at the flow level (not the gem level) lets users pin a specific flow without pinning browserctl.
+
+### Negative
+
+- Two registries, two search paths, two `list`/`describe` command pairs. Surface area grows.
+- Flow-vs-workflow distinction is an extra concept newcomers have to learn — addressed by `docs/concepts/flows.md`.
+
+### Risks
+
+- **Boundary erosion**: someone adds branching/state to a flow, turning it into a workflow-with-extra-steps. Mitigated by keeping the DSL deliberately smaller than the workflow DSL (no `compose`, no `store`/`fetch`) and by code review.
+- **Stdlib bitrot**: bundled flows can break when target sites change their login UI. Mitigated by smoke specs per stdlib flow and by versioning — bundles produced with a known-good flow version stay consumable until the user explicitly rotates.

--- a/docs/architecture/decisions/0014-bctl-bundle-format.md
+++ b/docs/architecture/decisions/0014-bctl-bundle-format.md
@@ -1,0 +1,135 @@
+# ADR-0014: `.bctl` Bundle Format — HMAC-then-Encrypt, Manifest, Transports, Origin Scope
+
+**Date**: 2026-05-09
+**Status**: accepted
+**Extends**: ADR-0008 (session persistence). The `.bctl` bundle replaces the v0.8 session zip as the canonical portable format.
+**Deciders**: Patrick
+
+## Context
+
+v0.8/v0.9 stored auth state as a zip of cookies + storage with optional passphrase encryption. Three problems surfaced as flows landed:
+
+1. **No metadata layer.** A zip on disk had no record of which origins it covered, which flow produced it, or when it was made. `state info` had nothing to read.
+2. **All-or-nothing encryption.** A passphrase-protected zip is opaque — you couldn't see what's inside without unlocking it. That made `state list` and `state info` either useless (skip the file) or insecure (decrypt to inspect).
+3. **No transport story.** Moving a session between machines meant `cp`. There was no shared abstraction for `s3://` or `op://`.
+
+v0.10 needs a single file format that carries enough metadata to be inspectable without unlocking, signs payload integrity even when not encrypted, and is movable through pluggable transports.
+
+## Decision
+
+Define `.bctl` — a single-file binary format with a plaintext manifest header, an optional encrypted payload, and a signed footer. Implementation: `lib/browserctl/state/bundle.rb`.
+
+### Wire format
+
+```
+magic:        "BCTL\x00"           5 bytes
+version:      0x01                 1 byte
+flags:        bit 0 = encrypted    1 byte
+reserved:     0x00                 1 byte
+manifest_len:                      4 bytes (big-endian)
+manifest:     JSON bytes           manifest_len bytes (always plaintext)
+payload_len:                       4 bytes (big-endian)
+payload:      see below            payload_len bytes
+footer:       32 bytes
+```
+
+**Plaintext payload** (`flags & 0x01 == 0`):
+- `payload` is JSON bytes for cookies + storage.
+- `footer` is `SHA-256(magic || ... || payload)` — corruption check, not a signature.
+
+**Encrypted payload** (`flags & 0x01 == 1`):
+- `payload = salt(16) || nonce(12) || ciphertext || tag(16)`.
+- Keys derived via `PBKDF2(passphrase, salt, 200_000, SHA-256, 64-byte output)`. First 32 bytes = AES-256-GCM key. Last 32 bytes = HMAC-SHA-256 key.
+- `footer` is `HMAC-SHA-256(hmac_key, magic || ... || payload)`.
+
+### HMAC-then-encrypt (encrypt-then-MAC, more precisely)
+
+The MAC covers the ciphertext, not the plaintext. This is encrypt-then-MAC — the standard composition that prevents an attacker from feeding crafted ciphertext through the AES-GCM path before integrity is verified.
+
+The manifest is part of the MAC input even though it's plaintext. Tampering with the manifest (e.g. swapping a `flow_version`, dropping origins) invalidates the footer, so an attacker cannot rewrite the manifest without the passphrase.
+
+GCM already authenticates the ciphertext under its own tag, so the outer HMAC is technically redundant for the encrypted payload itself. The reason for the outer HMAC: it covers the **manifest + magic + version + flags + payload boundaries**, not just the ciphertext. A bare GCM tag would let someone replace the manifest in a stored bundle without detection.
+
+### Manifest layout
+
+```json
+{
+  "name": "github",
+  "created_at": "2026-05-09T12:30:00Z",
+  "browserctl_version": "0.10.0",
+  "flow": "github_login",
+  "flow_version": "0.1.0",
+  "origins": ["https://github.com", "https://api.github.com"],
+  "expires_hint": "2026-05-16T12:30:00Z"
+}
+```
+
+- `flow` and `flow_version` enable auto-rotate: `load_state` → AUTH_REQUIRED uses `flow` as the `suggested_flow`. `flow_version` drives the runtime version check from ADR-0013.
+- `origins[]` defaults to the navigation chain captured during the producing flow's `produces_state` block. `state save --origins a,b,c` overrides. Inspectable without a passphrase.
+- `expires_hint` is advisory — the truth lives in the cookies' own expiry. Used by `state info` for human-readable summaries.
+
+### Origin scoping default
+
+Origin scope defaults to **auto-detected from the producing flow's navigation chain**. The flow's `produces_state` block records every URL navigated during the run; their origins (scheme + host) become the bundle's `origins[]`.
+
+`state save --origins a,b,c` overrides for the rare case where the flow navigates to an interstitial origin that should not be persisted (e.g. an OAuth provider during `oauth_github`).
+
+`state info <name>` always surfaces the captured origins. There is no separate "did you mean to save these origins?" prompt — the bundle is a record of what happened, with explicit override available.
+
+### Transport interface
+
+`Browserctl::State::Transport` is a registry of URI-scheme-to-transport mappings:
+
+```
+.scheme            String — "file", "s3", "op", ...
+#handles?(uri)     Boolean
+#available?        Boolean — CLI/network preflight
+#read(uri)         binary String
+#write(uri, blob)  nil; raises State::Transport::TransportError on failure
+```
+
+Bare paths with no scheme fall through to `FileTransport`. v0.10 ships `file`, `s3` (via aws CLI), and `op` (via 1Password CLI).
+
+Transports are responsible only for moving bytes — they never inspect or modify the bundle. A passphrase-protected bundle stays passphrase-protected end-to-end; the transport layer has no key material.
+
+## Alternatives Considered
+
+### Keep using zip, add a sidecar `.json` manifest
+- **Pros**: Zero format work; manifest stays inspectable.
+- **Cons**: Two files to keep in sync; encryption applies to one but not the other; no atomicity on copy.
+- **Why not**: Two files for one logical artefact is a UX regression — `state export github /tmp/x` should produce one file.
+
+### Encrypt-the-whole-thing, no plaintext header
+- **Pros**: Maximum confidentiality.
+- **Cons**: `state list`/`state info` need the passphrase to show anything — defeats their purpose.
+- **Why not**: The cost of plaintext metadata is small (origins and timestamps are not secrets); the ergonomic win is large.
+
+### MAC-then-encrypt
+- **Pros**: Slightly stronger when AES-GCM is replaced.
+- **Cons**: Forces decryption before integrity verification, opening up oracle attacks; standard composition order is encrypt-then-MAC.
+- **Why not**: Cryptographic best practice favours encrypt-then-MAC.
+
+### Origin scope = "all origins from cookies"
+- **Pros**: No flow instrumentation needed.
+- **Cons**: Cookies leak — third-party trackers, analytics, CDN cookies — none of which the user actually wants in their bundle. Result: noisy bundles.
+- **Why not**: Auto-detected nav chain is a tighter, more semantic boundary.
+
+## Consequences
+
+### Positive
+
+- One file, one format, one extension (`.bctl`).
+- `state info` works without a passphrase.
+- Bundle integrity is signed even in plaintext mode (corruption check) and authenticated in encrypted mode (HMAC).
+- New transports (e.g. `gs://`, `azure://`) plug in without touching the bundle codec.
+- Auto-rotate has everything it needs in the manifest — no separate "which flow produced this?" lookup.
+
+### Negative
+
+- New on-disk format means the existing v0.8 session zip is not interchangeable. There is no auto-migration script; users re-create bundles via `state save`. The old `session export`/`session import` commands continue to work for the v0.8 zip format through v0.10 with a deprecation warning.
+- Manifest is plaintext, so origin lists and timestamps leak in transit. Acceptable: those are not secrets.
+
+### Risks
+
+- **PBKDF2 iteration count drift**. 200,000 is chosen for 2026-era hardware; a future ADR will revisit if the OWASP recommendation changes. Encoded inside `version: 0x01`, so a future bundle format can change derivation without breaking old readers.
+- **Manifest schema growth**. Anything added to the manifest is plaintext forever (no way to encrypt it without breaking `state info`). Future fields must be reviewed for sensitivity.

--- a/docs/architecture/decisions/0015-auth-required-detection.md
+++ b/docs/architecture/decisions/0015-auth-required-detection.md
@@ -1,0 +1,106 @@
+# ADR-0015: `auth_required` Detection — Signals, False Positives, Pluggability
+
+**Date**: 2026-05-09
+**Status**: accepted
+**Extends**: ADR-0009 (uniform error shape — AUTH_REQUIRED is a structured code, not a free-form error). Sits next to the existing `Detectors.cloudflare?` from v0.8.
+**Deciders**: Patrick
+
+## Context
+
+v0.10's auto-rotate loop (`load_state` → AUTH_REQUIRED → invoke flow → save → continue) needs a reliable signal that the current page is no longer authenticated. The signal has to fire in two places:
+
+1. **Server-side**, during `state load`, before applying cookies. The daemon decides whether to short-circuit with AUTH_REQUIRED based on the bundle's payload (cookies + manifest), without navigating.
+2. **Client-side**, after a workflow has navigated, to catch sessions that look valid on disk but are invalidated by the server (server-side logout, JWT expiry).
+
+A single detector callable from both contexts is required.
+
+## Decision
+
+`Browserctl::Detectors::AuthRequired` — a pure module returning a structured `Result`. Three independent signals, evaluated in order, first hit wins.
+
+### Three signals
+
+1. **URL → login path.** Page is currently sitting on `/login`, `/signin`, `/sign-in`, `/auth/login`, `/auth/signin`, or `/account/login`. Catches redirect-based "you're not logged in" responses. Regex matches the canonical paths most apps use.
+2. **Recent HTTP 401/403.** The most recent network response on the current page is an auth challenge from the backend. Caller supplies recent responses from page traffic instrumentation; empty list skips this check (callers without traffic capture still get URL + cookie checks).
+3. **Cookie ledger.** A caller-supplied list of `{ name:, expires: }` contains entries that are already expired. Used by the daemon's `state load` preflight against the bundle's payload cookies — the only signal that fires before navigation.
+
+Each check is pure. No daemon dependencies. The same module runs server-side (`handlers/state.rb` preflight) and client-side (`workflow.rb` `load_state` hook).
+
+### Result shape
+
+```ruby
+Result.new(
+  triggered:      Boolean,
+  code:           "AUTH_REQUIRED" | nil,
+  reason:         "url_login_path" | "http_401_403" | "cookie_expired" | nil,
+  suggested_flow: String | nil
+)
+```
+
+Negative results carry `triggered: false`; positive results carry the discriminator and optional `suggested_flow` populated from the bundle manifest. The shape mirrors `Detectors.cloudflare?` so callers can swap detectors without restructuring the response handling.
+
+### Pluggability
+
+`Browserctl::Detectors` is a module namespace, not a registry. New detectors register by adding a module function — same pattern as `cloudflare?`. The auto-rotate path explicitly calls `Detectors::AuthRequired.detect(...)` rather than iterating over registered detectors, because:
+
+- The auto-rotate handler needs to know the **specific signal** (AUTH_REQUIRED vs cloudflare vs custom), so a single "is anything wrong?" iterator would lose information.
+- Detectors have different signatures: `cloudflare?` needs the page; `auth_required` also needs cookies and recent responses. Forcing a uniform signature would push optionality into every detector.
+- Order matters: cloudflare must be detected *before* auth_required (a cloudflare interstitial often redirects to a login-looking URL). The handler enforces this order explicitly.
+
+For third-party detectors, the recommended path is the same as third-party secret resolvers — register in `~/.browserctl/detectors.rb`, add a check call in the handler. We are **not** introducing a "detector chain" abstraction in v0.10 because there are only two detectors and the order/signature differences argue against premature uniformity. ADR revisit when the third detector lands.
+
+### False-positive handling
+
+The three signals each have a known false-positive class:
+
+| Signal | False positive | Mitigation |
+|---|---|---|
+| URL login path | Marketing pages at `/login` (e.g. a sign-up flow that doesn't require auth to view) | Cookie expiry check runs in parallel — bundles with valid cookies won't trigger auto-rotate even if URL matches. The detector still fires (correctly) on the URL, but auto-rotate is gated on the broader workflow context. |
+| HTTP 401/403 | API endpoints that intentionally return 403 for unauthorised actions on a fully-authenticated session | `recent_responses` is supplied by the caller — workflow authors who don't want this signal omit it. Auto-rotate uses it only for the page's primary navigation response. |
+| Cookie expiry | Session cookie still valid, but a tracking cookie expired | Caller filters to *session-relevant* cookies before passing them in. The `state load` preflight uses the bundle's manifest cookies, which are already scoped to the producing flow's origins. |
+
+False negatives are accepted as the cheaper failure mode: if AUTH_REQUIRED doesn't fire when it should, the workflow proceeds and fails on its own assertions, which the user can see and react to. A false positive that triggers an auto-rotate is more expensive — it runs a flow unnecessarily, possibly prompting for a 2FA code.
+
+The detector defaults to **conservative**: each individual check is tightly scoped, and signals combine via OR but the auto-rotate path only fires when both (a) the bundle has a bound flow and (b) the detector triggers. Bundles with no `flow` in the manifest never auto-rotate even if the detector would have fired.
+
+## Alternatives Considered
+
+### Single regex over the page HTML
+- **Pros**: One signal, one check.
+- **Cons**: HTML is the noisiest, most brittle surface. Login forms differ wildly. Requires DOM access on every navigate.
+- **Why not**: URL + HTTP status + cookie expiry are all cheap and structured; HTML scraping is the last resort.
+
+### Detector chain abstraction
+- **Pros**: Symmetric registration; future-proof.
+- **Cons**: Two detectors with different signatures; the chain would have to either accept a union of all signatures or force the lowest common denominator.
+- **Why not**: Premature abstraction. Revisit when the third detector lands.
+
+### Server-side only
+- **Pros**: Single call site.
+- **Cons**: Server-side `state load` preflight only sees the bundle, not the live page. Server-side logout (cookies still present, but server-revoked) goes undetected.
+- **Why not**: Need both call sites for the auto-rotate guarantee.
+
+### Client-side only (in-workflow)
+- **Pros**: Simpler daemon.
+- **Cons**: Every workflow author has to invoke the detector manually; the `load_state` ergonomic win disappears.
+- **Why not**: The whole point of v0.10 auto-rotate is that the loop is invisible to workflow authors.
+
+## Consequences
+
+### Positive
+
+- One module, two call sites, structured `Result` everywhere.
+- Auto-rotate has a clean preflight that runs before any navigation, so an expired bundle doesn't even apply its cookies.
+- New auth-related signals slot in without restructuring (add a `check_*` method, OR it into `detect`).
+- `AUTH_REQUIRED` exit code 7 + `suggested_flow` give CLI-only callers (Claude agents, shell scripts) the same recovery path as in-process workflows.
+
+### Negative
+
+- Three signals means three places to keep tuned. Login-path regex is the most likely source of drift; smoke specs cover the canonical six (`/login`, `/signin`, `/sign-in`, `/auth/login`, `/auth/signin`, `/account/login`).
+- Order-dependence with `cloudflare?` is implicit (handler-enforced), not enforced by the detector module itself.
+
+### Risks
+
+- **Sites with custom login URLs** (e.g. `/access`, `/portal`) will not trigger the URL signal. Cookie-expiry and HTTP signals should still fire; if they don't, the workflow fails on its own assertions and the user can add a custom detector.
+- **HTTP 401 response on `/api/health`** (non-load-bearing endpoint) could trigger AUTH_REQUIRED on the wrong page. Mitigation: callers feed only the page's primary navigation responses, not every XHR.
+- **Detector module growth**: as we add `paywall_required`, `rate_limited`, etc., the order-dependence problem from this ADR will become a real chain abstraction problem. Tracked as future work.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -13,3 +13,7 @@
 | [0009](0009-error-handling-strategy.md) | Uniform JSON-RPC error format with per-thread isolation | accepted | 2026-05-01 |
 | [0010](0010-concurrency-model.md) | Thread-per-client with layered mutexes | accepted | 2026-05-01 |
 | [0011](0011-screenshot-format.md) | PNG default for screenshots with path-scoped safety | accepted | 2026-05-01 |
+| [0012](0012-browser-agnostic-driver.md) | Browser-agnostic driver layer | accepted | 2026-05-02 |
+| [0013](0013-flow-dsl.md) | Flow DSL — separate registry, lifetime, stdlib split | accepted | 2026-05-09 |
+| [0014](0014-bctl-bundle-format.md) | `.bctl` bundle format — HMAC, manifest, transports, origin scope | accepted | 2026-05-09 |
+| [0015](0015-auth-required-detection.md) | `auth_required` detection — signals, false positives, pluggability | accepted | 2026-05-09 |


### PR DESCRIPTION
## Summary

Records the three architectural decisions called out in `docs/plans/v0.10-flows.md`:

- **ADR-0013** — Flow DSL: separate registry from workflows; lifetime semantics; stdlib gem-split trigger (~10 flows or first heavy optional dep).
- **ADR-0014** — `.bctl` bundle format: encrypt-then-MAC, plaintext manifest (so `state info` works without a passphrase), transport interface, origin scope = nav chain captured during `produces_state` with `--origins` override.
- **ADR-0015** — `auth_required` detection: three signals (URL login path, recent 401/403, expired cookies), false-positive analysis, no detector-chain abstraction yet.

Updates `docs/architecture/decisions/README.md` index (also backfills the missing 0012 row).

## Test plan
- [x] No code changes — docs only.
- [ ] Eyeballed for drift against `lib/browserctl/flow.rb`, `lib/browserctl/state/bundle.rb`, `lib/browserctl/detectors/auth_required.rb` while writing.