### PR TITLE
docs(skill): automate skill — flows, state, AUTH_REQUIRED loop (WS-6)

### DIFF
--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -316,9 +316,13 @@ module Browserctl
            flow_version: flow_version, passphrase: passphrase)
     end
 
-    # Restores a .bctl bundle into the running daemon.
-    def state_load(name, passphrase: nil)
-      call("state_load", name: name, passphrase: passphrase)
+    # Restores a .bctl bundle into the running daemon. The daemon runs the
+    # auth_required detector against the bundle's cookies before applying;
+    # callers that have already verified the bundle (e.g. workflow
+    # `load_state` after a successful rotate) can pass `skip_auth_check: true`
+    # to bypass it.
+    def state_load(name, passphrase: nil, skip_auth_check: false)
+      call("state_load", name: name, passphrase: passphrase, skip_auth_check: skip_auth_check)
     end
 
     # Lists all stored state bundles (manifest only — no payload decryption).

--- a/lib/browserctl/server/handlers/state.rb
+++ b/lib/browserctl/server/handlers/state.rb
@@ -42,6 +42,21 @@ module Browserctl
           return { error: "no open pages — open a page before loading state" } unless target
 
           cookies = pluck(data[:payload], :cookies, default: [])
+
+          unless req[:skip_auth_check]
+            auth = Browserctl::Detectors.auth_required(
+              target.page, cookies: cookies, suggested_flow: data[:manifest][:flow]
+            )
+            if auth.triggered
+              return Browserctl::AuthRequiredError.new(
+                auth.reason,
+                state: req[:name],
+                suggested_flow: auth.suggested_flow,
+                reason: auth.reason
+              ).to_response
+            end
+          end
+
           restore_state_cookies(target, cookies)
           ls_count = restore_local_storage(pluck(data[:payload], :local_storage, default: {}))
 

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -69,7 +69,39 @@ module Browserctl
       res
     end
 
+    # Persists the daemon's current cookies + storage as a .bctl bundle.
+    # Optional flow binding lets `load_state` auto-rotate when the bundle
+    # is detected as needing authentication.
+    def save_state(name, flow: nil, origins: nil, encrypt: false)
+      passphrase = encrypt ? ENV.fetch("BROWSERCTL_STATE_PASSPHRASE", nil) : nil
+      res = @client.state_save(name.to_s,
+                               flow: flow&.to_s, origins: origins, passphrase: passphrase)
+      raise WorkflowError, res[:error] if res[:error]
+
+      res
+    end
+
+    # Restores a .bctl bundle. When the daemon detects AUTH_REQUIRED before
+    # applying (e.g. expired cookies in the payload), this rotates the bound
+    # flow and retries — no caller code change required.
+    #
+    # @param on_auth_required [Proc, nil] override the auto-rotate path. The
+    #   block runs in the workflow context, in lieu of invoking the manifest's
+    #   bound flow. Use this when the recovery procedure is bespoke.
+    def load_state(name, on_auth_required: nil)
+      res = @client.state_load(name.to_s)
+      return res unless auth_required_response?(res)
+
+      recover_auth_required_state(name.to_s, res, on_auth_required)
+    end
+    DEPRECATED_LOAD_SESSION_FALLBACK = <<~MSG
+      [browserctl] DEPRECATION: `load_session(name, fallback:, expired_if:)` is superseded by
+      `load_state(name)` with a flow-bound bundle (`save_state(name, flow: :name)`).
+      `load_session` will be removed in v0.12. See docs/concepts/state.md.
+    MSG
+
     def load_session(session_name, fallback: nil, expired_if: nil)
+      warn DEPRECATED_LOAD_SESSION_FALLBACK if fallback || expired_if
       validate_expired_if!(expired_if)
       fallback_name = fallback&.to_s
       res = @client.session_load(session_name)
@@ -118,6 +150,33 @@ module Browserctl
     end
 
     private
+
+    def auth_required_response?(res)
+      (res[:code] || res["code"]) == "AUTH_REQUIRED"
+    end
+
+    def recover_auth_required_state(name, initial_res, on_auth_required)
+      if on_auth_required
+        on_auth_required.call
+      else
+        flow_name = initial_res[:suggested_flow] || initial_res["suggested_flow"]
+        unless flow_name && !flow_name.to_s.empty?
+          raise WorkflowError,
+                "state '#{name}' needs auth but bundle has no bound flow — " \
+                "save with `save_state('#{name}', flow: :NAME)` or pass on_auth_required:"
+        end
+
+        invoke(flow_name)
+      end
+
+      after_save = @client.state_save(name)
+      raise WorkflowError, after_save[:error] if after_save[:error]
+
+      retry_res = @client.state_load(name, skip_auth_check: true)
+      raise WorkflowError, retry_res[:error] if retry_res[:error]
+
+      retry_res.merge(rotated: true)
+    end
 
     def validate_expired_if!(expired_if)
       return unless expired_if

