### PR TITLE
feat: fingerprint matcher (v0.11 WS-2.1)

### DIFF
--- a/lib/browserctl/replay/fingerprint_matcher.rb
+++ b/lib/browserctl/replay/fingerprint_matcher.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Replay
+    # Scores candidate snapshot entries against a recorded fingerprint and
+    # returns the best match above a configurable threshold.
+    #
+    # Inputs are the wire-shape fingerprints emitted by Snapshot::Fingerprint:
+    #   { text:, role:, neighbors: [...], position: { index:, depth: } }
+    #
+    # Score is a weighted sum in [0.0, 1.0]:
+    #   text      0.40   (exact match; case-insensitive)
+    #   role      0.20   (exact match)
+    #   neighbors 0.25   (Jaccard over the neighbor sets)
+    #   position  0.15   (proximity in (index, depth) space)
+    #
+    # Defaults reflect the v0.11 acceptance bar: text + role together (0.60)
+    # are enough to clear the default threshold, so a renamed neighbor or a
+    # shifted index doesn't break replay.
+    class FingerprintMatcher
+      DEFAULT_THRESHOLD = 0.6
+      WEIGHTS = { text: 0.40, role: 0.20, neighbors: 0.25, position: 0.15 }.freeze
+
+      Match = Struct.new(:candidate, :score, keyword_init: true)
+
+      def initialize(threshold: DEFAULT_THRESHOLD, weights: WEIGHTS)
+        @threshold = threshold
+        @weights = weights
+      end
+
+      # Returns the highest-scoring candidate entry above the threshold, or
+      # nil if no candidate qualifies. `candidates` must be an array of
+      # snapshot entries (hashes with a :fingerprint key). The returned
+      # Match wraps the candidate hash and the numeric score.
+      def best(target_fp, candidates)
+        scored = candidates
+                 .map { |c| Match.new(candidate: c, score: score(target_fp, c[:fingerprint])) }
+                 .sort_by { |m| -m.score }
+
+        winner = scored.first
+        return nil unless winner && winner.score >= @threshold
+
+        winner
+      end
+
+      def score(target, candidate)
+        return 0.0 unless target && candidate
+
+        (@weights[:text] * text_score(target[:text], candidate[:text])) +
+          (@weights[:role]      * bool_score(target[:role] == candidate[:role])) +
+          (@weights[:neighbors] * jaccard(target[:neighbors], candidate[:neighbors])) +
+          (@weights[:position] * position_score(target[:position], candidate[:position]))
+      end
+
+      private
+
+      def text_score(target, candidate)
+        return 0.0 if target.nil? || candidate.nil? || target.empty? || candidate.empty?
+
+        target.downcase.strip == candidate.downcase.strip ? 1.0 : 0.0
+      end
+
+      def bool_score(flag) = flag ? 1.0 : 0.0
+
+      def jaccard(target, candidate)
+        target = Array(target)
+        candidate = Array(candidate)
+        return 1.0 if target.empty? && candidate.empty?
+        return 0.0 if target.empty? || candidate.empty?
+
+        inter = (target & candidate).size
+        union = (target | candidate).size
+        union.zero? ? 0.0 : inter.to_f / union
+      end
+
+      def position_score(target, candidate)
+        return 0.0 unless target && candidate
+
+        idx_d = (target[:index].to_i - candidate[:index].to_i).abs
+        depth_d = (target[:depth].to_i - candidate[:depth].to_i).abs
+        # Soft falloff: 1.0 when identical, ~0 once they're 4+ apart in either axis.
+        [1.0 - ((idx_d + depth_d) / 8.0), 0.0].max
+      end
+    end
+  end
+end

