### PR TITLE
test: snapshot determinism specs (v0.11 WS-1.4)

### DIFF
--- a/spec/fixtures/snapshots/login_form.html
+++ b/spec/fixtures/snapshots/login_form.html
@@ -1,0 +1,18 @@
+<html>
+<body>
+  <header>
+    <a href="/">Home</a>
+    <a href="/help">Help</a>
+  </header>
+  <main>
+    <form id="login">
+      <label for="email">Email</label>
+      <input id="email" type="email" name="email" placeholder="you@example.com">
+      <label for="pw">Password</label>
+      <input id="pw" type="password" name="password" placeholder="••••••••">
+      <button type="submit">Sign in</button>
+      <a href="/forgot">Forgot password?</a>
+    </form>
+  </main>
+</body>
+</html>

--- a/spec/fixtures/snapshots/login_form_mutated.html
+++ b/spec/fixtures/snapshots/login_form_mutated.html
@@ -1,0 +1,18 @@
+<html>
+<body>
+  <header class="topnav-rebrand">
+    <a href="/" class="link link--primary">Home</a>
+    <a href="/help" class="link">Help</a>
+  </header>
+  <main class="container-xl">
+    <form id="login" class="form form--auth-v2">
+      <label for="email" class="lbl">Email</label>
+      <input id="email" type="email" name="email" placeholder="you@example.com" class="input">
+      <label for="pw" class="lbl">Password</label>
+      <input id="pw" type="password" name="password" placeholder="••••••••" class="input">
+      <button type="submit" class="btn btn--primary">Sign in</button>
+      <a href="/forgot" class="link link--muted">Forgot password?</a>
+    </form>
+  </main>
+</body>
+</html>

--- a/spec/unit/snapshot_determinism_spec.rb
+++ b/spec/unit/snapshot_determinism_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/server/snapshot_builder"
+
+FIXTURES_DIR = File.expand_path("../fixtures/snapshots", __dir__)
+
+RSpec.describe "Snapshot determinism" do
+  def page(name) = double("page", body: File.read(File.join(FIXTURES_DIR, name)))
+
+  let(:builder) { Browserctl::SnapshotBuilder.new }
+
+  describe "stable refs across calls" do
+    it "produces identical refs when snapshotting the same page twice" do
+      first  = builder.call(page("login_form.html"))
+      second = builder.call(page("login_form.html"))
+      expect(second.map { |e| e[:ref] }).to eq(first.map { |e| e[:ref] })
+    end
+
+    it "every entry has the expected wire-shape keys" do
+      entry = builder.call(page("login_form.html")).first
+      expect(entry.keys).to include(:ref, :tag, :text, :selector, :attrs, :fingerprint)
+    end
+
+    it "all refs are unique within a snapshot" do
+      refs = builder.call(page("login_form.html")).map { |e| e[:ref] }
+      expect(refs.uniq.size).to eq(refs.size)
+    end
+  end
+
+  describe "fingerprint survives structural drift" do
+    it "matches Sign-in button across class-only mutations" do
+      base    = builder.call(page("login_form.html"))
+      mutated = builder.call(page("login_form_mutated.html"))
+
+      base_btn    = base.find    { |e| e[:tag] == "button" }
+      mutated_btn = mutated.find { |e| e[:tag] == "button" }
+
+      expect(mutated_btn[:fingerprint]).to eq(base_btn[:fingerprint])
+    end
+
+    it "matches each labelled input across class-only mutations" do
+      base    = builder.call(page("login_form.html")).select { |e| e[:tag] == "input" }
+      mutated = builder.call(page("login_form_mutated.html")).select { |e| e[:tag] == "input" }
+
+      base.zip(mutated).each do |b, m|
+        expect(m[:fingerprint][:text]).to eq(b[:fingerprint][:text])
+        expect(m[:fingerprint][:role]).to eq(b[:fingerprint][:role])
+      end
+    end
+
+    it "ref and fingerprint are independent of class attributes" do
+      base    = builder.call(page("login_form.html")).map { |e| [e[:ref], e[:fingerprint]] }
+      mutated = builder.call(page("login_form_mutated.html")).map { |e| [e[:ref], e[:fingerprint]] }
+      expect(mutated).to eq(base)
+    end
+  end
+end


### PR DESCRIPTION
Golden tests that pin the v0.11 ref + fingerprint guarantees against realistic HTML.

## What it covers

\`spec/unit/snapshot_determinism_spec.rb\` against two fixtures (\`spec/fixtures/snapshots/login_form.html\` + \`login_form_mutated.html\`):

- Same page snapshotted twice → identical ref set
- All refs unique within a snapshot
- Wire-shape keys present on every entry
- Class-only DOM mutations leave both ref **and** fingerprint untouched

The mutated fixture is the realistic 'restyle without semantic change' case — same DOM structure, same labels, same form, every element gets a CSS class slapped on. The replay layer needs to treat that as a no-op.

## Type of change

- [x] New feature (test coverage)

## How to test

\`bundle exec rspec spec/unit/snapshot_determinism_spec.rb\` — 6 examples, all green.

## Checklist

- [x] Tests added or updated
- [x] \`bundle exec rspec\` passes
- [x] \`bundle exec rubocop\` reports no offenses