--- a/skills/automate/SKILL.md
+++ b/skills/automate/SKILL.md
@@ -110,14 +110,33 @@ browserctl resume login                    # resume automation after human actio
 # DevTools
 browserctl devtools login          # open Chrome DevTools URL for a named page
 
-# Cookies
+# Flows (v0.10) — small, replayable auth surfaces. Prefer over hand-coded login.
+browserctl flow list                                              # list registered flows (stdlib + project)
+browserctl flow describe github_login                             # show params, preconditions, steps
+browserctl flow run github_login --page work --username pat       # run against a named page; secret_ref params resolve at runtime
+
+# State (v0.10) — single verb for "log in once, reuse later". Replaces session/cookie/storage as the recommended path.
+browserctl state save   github --flow github_login                # snapshot cookies+storage, bind producing flow into the manifest
+browserctl state save   github --encrypt                          # passphrase-protected at rest (AES-256-GCM)
+browserctl state save   github --origins github.com,api.github.com # override auto-detected nav-chain origins
+browserctl state load   github                                    # restore into running daemon; auto-rotates if AUTH_REQUIRED
+browserctl state list                                             # show all bundles + origin/flow/age
+browserctl state info   github                                    # manifest: origins, flow, flow_version, expiry hint
+browserctl state rotate github                                    # invoke the bound flow + re-save (manual refresh)
+browserctl state delete github
+browserctl state export github /tmp/github.bctl                   # file path
+browserctl state export github s3://bucket/key.bctl               # via aws CLI
+browserctl state export github op://Vault/github-state            # via 1Password CLI
+browserctl state import /tmp/github.bctl
+
+# Cookies (low-level escape hatch — prefer `state` for auth)
 browserctl cookie list   login                                                  # list all cookies as JSON
 browserctl cookie set    login cf_clearance "xyz..." --domain ".example.com"   # set a cookie
 browserctl cookie delete login                                                  # clear all cookies
 browserctl cookie export login .browserctl/sessions/app.json                   # export to file
 browserctl cookie import login .browserctl/sessions/app.json                   # import from file
 
-# Storage (localStorage / sessionStorage)
+# Storage (localStorage / sessionStorage — low-level escape hatch; prefer `state` for auth)
 browserctl storage get    login cart_id                                         # read a key (default: localStorage)
 browserctl storage get    login cart_id --store session                         # read from sessionStorage
 browserctl storage set    login cart_id "abc123"                                # write a key
@@ -127,7 +146,7 @@ browserctl storage import login .browserctl/storage.json                        
 browserctl storage delete login                                                  # clear all storage
 browserctl storage delete login --store session                                  # clear sessionStorage only
 
-# Session (save/restore full browser state: pages + cookies + localStorage)
+# Session (legacy — kept for v0.8/v0.9 callers; new code should use `state`)
 browserctl session save   myapp                          # snapshot current state (plaintext, 0o600)
 browserctl session save   myapp --encrypt                # AES-256-GCM at rest, key in macOS Keychain
 browserctl session load   myapp                          # restore into running daemon
@@ -312,6 +331,80 @@ browserctl navigate main https://protected.example.com
 
 > Switching browsers (Brave, Chromium) does **not** bypass Cloudflare Turnstile. The CDP attach itself is detected as automation regardless of the Chromium flavour. The reliable path is HITL solve once → capture `cf_clearance` → replay.
 
