### PR TITLE
feat: element fingerprint (v0.11 WS-1.2)

### DIFF
--- a/lib/browserctl/server/snapshot_builder.rb
+++ b/lib/browserctl/server/snapshot_builder.rb
@@ -2,6 +2,7 @@
 
 require "nokogiri"
 require "browserctl/snapshot/ref"
+require "browserctl/snapshot/fingerprint"
 
 module Browserctl
   class SnapshotBuilder
@@ -9,8 +10,9 @@ module Browserctl
                       [role=button] [role=link] [role=menuitem]].freeze
     ATTRS        = %w[type name placeholder href aria-label role].freeze
 
-    def initialize(ref_deriver: Snapshot::RefDeriver.new)
+    def initialize(ref_deriver: Snapshot::RefDeriver.new, fingerprint: Snapshot::Fingerprint.new)
       @ref_deriver = ref_deriver
+      @fingerprint = fingerprint
     end
 
     def call(page)
@@ -27,7 +29,8 @@ module Browserctl
 
     def element_entry(elem, ref)
       { ref: ref, tag: elem.name, text: elem.text.strip.slice(0, 80),
-        selector: css_path(elem), attrs: element_attrs(elem) }
+        selector: css_path(elem), attrs: element_attrs(elem),
+        fingerprint: @fingerprint.build(elem) }
     end
 
     def element_attrs(elem)

--- a/lib/browserctl/snapshot/fingerprint.rb
+++ b/lib/browserctl/snapshot/fingerprint.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "browserctl/snapshot/ref"
+
+module Browserctl
+  module Snapshot
+    # Builds a per-element fingerprint that survives small DOM changes.
+    #
+    # The fingerprint is later used by the replay layer to rematch an
+    # element when its recorded selector no longer resolves: score the
+    # candidate elements in the new DOM against the recorded fingerprint
+    # and pick the best match above a threshold.
+    #
+    # Shape:
+    #   {
+    #     text:      <accessible name>,
+    #     role:      <ARIA role, explicit or implicit>,
+    #     neighbors: [<short text of nearby siblings>, ...],
+    #     position:  { index: <int>, depth: <int> }
+    #   }
+    class Fingerprint
+      NEIGHBOR_RADIUS = 2 # siblings to capture on each side
+      NEIGHBOR_TEXT_LEN = 40
+
+      def initialize(ref_deriver: RefDeriver.new)
+        @ref_deriver = ref_deriver
+      end
+
+      def build(node)
+        {
+          text: accessible_name(node),
+          role: role(node),
+          neighbors: neighbors(node),
+          position: position(node)
+        }
+      end
+
+      private
+
+      def role(node)
+        explicit = node["role"]
+        return explicit if explicit && !explicit.empty?
+
+        RefDeriver::IMPLICIT_ROLE[node.name] || node.name
+      end
+
+      def accessible_name(node)
+        %w[aria-label placeholder alt title].each do |attr|
+          v = node[attr]
+          return v.strip if v && !v.strip.empty?
+        end
+        node.text.to_s.strip.slice(0, 80)
+      end
+
+      def neighbors(node)
+        parent = node.parent
+        return [] unless parent.respond_to?(:children)
+
+        idx = parent.children.to_a.index(node) || 0
+        window = parent.children.to_a[[idx - NEIGHBOR_RADIUS, 0].max...(idx + NEIGHBOR_RADIUS + 1)] || []
+        window
+          .reject { |c| c == node || !c.respond_to?(:name) }
+          .map { |c| neighbor_signal(c) }
+          .reject(&:empty?)
+      end
+
+      def neighbor_signal(node)
+        text = node.text.to_s.strip.gsub(/\s+/, " ").slice(0, NEIGHBOR_TEXT_LEN)
+        text.empty? ? "" : "#{node.name}:#{text}"
+      end
+
+      def position(node)
+        idx = node.parent.respond_to?(:children) ? (node.parent.children.to_a.index(node) || 0) : 0
+        { index: idx, depth: depth(node) }
+      end
+
+      def depth(node)
+        d = 0
+        cur = node.parent
+        while cur.respond_to?(:name) && cur.name != "document"
+          d += 1
+          cur = cur.parent
+        end
+        d
+      end
+    end
+  end
+end

