### PR TITLE
feat: stable ref derivation (v0.11 WS-1.1)

### DIFF
--- a/lib/browserctl/constants.rb
+++ b/lib/browserctl/constants.rb
@@ -5,7 +5,7 @@ module Browserctl
   IDLE_TTL         = 30 * 60
   # Increment when a breaking wire protocol change ships (new field names, removed commands, changed response shapes).
   # Clients read this from `ping` to verify compatibility before sending commands.
-  PROTOCOL_VERSION = "2"
+  PROTOCOL_VERSION = "3"
 
   def self.socket_path(name = nil)
     File.join(BROWSERCTL_DIR, name ? "#{name}.sock" : "browserd.sock")

--- a/lib/browserctl/server/snapshot_builder.rb
+++ b/lib/browserctl/server/snapshot_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require "browserctl/snapshot/ref"
 
 module Browserctl
   class SnapshotBuilder
@@ -8,16 +9,24 @@ module Browserctl
                       [role=button] [role=link] [role=menuitem]].freeze
     ATTRS        = %w[type name placeholder href aria-label role].freeze
 
+    def initialize(ref_deriver: Snapshot::RefDeriver.new)
+      @ref_deriver = ref_deriver
+    end
+
     def call(page)
       doc = Nokogiri::HTML(page.body)
-      ref = 0
-      doc.css(INTERACTABLE.join(",")).map { |el| element_entry(el, ref += 1) }
+      taken = {}
+      doc.css(INTERACTABLE.join(",")).map do |el|
+        ref = @ref_deriver.disambiguate(@ref_deriver.derive(el), taken)
+        taken[ref] = true
+        element_entry(el, ref)
+      end
     end
 
     private
 
     def element_entry(elem, ref)
-      { ref: "e#{ref}", tag: elem.name, text: elem.text.strip.slice(0, 80),
+      { ref: ref, tag: elem.name, text: elem.text.strip.slice(0, 80),
         selector: css_path(elem), attrs: element_attrs(elem) }
     end
 

--- a/lib/browserctl/snapshot/ref.rb
+++ b/lib/browserctl/snapshot/ref.rb
@@ -59,7 +59,7 @@ module Browserctl
       def parent_path(node)
         parts = []
         cur = node.parent
-        while cur&.respond_to?(:name) && cur.name != "html" && cur.name != "document"
+        while cur.respond_to?(:name) && cur.name != "html" && cur.name != "document"
           parts.unshift(cur.name)
           cur = cur.parent
         end

--- a/lib/browserctl/snapshot/ref.rb
+++ b/lib/browserctl/snapshot/ref.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Browserctl
+  module Snapshot
+    # Derives a stable element ref from semantic + structural signals.
+    #
+    # The same DOM element should produce the same ref across two snapshots
+    # of the same page. Inputs to the hash are:
+    #   - role (explicit @role, else implicit ARIA role from tag)
+    #   - accessible name (aria-label || text || placeholder || alt)
+    #   - tag
+    #   - parent path (chain of ancestor tag names up to <html>)
+    #
+    # Collisions within a single snapshot are disambiguated by the caller via
+    # `disambiguate(ref, taken)` — the deriver itself is pure.
+    class RefDeriver
+      IMPLICIT_ROLE = {
+        "a" => "link", "button" => "button", "input" => "textbox",
+        "select" => "combobox", "textarea" => "textbox"
+      }.freeze
+
+      HASH_LEN = 7
+
+      def derive(node)
+        signal = [role(node), accessible_name(node), node.name, parent_path(node)].join("|")
+        "e#{Digest::SHA256.hexdigest(signal)[0, HASH_LEN]}"
+      end
+
+      # Given a candidate ref and a set of already-taken refs in the current
+      # snapshot, return a unique ref. Adds `-2`, `-3`, ... as needed.
+      def disambiguate(ref, taken)
+        return ref unless taken.include?(ref)
+
+        n = 2
+        n += 1 while taken.include?("#{ref}-#{n}")
+        "#{ref}-#{n}"
+      end
+
+      private
+
+      def role(node)
+        explicit = node["role"]
+        return explicit if explicit && !explicit.empty?
+
+        IMPLICIT_ROLE[node.name] || node.name
+      end
+
+      def accessible_name(node)
+        %w[aria-label placeholder alt title].each do |attr|
+          v = node[attr]
+          return v.strip if v && !v.strip.empty?
+        end
+        text = node.text.to_s.strip
+        text.empty? ? "" : text.slice(0, 80)
+      end
+
+      def parent_path(node)
+        parts = []
+        cur = node.parent
+        while cur&.respond_to?(:name) && cur.name != "html" && cur.name != "document"
+          parts.unshift(cur.name)
+          cur = cur.parent
+        end
+        parts.join(">")
+      end
+    end
+  end
+end

--- a/spec/integration/daemon_spec.rb
+++ b/spec/integration/daemon_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "browserd daemon", :integration do
       expect(res[:pid]).to be_a(Integer)
     end
 
-    it "reports protocol_version 2" do
+    it "reports protocol_version 3" do
       res = @client.ping
-      expect(res[:protocol_version]).to eq("2")
+      expect(res[:protocol_version]).to eq("3")
     end
   end
 

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -78,13 +78,16 @@ RSpec.describe Browserctl::CommandDispatcher do
     let(:pages) { { "main" => Browserctl::PageSession.new(page) } }
     subject(:dispatcher) { described_class.new(pages, double("driver")) }
 
-    before do
-      dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" })
-    end
+    let(:snapshot) { dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "elements" }) }
+    let(:elements) { snapshot[:snapshot] }
+    let(:button_ref) { elements.find { |e| e[:tag] == "button" }[:ref] }
+    let(:input_ref)  { elements.find { |e| e[:tag] == "input" }[:ref] }
+
+    before { snapshot }
 
     it "resolves ref to selector for click" do
       allow(page).to receive(:at_css).and_return(double("el", evaluate: nil))