+## Flows and state — the auth recovery loop (v0.10)
+
+If a task needs an authenticated browser, **use a flow + state bundle** instead of hand-coding login steps. A flow is a small, replayable sequence that produces an authenticated state; a state bundle (`.bctl`) is the saved cookies+storage with a manifest binding it to its producing flow.
+
+The recovery loop the daemon runs for you:
+
+```
+load_state → cookies still valid? ─yes→ continue
+                       │
+                       no
+                       ▼
+            run bound flow (from manifest) → save fresh bundle → continue
+```
+
+`load_state` returns `{rotated: true}` when this happened. No caller-side detect-expiry logic required.
+
+The CLI surfaces the same loop via **exit code 7** = `AUTH_REQUIRED`. When you see exit 7 from any command, the JSON response carries `{code: "AUTH_REQUIRED", state: "<name>", suggested_flow: "<name>"}` — run that flow, retry the original command.
+
+### Example 1 — Workflow with auto-rotate (preferred path)
+
+```ruby
+# .browserctl/workflows/check_inbox.rb
+Browserctl.workflow "check_inbox" do
+  step "load auth" do
+    open_page(:work, url: "https://github.com")
+    load_state(:github)              # transparently rotates if expired
+  end
+  step "do work" do
+    page(:work).navigate("https://github.com/notifications")
+    page(:work).wait("[data-testid=notifications-list]")
+  end
+end
+```
+
+First run: `browserctl flow run github_login --username pat --state-name github` to produce the bundle. After that, `workflow run check_inbox` re-authenticates automatically when cookies expire. No `fallback:` parameter needed — the manifest carries the binding.
+
+### Example 2 — CLI loop with exit code 7
+
+```sh
+#!/usr/bin/env bash
+set -e
+attempt() { browserctl state load github && browserctl navigate work https://github.com/notifications; }
+if ! attempt; then
+  if [ "$?" -eq 7 ]; then
+    browserctl flow run github_login --state-name github   # bundle is refreshed
+    attempt
+  else
+    exit $?
+  fi
+fi
+```
+
+Use this shape when driving browserctl from a shell script or CI job.
+
+### Example 3 — Explicit override with `on_auth_required`
+
+```ruby
+Browserctl.workflow "check_dashboard" do
+  step "load auth" do
+    open_page(:app, url: "https://app.example.com")
+    load_state(:app, on_auth_required: -> {
+      # Replace the default "invoke the bound flow" path — e.g. for a custom
+      # 2FA prompt, ad-hoc HITL pause, or branching across SSO providers.
+      ask("MFA code: ").tap { |code| invoke "company_sso_login", mfa: code }
+    })
+  end
+  step "do work" do
+    page(:app).wait("[data-test=dashboard]")
+  end
+end
+```
+
+Use when the default "invoke the bound flow" doesn't fit — the lambda runs in place of the flow, then the daemon re-saves the bundle.
+
 ## Rules
 
 - **Probe before you harden** — explore with discrete commands or a throwaway file, then write the named workflow.
@@ -328,9 +421,12 @@ browserctl navigate main https://protected.example.com
 - **Use `ask`** when automation needs a human-supplied value (2FA code, CAPTCHA answer, confirmation) but doesn't need to hand over full browser control. Cleaner than `pause` for value injection.
 - **Use `pause`/`resume`** when a human must act mid-automation (e.g. solving a CAPTCHA, MFA). Poll `snap` after resume to confirm the blocker is cleared.
 - **Capture `cf_clearance` after solving** a Cloudflare challenge — store and replay it with `cookie set` to avoid re-solving in future sessions.
