### PR TITLE
fix: pass first open page to flow during load_state auto-rotate

### DIFF
--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -97,6 +97,8 @@ browserctl state save github --flow github_login
 
 Then `state rotate github` re-runs the bound flow and overwrites the bundle. WS-5 of v0.10 wires `load_state :github` in workflows to call `state rotate` automatically when the daemon detects an expired bundle, so most code never needs to think about rotation explicitly.
 
+When the auto-rotate path invokes the bound flow, the flow receives the workflow's first open page as its `page` proxy — same convention the daemon's preflight uses for the auth check. That means stdlib flows that read `page.url` or call `page.fill` work the same whether you `flow run` them by hand or let `load_state` invoke them. To override the target page (e.g. a flow that should run against a dedicated `:auth` tab), pass `on_auth_required: -> { invoke :my_flow, page: :auth }` to `load_state`.
+
 ---
 
 ## Stdlib flows

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -166,7 +166,13 @@ module Browserctl
                 "save with `save_state('#{name}', flow: :NAME)` or pass on_auth_required:"
         end
 
-        invoke(flow_name)
+        # Match the daemon's `state load` preflight: it auth-checks the first
+        # open page (insertion order). Passing that same name to the flow
+        # gives stdlib flows a `page` proxy to drive (oauth_github reads
+        # `page.url`, totp_2fa calls `page.fill`, etc.). Falls back to no
+        # page only when nothing is open — `state_save` would have errored
+        # earlier in that case, so this is a defence-in-depth nil.
+        invoke(flow_name, page: first_open_page)
       end
 
       after_save = @client.state_save(name)
@@ -176,6 +182,12 @@ module Browserctl
       raise WorkflowError, retry_res[:error] if retry_res[:error]
 
       retry_res.merge(rotated: true)
+    end
+
+    def first_open_page
+      res = @client.page_list
+      pages = res[:pages] || res["pages"] || []
+      pages.first
     end
 
     def validate_expired_if!(expired_if)

--- a/spec/unit/workflow_load_state_spec.rb
+++ b/spec/unit/workflow_load_state_spec.rb
@@ -24,13 +24,27 @@ RSpec.describe "WorkflowContext#load_state" do
     allow(client).to receive(:state_load).with("github").and_return(auth_response)
     allow(client).to receive(:state_load).with("github", skip_auth_check: true).and_return(fresh_response)
     allow(client).to receive(:state_save).with("github").and_return(ok: true)
-    allow(ctx).to receive(:invoke).with("github_login")
+    allow(client).to receive(:page_list).and_return(pages: ["work"])
+    allow(ctx).to receive(:invoke).with("github_login", page: "work")
 
     result = ctx.load_state("github")
 
-    expect(ctx).to have_received(:invoke).with("github_login")
+    expect(ctx).to have_received(:invoke).with("github_login", page: "work")
     expect(client).to have_received(:state_save).with("github")
     expect(result).to include(rotated: true, ok: true, cookies: 4)
+  end
+
+  it "passes page: nil to the flow when no pages are open (defence-in-depth)" do
+    auth_response = { error: "expired", code: "AUTH_REQUIRED", suggested_flow: "github_login" }
+    allow(client).to receive(:state_load).with("github").and_return(auth_response)
+    allow(client).to receive(:state_load).with("github", skip_auth_check: true).and_return(ok: true)
+    allow(client).to receive(:state_save).with("github").and_return(ok: true)
+    allow(client).to receive(:page_list).and_return(pages: [])
+    allow(ctx).to receive(:invoke).with("github_login", page: nil)
+
+    ctx.load_state("github")
+
+    expect(ctx).to have_received(:invoke).with("github_login", page: nil)
   end
 
   it "honours an explicit on_auth_required: hook over the auto path" do
@@ -61,7 +75,8 @@ RSpec.describe "WorkflowContext#load_state" do
     allow(client).to receive(:state_save).with("github").and_return(ok: true)
     allow(client).to receive(:state_load).with("github", skip_auth_check: true)
                                          .and_return(error: "still bad")
-    allow(ctx).to receive(:invoke).with("github_login")
+    allow(client).to receive(:page_list).and_return(pages: ["work"])
+    allow(ctx).to receive(:invoke).with("github_login", page: "work")
 
     expect { ctx.load_state("github") }
       .to raise_error(Browserctl::WorkflowError, /still bad/)


### PR DESCRIPTION
## Summary

Closes the follow-up flagged in #104. Stdlib flows that read \`page.url\` or call \`page.fill\` (oauth_github, totp_2fa, etc.) were unusable through the \`load_state\` auto-rotate path because \`recover_auth_required_state\` invoked them with no \`page:\` argument — \`FlowContext\` got \`page: nil\` and the precondition fired or \`page.url\` raised NoMethodError.

## Fix

\`WorkflowContext#recover_auth_required_state\` now resolves the workflow's first open page via \`client.page_list\` and forwards it to \`invoke(flow_name, page: <name>)\`. Same convention the daemon's \`state load\` preflight already uses (\`@pages.values.first\`), so the page the auth detector ran against is the page the flow then runs against.

\`page: nil\` fallback when no pages are open — defence-in-depth; \`state_load\` would have already errored with \"no open pages\" before reaching this branch.

## Why first-open-page

- Matches what the daemon already does in \`cmd_state_load\`, so there is no divergence between \"which page was preflighted\" and \"which page the flow drives\".
- Workflow callers who want a different page pass \`on_auth_required: -> { invoke :flow, page: :other }\` — explicit and documented.
- Adding a new \"target page\" field to the bundle manifest was rejected as overengineering for v0.10; revisit if a real use case for non-first-page recovery shows up.

## Changes

- \`lib/browserctl/workflow.rb\` — resolve and forward the page; new \`first_open_page\` helper.
- \`spec/unit/workflow_load_state_spec.rb\` — assert the page is forwarded; new spec for the empty-pages defence.
- \`docs/concepts/flows.md\` — document the convention and the override path.

## Test plan
- [x] \`bundle exec rspec spec/unit\` — 469 examples, 0 failures.
- [x] \`bundle exec rubocop lib/browserctl/workflow.rb spec/unit/workflow_load_state_spec.rb\` — clean.
- [x] Pre-push full suite — green (522 examples, 0 failures, 53 pending integration).
- [ ] After this lands, #104's e2e flow can drop the \`client.navigate(\"work\", ...)\` workaround in favour of the \`page.navigate\` proxy form.