-      res = dispatcher.dispatch({ cmd: "click", name: "main", ref: "e2" })
+      res = dispatcher.dispatch({ cmd: "click", name: "main", ref: button_ref })
       expect(res[:ok]).to be true
     end
 
@@ -96,7 +99,7 @@ RSpec.describe Browserctl::CommandDispatcher do
     it "resolves ref to selector for fill" do
       el = double("el", focus: nil, evaluate: nil, type: nil)
       allow(page).to receive(:at_css).and_return(el)
-      res = dispatcher.dispatch({ cmd: "fill", name: "main", ref: "e1", value: "test@example.com" })
+      res = dispatcher.dispatch({ cmd: "fill", name: "main", ref: input_ref, value: "test@example.com" })
       expect(res[:ok]).to be true
     end
 

--- a/spec/unit/snapshot_builder_spec.rb
+++ b/spec/unit/snapshot_builder_spec.rb
@@ -6,19 +6,37 @@ require "browserctl/server/snapshot_builder"
 RSpec.describe Browserctl::SnapshotBuilder do
   subject(:builder) { described_class.new }
 
+  def page_with(html) = double("page", body: html)
+
   describe "#call" do
     it "returns an array of element entries with required keys" do
-      page = double("page", body: "<html><body><a href='/'>Home</a></body></html>")
-      result = builder.call(page)
+      result = builder.call(page_with("<html><body><a href='/'>Home</a></body></html>"))
       expect(result).to be_an(Array)
       expect(result.first).to include(:ref, :tag, :text, :selector, :attrs)
     end
 
-    it "increments ref counters per element" do
+    it "derives stable hash-prefixed refs (e<7-hex>)" do
       html = "<html><body><a>One</a><button>Two</button></body></html>"
-      page = double("page", body: html)
-      refs = builder.call(page).map { |e| e[:ref] }
-      expect(refs).to eq(%w[e1 e2])
+      refs = builder.call(page_with(html)).map { |e| e[:ref] }
+      expect(refs).to all(match(/\Ae[0-9a-f]{7}(-\d+)?\z/))
+      expect(refs.uniq.size).to eq(refs.size)
+    end
+
+    it "produces identical refs across two snapshots of the same page" do
+      html = "<html><body><a>One</a><button>Two</button></body></html>"
+      first  = builder.call(page_with(html)).map { |e| e[:ref] }
+      second = builder.call(page_with(html)).map { |e| e[:ref] }
+      expect(first).to eq(second)
+    end
+
+    it "disambiguates collisions with a numeric suffix" do
+      # Two anchors with identical role/name/tag/parent-path should collide
+      # on the base hash and get -2 appended to the second.
+      html = "<html><body><a>Same</a><a>Same</a></body></html>"
+      refs = builder.call(page_with(html)).map { |e| e[:ref] }
+      expect(refs.size).to eq(2)
+      expect(refs[0]).to match(/\Ae[0-9a-f]{7}\z/)
+      expect(refs[1]).to eq("#{refs[0]}-2")
     end
   end
 end