--- a/spec/unit/fingerprint_matcher_spec.rb
+++ b/spec/unit/fingerprint_matcher_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/replay/fingerprint_matcher"
+
+RSpec.describe Browserctl::Replay::FingerprintMatcher do
+  subject(:matcher) { described_class.new }
+
+  def entry(ref:, text:, role:, neighbors: [], position: { index: 0, depth: 1 })
+    { ref: ref, fingerprint: { text: text, role: role, neighbors: neighbors, position: position } }
+  end
+
+  describe "#best" do
+    let(:target) do
+      { text: "Sign in", role: "button", neighbors: ["input:", "a:Forgot password?"],
+        position: { index: 7, depth: 4 } }
+    end
+
+    it "returns the exact match when present" do
+      candidates = [
+        entry(ref: "a", text: "Cancel", role: "button"),
+        entry(ref: "b", text: "Sign in", role: "button",
+              neighbors: ["input:", "a:Forgot password?"], position: { index: 7, depth: 4 }),
+        entry(ref: "c", text: "Submit", role: "button")
+      ]
+      result = matcher.best(target, candidates)
+      expect(result.candidate[:ref]).to eq("b")
+      expect(result.score).to be_within(0.001).of(1.0)
+    end
+
+    it "tolerates neighbor and position drift when text+role agree" do
+      candidates = [
+        entry(ref: "a", text: "Cancel", role: "button"),
+        entry(ref: "b", text: "Sign in", role: "button",
+              neighbors: ["input:"], position: { index: 9, depth: 5 })
+      ]
+      result = matcher.best(target, candidates)
+      expect(result.candidate[:ref]).to eq("b")
+      expect(result.score).to be >= 0.6
+    end
+
+    it "returns nil when no candidate clears the threshold" do
+      candidates = [
+        entry(ref: "a", text: "Cancel", role: "button"),
+        entry(ref: "b", text: "Submit", role: "link")
+      ]
+      expect(matcher.best(target, candidates)).to be_nil
+    end
+
+    it "returns nil for an empty candidate list" do
+      expect(matcher.best(target, [])).to be_nil
+    end
+
+    it "respects an injected threshold" do
+      strict = described_class.new(threshold: 0.95)
+      partial = entry(ref: "p", text: "Sign in", role: "button",
+                      neighbors: [], position: { index: 99, depth: 99 })
+      expect(strict.best(target, [partial])).to be_nil
+    end
+  end
+
+  describe "#score" do
+    it "is 0.0 when both fingerprints are nil/empty" do
+      expect(matcher.score(nil, {})).to eq(0.0)
+    end
+
+    it "is case-insensitive for text" do
+      a = { text: "Sign In",  role: "button", neighbors: [], position: { index: 0, depth: 0 } }
+      b = { text: "sign in",  role: "button", neighbors: [], position: { index: 0, depth: 0 } }
+      expect(matcher.score(a, b)).to be_within(0.001).of(0.4 + 0.2 + 0.25 + 0.15)
+    end
+  end
+end


### PR DESCRIPTION
First PR of WS-2 (self-healing replay).

Pure scoring module that powers the replay rematch. Given a recorded fingerprint and a list of candidate snapshot entries, returns the best match above a threshold — or \`nil\` if nothing qualifies.

## Score breakdown

Weighted sum in \`[0.0, 1.0]\`:

| Signal     | Weight | Comparison                                           |
|------------|--------|------------------------------------------------------|
| text       | 0.40   | exact match, case-insensitive                        |
| role       | 0.20   | exact match                                          |
| neighbors  | 0.25   | Jaccard over the recorded vs candidate neighbor sets |
| position   | 0.15   | soft falloff over \`(index, depth)\` distance         |

Default threshold \`0.6\` — text + role agreement alone clears the bar, so a renamed neighbor or a shifted index won't break replay. Threshold and weights are constructor-injectable for callers that want a different sensitivity profile.

## What this does **not** do

- No I/O, no DOM access, no daemon coupling — just scoring against the wire-shape fingerprint emitted by \`Snapshot::Fingerprint\`.
- PageProxy fallback wiring (WS-2.2) and drift report (WS-2.3) land in subsequent PRs.

## Type of change

- [x] New feature

## How to test

\`bundle exec rspec spec/unit/fingerprint_matcher_spec.rb\` — 7 examples, all green.

## Checklist

- [x] Tests added or updated
- [x] \`bundle exec rspec\` passes
- [x] \`bundle exec rubocop\` reports no offenses