-- **Use `session save/load`** to persist the full browser state across daemon restarts — saves cookies, localStorage, and open page URLs. Load it on a fresh daemon to skip login entirely.
+- **Use `flow run` over hand-coded login** (v0.10) — for any auth-gated task, prefer a registered flow (`browserctl flow list` to see what's available; `flow describe <name>` for params). Stdlib ships `totp_2fa`, `basic_auth`, `magic_link_email`, `oauth_google`, `oauth_github`, `cloudflare_solve`.
+- **Use `state save/load` to persist auth across runs** (v0.10) — `state save <name> --flow <flow>` snapshots cookies+storage and binds the producing flow into the manifest; `state load <name>` restores and auto-rotates via the bound flow when cookies expired. Replaces ad-hoc cookie/storage juggling for auth.
+- **Exit code 7 means re-auth** — any CLI command exiting 7 returned `AUTH_REQUIRED` with a `suggested_flow`. Run that flow, retry the command. From inside a workflow, `load_state` handles this loop transparently.
 - **Use `secret_ref:` for credentials** — `param :password, secret_ref: "op://vault/item/field"` resolves the value from your keychain or secret manager at runtime. Never pass credentials as CLI flags or hardcode them in workflow files. `secret_ref:` always implies `secret: true`.
-- **Use `load_session` with `fallback:`** instead of hand-rolling expiry detection — `load_session("myapp", fallback: "login_myapp")` handles the detect-expiry → re-login → retry cycle automatically.
+- **Use `session save/load`** for v0.8/v0.9 callers only — new code should use `state save/load`. The session zip format remains readable through v0.10 with a deprecation warning.
+- **`load_session(fallback:, expired_if:)` is deprecated** — the recovery loop now lives in `load_state`. Existing usages still work through v0.10 but emit a stderr DEPRECATION warning; migrate to `save_state(name, flow: :name)` + `load_state(name)`.
 - **Save stable sequences as workflows** — ask the user first, then write the `.rb` file. Use `browserctl record` to capture a live session automatically.
 
 ## Recording and refs
@@ -380,10 +476,12 @@ end
 | `open_page(name, url: nil)` | Open a named page, optionally navigating to a URL |
 | `close_page(name)` | Close a named page |
 | `page(:name)` | Return a `PageProxy` for the named page |
-| `save_session(name, encrypt: false)` | Snapshot current browser state to a named session; `encrypt: true` stores sensitive files as AES-256-GCM blobs with the key in macOS Keychain (darwin only) |
-| `load_session(name)` | Restore a saved session into the running daemon |
-| `load_session(name, fallback: "workflow_name")` | Restore session; if load fails, invoke the named fallback workflow then retry once. Use this instead of hand-rolling detect-expiry logic. |
-| `load_session(name, fallback: "workflow_name", expired_if: -> { ... })` | Same as above, but also calls the lambda after restore; if it returns `true`, the fallback workflow is invoked and the session is re-established. Use when the server can invalidate sessions without changing cookies (e.g. server-side logout, expired JWT in localStorage). |
+| `save_state(name, flow: :name, origins: nil, encrypt: false)` | (v0.10) Save cookies+storage as a `.bctl` bundle and bind the producing flow into the manifest so future `load_state` calls can auto-rotate. `origins:` overrides the auto-detected nav-chain origins. |
+| `load_state(name)` | (v0.10) Restore a `.bctl` bundle. If the daemon detects AUTH_REQUIRED, it invokes the manifest's bound flow, re-saves, and continues. Returns `{rotated: true}` when this happened. |
+| `load_state(name, on_auth_required: -> { ... })` | (v0.10) Same as above, but the lambda runs in place of the bound flow when AUTH_REQUIRED fires. Use for custom MFA prompts, branching SSO, or HITL pauses. |
+| `save_session(name, encrypt: false)` | (legacy, v0.8) Snapshot to the old session-zip format; prefer `save_state`. |
+| `load_session(name)` | (legacy, v0.8) Restore a session zip; prefer `load_state`. |
+| `load_session(name, fallback:, expired_if:)` | **Deprecated in v0.10** — use `load_state` with a flow-bound bundle. Removal in v0.12. Emits stderr deprecation warning when `fallback:` or `expired_if:` is passed. |
 | `list_sessions` | Return all saved session metadata |
 | `store :key, value` | Store a value for use in later steps (persists in daemon until it stops) |
 | `fetch :key` | Retrieve a value stored by an earlier step |

--- a/spec/unit/workflow_load_state_spec.rb
+++ b/spec/unit/workflow_load_state_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/workflow"
+
+RSpec.describe "WorkflowContext#load_state" do
+  let(:client) { instance_double(Browserctl::Client) }
+  let(:ctx)    { Browserctl::WorkflowContext.new({}, client) }
+
+  it "returns the load result when the bundle is fresh" do
+    allow(client).to receive(:state_load).with("github").and_return(ok: true, cookies: 4)
+    expect(ctx.load_state("github")).to eq(ok: true, cookies: 4)
+  end
+
+  it "auto-rotates via the bundle's bound flow when AUTH_REQUIRED is returned" do
+    auth_response = {
+      error: "expired cookies",
+      code: "AUTH_REQUIRED",
+      state: "github",
+      suggested_flow: "github_login"
+    }
+    fresh_response = { ok: true, cookies: 4 }
+
+    allow(client).to receive(:state_load).with("github").and_return(auth_response)
+    allow(client).to receive(:state_load).with("github", skip_auth_check: true).and_return(fresh_response)
+    allow(client).to receive(:state_save).with("github").and_return(ok: true)
+    allow(ctx).to receive(:invoke).with("github_login")
+
+    result = ctx.load_state("github")
+
+    expect(ctx).to have_received(:invoke).with("github_login")
+    expect(client).to have_received(:state_save).with("github")
+    expect(result).to include(rotated: true, ok: true, cookies: 4)
+  end
+
+  it "honours an explicit on_auth_required: hook over the auto path" do
+    auth_response = { error: "expired", code: "AUTH_REQUIRED", suggested_flow: "ignored_flow" }
+    allow(client).to receive(:state_load).with("github").and_return(auth_response)
+    allow(client).to receive(:state_load).with("github", skip_auth_check: true).and_return(ok: true)
+    allow(client).to receive(:state_save).with("github").and_return(ok: true)
+    allow(ctx).to receive(:invoke)
+
+    custom_ran = false
+    ctx.load_state("github", on_auth_required: -> { custom_ran = true })
+
+    expect(custom_ran).to be(true)
+    expect(ctx).not_to have_received(:invoke)
+  end
+
+  it "raises a WorkflowError when AUTH_REQUIRED hits and no flow is bound" do
+    allow(client).to receive(:state_load).with("github")
+                                         .and_return(error: "expired", code: "AUTH_REQUIRED")
+    expect { ctx.load_state("github") }
+      .to raise_error(Browserctl::WorkflowError, /no bound flow/)
+  end
+
+  it "raises when the rotated flow still fails the auth check" do
+    allow(client).to receive(:state_load).with("github")
+                                         .and_return(error: "expired", code: "AUTH_REQUIRED",
+                                                     suggested_flow: "github_login")
+    allow(client).to receive(:state_save).with("github").and_return(ok: true)
+    allow(client).to receive(:state_load).with("github", skip_auth_check: true)
+                                         .and_return(error: "still bad")
+    allow(ctx).to receive(:invoke).with("github_login")
+
+    expect { ctx.load_state("github") }
+      .to raise_error(Browserctl::WorkflowError, /still bad/)
+  end
+end
+
+RSpec.describe "WorkflowContext#save_state" do
+  let(:client) { instance_double(Browserctl::Client) }
+  let(:ctx)    { Browserctl::WorkflowContext.new({}, client) }
+
+  it "calls state_save with the flow binding" do
+    expect(client).to receive(:state_save).with("github", flow: "github_login",
+                                                          origins: nil, passphrase: nil)
+                                          .and_return(ok: true)
+    ctx.save_state("github", flow: :github_login)
+  end
+
+  it "raises when the daemon returns an error" do
+    allow(client).to receive(:state_save).and_return(error: "not allowed")
+    expect { ctx.save_state("github") }.to raise_error(Browserctl::WorkflowError, "not allowed")
+  end
+end
+
+RSpec.describe "WorkflowContext#load_session deprecation" do
+  let(:client) { instance_double(Browserctl::Client) }
+  let(:ctx)    { Browserctl::WorkflowContext.new({}, client) }
+
+  it "warns when fallback: is used" do
+    allow(client).to receive(:session_load).with("my-session").and_return(ok: true)
+    expect { ctx.load_session("my-session", fallback: :setup) }
+      .to output(/DEPRECATION.*load_state/m).to_stderr
+  end
+
+  it "does not warn when called without fallback / expired_if" do
+    allow(client).to receive(:session_load).with("my-session").and_return(ok: true)
+    expect { ctx.load_session("my-session") }.not_to output(/DEPRECATION/).to_stderr
+  end
+end


### PR DESCRIPTION
## Summary

WS-6 (PRs 19+20) of [v0.10 flows plan](docs/plans/v0.10-flows.md). Updates the \`automate\` skill so AI agents drive the new flows / state / auth-recovery surface without manual coaching.

## Changes

- **Commands surface**: adds \`flow run/list/describe\` and \`state save/load/list/info/rotate/export/import\`; marks \`cookie\` / \`storage\` / \`session\` as escape hatches / legacy.
- **New section "Flows and state — the auth recovery loop"** with three examples:
  1. Workflow with \`load_state\` auto-rotate (preferred path).
  2. CLI loop reacting to exit code 7 = AUTH_REQUIRED.
  3. \`on_auth_required: ->\` override for custom MFA / branching SSO.
- **DSL reference table**: rows for \`save_state\` and \`load_state\`; \`load_session(fallback:, expired_if:)\` marked deprecated.
- **Rules**: "prefer flow run over hand-coded login"; "exit code 7 means re-auth"; deprecation note for \`load_session\`.

## Test plan
- [x] No code changes — skill markdown only.
- [ ] Manual: spin up a fresh Claude Code session with browserctl installed, hand it an expired GitHub cookie, verify it recovers via \`flow run\` without coaching (acceptance criterion for WS-6).