--- a/spec/unit/snapshot_ref_spec.rb
+++ b/spec/unit/snapshot_ref_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nokogiri"
+require "browserctl/snapshot/ref"
+
+RSpec.describe Browserctl::Snapshot::RefDeriver do
+  subject(:deriver) { described_class.new }
+
+  def first_node(html, css)
+    Nokogiri::HTML(html).at_css(css)
+  end
+
+  describe "#derive" do
+    it "produces e<7-hex>" do
+      node = first_node("<html><body><button>Go</button></body></html>", "button")
+      expect(deriver.derive(node)).to match(/\Ae[0-9a-f]{7}\z/)
+    end
+
+    it "is deterministic for the same node signal" do
+      html = "<html><body><a href='/x'>Hi</a></body></html>"
+      a = deriver.derive(first_node(html, "a"))
+      b = deriver.derive(first_node(html, "a"))
+      expect(a).to eq(b)
+    end
+
+    it "is unaffected by class-only mutations" do
+      base    = first_node("<html><body><a>Hi</a></body></html>", "a")
+      mutated = first_node("<html><body><a class='renamed-x'>Hi</a></body></html>", "a")
+      expect(deriver.derive(base)).to eq(deriver.derive(mutated))
+    end
+
+    it "differs when accessible name changes" do
+      a = first_node("<html><body><button>Save</button></body></html>", "button")
+      b = first_node("<html><body><button>Cancel</button></body></html>", "button")
+      expect(deriver.derive(a)).not_to eq(deriver.derive(b))
+    end
+
+    it "differs when parent path changes" do
+      a = first_node("<html><body><div><a>X</a></div></body></html>", "a")
+      b = first_node("<html><body><form><a>X</a></form></body></html>", "a")
+      expect(deriver.derive(a)).not_to eq(deriver.derive(b))
+    end
+
+    it "prefers explicit role over implicit tag role" do
+      a = first_node("<html><body><a role='button'>Go</a></body></html>", "a")
+      b = first_node("<html><body><a>Go</a></body></html>", "a")
+      expect(deriver.derive(a)).not_to eq(deriver.derive(b))
+    end
+  end
+
+  describe "#disambiguate" do
+    it "returns ref unchanged when not taken" do
+      expect(deriver.disambiguate("eabc1234", {})).to eq("eabc1234")
+    end
+
+    it "appends -2 on first collision, -3 on next, etc" do
+      taken = { "eabc1234" => true }
+      expect(deriver.disambiguate("eabc1234", taken)).to eq("eabc1234-2")
+      taken["eabc1234-2"] = true
+      expect(deriver.disambiguate("eabc1234", taken)).to eq("eabc1234-3")
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?

First PR of the v0.11 Replayable milestone (WS-1 #1 in `docs/plans/v0.11-replayable.md`).

Replaces the incrementing element-ref counter with a stable hash:

```
ref = "e" + sha256(role | accessible-name | tag | parent-path)[0..6]
```

Same DOM element → same ref across snapshots. Means a recorded workflow
can refer to an element by ref and still resolve it on replay even if
the page DOM was re-rendered with the same semantics.

Within a single snapshot, exact-collision refs are disambiguated with
`-2`, `-3`, … suffixes.

## Type of change

- [x] New feature
- [x] Refactor / internal improvement

### Breaking change

`PROTOCOL_VERSION` bumped `2 → 3`. Refs no longer match `/^e\d+$/`; clients
that hard-coded `e1`, `e2`, etc. will break. Format is now
`/^e[0-9a-f]{7}(-\d+)?$/`. Recording log compat handled in a later PR.

## How to test

- `bundle exec rspec spec/unit/snapshot_ref_spec.rb spec/unit/snapshot_builder_spec.rb`
- Manually: `browserctl page open foo --url https://example.com && browserctl snapshot foo` — refs should look like `e3f9a1b`.

## Checklist

- [x] Tests added or updated
- [x] `bundle exec rspec` passes
- [x] `bundle exec rubocop` reports no offenses
- [ ] CHANGELOG.md — auto-generated by release-please from the conventional commit