### PR TITLE
refactor: snapshot pipeline (v0.11 WS-1.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/superpowers/
 .claude/feedback/
 examples/smoke/*.yml
 examples/smoke/*.json
+.claude/worktrees/

--- a/lib/browserctl/server/snapshot_builder.rb
+++ b/lib/browserctl/server/snapshot_builder.rb
@@ -1,67 +1,31 @@
 # frozen_string_literal: true
 
-require "nokogiri"
-require "browserctl/snapshot/ref"
-require "browserctl/snapshot/fingerprint"
+require "browserctl/snapshot/extractor"
+require "browserctl/snapshot/annotator"
+require "browserctl/snapshot/serializer"
 
 module Browserctl
+  # Orchestrates the snapshot pipeline:
+  #
+  #   page.body  ──Extractor──▶  [nodes]
+  #              ──Annotator──▶  [entries with ref + fingerprint]
+  #              ──Serializer─▶  wire-shape array
+  #
+  # Each stage is independently testable. Inject alternates via the keyword
+  # args for tests that want to isolate one stage.
   class SnapshotBuilder
-    INTERACTABLE = %w[a button input select textarea
-                      [role=button] [role=link] [role=menuitem]].freeze
-    ATTRS        = %w[type name placeholder href aria-label role].freeze
-
-    def initialize(ref_deriver: Snapshot::RefDeriver.new, fingerprint: Snapshot::Fingerprint.new)
-      @ref_deriver = ref_deriver
-      @fingerprint = fingerprint
+    def initialize(extractor: Snapshot::Extractor.new,
+                   annotator: Snapshot::Annotator.new,
+                   serializer: Snapshot::Serializer.new)
+      @extractor = extractor
+      @annotator = annotator
+      @serializer = serializer
     end
 
     def call(page)
-      doc = Nokogiri::HTML(page.body)
-      taken = {}
-      doc.css(INTERACTABLE.join(",")).map do |el|
-        ref = @ref_deriver.disambiguate(@ref_deriver.derive(el), taken)
-        taken[ref] = true
-        element_entry(el, ref)
-      end
-    end
-
-    private
-
-    def element_entry(elem, ref)
-      { ref: ref, tag: elem.name, text: elem.text.strip.slice(0, 80),
-        selector: css_path(elem), attrs: element_attrs(elem),
-        fingerprint: @fingerprint.build(elem) }
-    end
-
-    def element_attrs(elem)
-      elem.attributes.transform_values(&:value).slice(*ATTRS)
-    end
-
-    def css_path(node)
-      ancestors_until_html(node).map { |n| path_segment(n) }.join(" > ")
-    end
-
-    def ancestors_until_html(node)
-      [].tap do |acc|
-        while node && node.name != "html"
-          acc.unshift(node)
-          node = node.parent
-        end
-      end
-    end
-
-    def path_segment(node)
-      node.name + id_fragment(node) + class_fragment(node)
-    end
-
-    def id_fragment(node)
-      (id = node["id"]) && !id.empty? ? "##{id}" : ""
-    end
-
-    def class_fragment(node)
-      return "" if node["id"] && !node["id"].empty?
-
-      (klass = node["class"]&.split&.first) ? ".#{klass}" : ""
+      nodes = @extractor.call(page.body)
+      entries = @annotator.call(nodes)
+      @serializer.call(entries)
     end
   end
 end

--- a/lib/browserctl/snapshot/annotator.rb
+++ b/lib/browserctl/snapshot/annotator.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "browserctl/snapshot/ref"
+require "browserctl/snapshot/fingerprint"
+
+module Browserctl
+  module Snapshot
+    # Stage 2 of the snapshot pipeline.
+    #
+    # Takes the list of interactable nodes from Extractor and produces
+    # element entries with stable refs, semantic metadata, a CSS selector
+    # path, and a fingerprint. Each entry is a plain Hash.
+    class Annotator
+      ATTRS = %w[type name placeholder href aria-label role].freeze
+
+      def initialize(ref_deriver: RefDeriver.new, fingerprint: Fingerprint.new)
+        @ref_deriver = ref_deriver
+        @fingerprint = fingerprint
+      end
+
+      def call(nodes)
+        taken = {}
+        nodes.map do |node|
+          ref = @ref_deriver.disambiguate(@ref_deriver.derive(node), taken)
+          taken[ref] = true
+          entry(node, ref)
+        end
+      end
+
+      private
+
+      def entry(node, ref)
+        {
+          ref: ref,
+          tag: node.name,
+          text: node.text.strip.slice(0, 80),
+          selector: css_path(node),
+          attrs: attrs(node),
+          fingerprint: @fingerprint.build(node)
+        }
+      end
+
+      def attrs(node)
+        node.attributes.transform_values(&:value).slice(*ATTRS)
+      end
+
+      def css_path(node)
+        ancestors_until_html(node).map { |n| segment(n) }.join(" > ")
+      end
+
+      def ancestors_until_html(node)
+        [].tap do |acc|
+          while node && node.name != "html"
+            acc.unshift(node)
+            node = node.parent
+          end
+        end
+      end
+
+      def segment(node)
+        node.name + id_fragment(node) + class_fragment(node)
+      end
+
+      def id_fragment(node)
+        (id = node["id"]) && !id.empty? ? "##{id}" : ""
+      end
+
+      def class_fragment(node)
+        return "" if node["id"] && !node["id"].empty?
+
+        (klass = node["class"]&.split&.first) ? ".#{klass}" : ""
+      end
+    end
+  end
+end

--- a/lib/browserctl/snapshot/extractor.rb
+++ b/lib/browserctl/snapshot/extractor.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+
+module Browserctl
+  module Snapshot
+    # Stage 1 of the snapshot pipeline.
+    #
+    # Parses raw HTML and returns the set of interactable Nokogiri nodes
+    # that the rest of the pipeline will annotate. This stage knows nothing
+    # about refs, fingerprints, or wire format.
+    class Extractor
+      INTERACTABLE = %w[a button input select textarea
+                        [role=button] [role=link] [role=menuitem]].freeze
+
+      def call(html)
+        Nokogiri::HTML(html).css(INTERACTABLE.join(",")).to_a
+      end
+    end
+  end
+end

--- a/lib/browserctl/snapshot/serializer.rb
+++ b/lib/browserctl/snapshot/serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Snapshot
+    # Stage 3 of the snapshot pipeline.
+    #
+    # Right now this is the identity function — annotated entries are
+    # already in the wire shape clients expect. It exists as a seam so
+    # later milestones can canonicalize, redact, or compress without
+    # touching extraction or annotation.
+    class Serializer
+      def call(entries)
+        entries
+      end
+    end
+  end
+end

--- a/spec/unit/snapshot_annotator_spec.rb
+++ b/spec/unit/snapshot_annotator_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nokogiri"
+require "browserctl/snapshot/annotator"
+
+RSpec.describe Browserctl::Snapshot::Annotator do
+  subject(:annotator) { described_class.new }
+
+  def nodes_for(html, css)
+    Nokogiri::HTML(html).css(css).to_a
+  end
+
+  it "produces entries with ref, tag, text, selector, attrs, fingerprint" do
+    html = "<html><body><a href='/'>Home</a></body></html>"
+    entries = annotator.call(nodes_for(html, "a"))
+    expect(entries.first.keys).to include(:ref, :tag, :text, :selector, :attrs, :fingerprint)
+    expect(entries.first[:tag]).to eq("a")
+    expect(entries.first[:attrs]).to include("href" => "/")
+  end
+
+  it "deduplicates colliding refs with -2 suffix" do
+    nodes = nodes_for("<html><body><a>Same</a><a>Same</a></body></html>", "a")
+    refs = annotator.call(nodes).map { |e| e[:ref] }
+    expect(refs.size).to eq(2)
+    expect(refs[1]).to eq("#{refs[0]}-2")
+  end
+
+  it "is decoupled from extraction (works on raw nodes)" do
+    nodes = nodes_for("<html><body><button id='go'>Go</button></body></html>", "button")
+    entries = annotator.call(nodes)
+    expect(entries.first[:selector]).to include("button#go")
+  end
+end

--- a/spec/unit/snapshot_extractor_spec.rb
+++ b/spec/unit/snapshot_extractor_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/snapshot/extractor"
+
+RSpec.describe Browserctl::Snapshot::Extractor do
+  subject(:extractor) { described_class.new }
+
+  it "returns interactable nodes from HTML" do
+    html = <<~HTML
+      <html><body>
+        <p>Not interactable</p>
+        <a>Link</a>
+        <button>Btn</button>
+        <input type="text">
+        <div role="button">Custom</div>
+      </body></html>
+    HTML
+    nodes = extractor.call(html)
+    expect(nodes.map(&:name)).to contain_exactly("a", "button", "input", "div")
+  end
+
+  it "returns an empty array when no interactable elements are present" do
+    expect(extractor.call("<html><body><p>plain</p></body></html>")).to eq([])
+  end
+end


### PR DESCRIPTION
Stacked on #107.

Splits \`SnapshotBuilder\` into three single-purpose stages so ref + fingerprint logic is independently testable:

\`\`\`
page.body  ──Extractor──▶  [Nokogiri nodes]
           ──Annotator──▶  [entries with ref + fingerprint]
           ──Serializer─▶  wire-shape array
\`\`\`

\`SnapshotBuilder\` is now a thin orchestrator that wires the three stages together. Each stage has its own spec; alternates can be injected via keyword args.

\`Serializer\` is currently the identity function. It exists as a seam for future canonicalization, redaction, or compression — added now so we don't have to rewire callers later.

No behavior change — same wire shape, same refs, same fingerprints. Existing snapshot specs continue to pass unchanged.

## Type of change

- [x] Refactor / internal improvement

## How to test

- \`bundle exec rspec spec/unit/snapshot_extractor_spec.rb spec/unit/snapshot_annotator_spec.rb spec/unit/snapshot_builder_spec.rb\`
- Full unit suite: \`bundle exec rspec spec/unit\` (490 examples, all green)

## Checklist

- [x] Tests added or updated
- [x] \`bundle exec rspec\` passes
- [x] \`bundle exec rubocop\` reports no offenses