--- a/spec/unit/snapshot_builder_spec.rb
+++ b/spec/unit/snapshot_builder_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe Browserctl::SnapshotBuilder do
     it "returns an array of element entries with required keys" do
       result = builder.call(page_with("<html><body><a href='/'>Home</a></body></html>"))
       expect(result).to be_an(Array)
-      expect(result.first).to include(:ref, :tag, :text, :selector, :attrs)
+      expect(result.first).to include(:ref, :tag, :text, :selector, :attrs, :fingerprint)
+    end
+
+    it "emits a fingerprint hash per element" do
+      result = builder.call(page_with("<html><body><button>Go</button></body></html>"))
+      expect(result.first[:fingerprint]).to include(:text, :role, :neighbors, :position)
     end
 
     it "derives stable hash-prefixed refs (e<7-hex>)" do

--- a/spec/unit/snapshot_fingerprint_spec.rb
+++ b/spec/unit/snapshot_fingerprint_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nokogiri"
+require "browserctl/snapshot/fingerprint"
+
+RSpec.describe Browserctl::Snapshot::Fingerprint do
+  subject(:fingerprint) { described_class.new }
+
+  def node(html, css)
+    Nokogiri::HTML(html).at_css(css)
+  end
+
+  describe "#build" do
+    it "captures text, role, neighbors, and position" do
+      html = <<~HTML
+        <html><body><form>
+          <label>Email</label>
+          <input type="email" placeholder="you@example.com">
+          <button>Submit</button>
+        </form></body></html>
+      HTML
+      fp = fingerprint.build(node(html, "input"))
+
+      expect(fp[:text]).to eq("you@example.com")
+      expect(fp[:role]).to eq("textbox")
+      expect(fp[:neighbors]).to include(match(/label:Email/), match(/button:Submit/))
+      expect(fp[:position]).to include(:index, :depth)
+      expect(fp[:position][:depth]).to be > 0
+    end
+
+    it "uses explicit role over implicit tag role" do
+      html = "<html><body><a role='button'>Go</a></body></html>"
+      expect(fingerprint.build(node(html, "a"))[:role]).to eq("button")
+    end
+
+    it "is stable when an unrelated class is added" do
+      base    = node("<html><body><div><button>Save</button><span>x</span></div></body></html>", "button")
+      mutated = node("<html><body><div><button class='primary-x9'>Save</button><span>x</span></div></body></html>",
+                     "button")
+      expect(fingerprint.build(base)).to eq(fingerprint.build(mutated))
+    end
+
+    it "differs when accessible name changes" do
+      a = node("<html><body><button>Save</button></body></html>", "button")
+      b = node("<html><body><button>Cancel</button></body></html>", "button")
+      expect(fingerprint.build(a)[:text]).not_to eq(fingerprint.build(b)[:text])
+    end
+
+    it "returns empty neighbors when element has no siblings" do
+      html = "<html><body><button>Solo</button></body></html>"
+      expect(fingerprint.build(node(html, "button"))[:neighbors]).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Builds on #106.

Adds per-element \`fingerprint\` to every snapshot entry:

```ruby
fingerprint: {
  text:      "Sign in",
  role:      "button",
  neighbors: ["label:Email", "input:"],
  position:  { index: 3, depth: 4 }
}
```

The fingerprint is the rematch signal for the WS-2 replay fallback — when a recorded selector fails, the matcher will score candidate elements in the new DOM against this fingerprint and pick the best.

Inputs:
- **text**: aria-label / placeholder / alt / title / visible text (≤80 chars)
- **role**: explicit \`@role\`, else implicit ARIA role from tag
- **neighbors**: short \`tag:text\` signals from siblings within radius 2, ignoring whitespace text nodes
- **position**: index in parent + DOM depth

Designed to be stable across class renames and unrelated subtree changes.

## Type of change

- [x] New feature

## How to test

\`bundle exec rspec spec/unit/snapshot_fingerprint_spec.rb\`

## Checklist

- [x] Tests added or updated
- [x] \`bundle exec rspec\` passes
- [x] \`bundle exec rubocop\` reports no offenses