### PR TITLE
feat: replay fallback in PageProxy (v0.11 WS-2.2)

### DIFF
--- a/lib/browserctl/replay/context.rb
+++ b/lib/browserctl/replay/context.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Replay
+    # Per-page replay context carried by PageProxy during a workflow run
+    # generated from a recording.
+    #
+    # Holds the recorded fingerprint for each selector that the workflow
+    # interacts with. When a selector-driven command fails with
+    # selector_not_found at replay time, the proxy looks up the fingerprint
+    # here and asks FingerprintMatcher to find a candidate in the live
+    # snapshot. The matched element's stable ref is then re-used to retry
+    # the original command.
+    #
+    # Drift events (rematches, threshold misses) are accumulated on the
+    # context so the surrounding workflow runner can render them into a
+    # drift report at end-of-run.
+    class Context
+      DriftEvent = Struct.new(:command, :selector, :matched_ref, :score, :reason, keyword_init: true)
+
+      attr_reader :drift_events
+
+      def initialize(fingerprints: {})
+        @fingerprints = fingerprints
+        @drift_events = []
+      end
+
+      def fingerprint_for(selector)
+        @fingerprints[selector]
+      end
+
+      def record(command:, selector:, matched_ref: nil, score: nil, reason: nil)
+        @drift_events << DriftEvent.new(
+          command: command, selector: selector,
+          matched_ref: matched_ref, score: score, reason: reason
+        )
+      end
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/interaction.rb
+++ b/lib/browserctl/server/handlers/interaction.rb
@@ -27,7 +27,7 @@ module Browserctl
               "return { x: r.left + r.width / 2, y: r.top + r.height / 2 }; " \
               "})(#{sel.to_json})"
             )
-            return { error: "selector not found: #{sel}" } unless coords
+            return { error: "selector not found: #{sel}", code: "selector_not_found" } unless coords
 
             session.page.mouse.move(x: coords["x"], y: coords["y"])
             { ok: true }
@@ -43,7 +43,7 @@ module Browserctl
             return sel if sel.is_a?(Hash)
 
             el = session.page.at_css(sel)
-            return { error: "selector not found: #{sel}" } unless el
+            return { error: "selector not found: #{sel}", code: "selector_not_found" } unless el
 
             el.select_file(path)
             { ok: true }
@@ -56,7 +56,7 @@ module Browserctl
             return sel if sel.is_a?(Hash)
 
             el = session.page.at_css(sel)
-            return { error: "selector not found: #{sel}" } unless el
+            return { error: "selector not found: #{sel}", code: "selector_not_found" } unless el
 
             el.evaluate(
               "this.value = #{req[:value].to_json}; " \

--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -52,7 +52,7 @@ module Browserctl
 
         def type_into(page, selector, value)
           el = page.at_css(selector)
-          return { error: "selector not found: #{selector}" } unless el
+          return { error: "selector not found: #{selector}", code: "selector_not_found" } unless el
 
           el.focus
           el.evaluate("this.select()")
@@ -62,7 +62,7 @@ module Browserctl
 
         def click_element(page, selector)
           el = page.at_css(selector)
-          return { error: "selector not found: #{selector}" } unless el
+          return { error: "selector not found: #{selector}", code: "selector_not_found" } unless el
 
           # Use the DOM native click() so JS-only event listeners fire.
           # CDP mouse simulation (el.click) dispatches events at screen coordinates

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -4,6 +4,8 @@ require "timeout"
 require_relative "client"
 require_relative "errors"
 require_relative "flow_registry"
+require_relative "replay/context"
+require_relative "replay/fingerprint_matcher"
 require_relative "secret_resolvers"
 require_relative "session"
 
@@ -276,19 +278,27 @@ module Browserctl
   end
 
   class PageProxy
-    def initialize(name, client)
-      @name   = name
-      @client = client
+    attr_accessor :replay_context
+
+    def initialize(name, client, replay_context: nil, matcher: nil)
+      @name           = name
+      @client         = client
+      @replay_context = replay_context
+      @matcher        = matcher || Replay::FingerprintMatcher.new
     end
 
     def navigate(url) = unwrap @client.navigate(@name, url)
 
     def fill(selector = nil, value = nil, ref: nil)
-      unwrap @client.fill(@name, selector, value, ref: ref)
+      with_selector_fallback(:fill, selector, ref) do |sel, r|
+        @client.fill(@name, sel, value, ref: r)
+      end
     end
 
     def click(selector = nil, ref: nil)
-      unwrap @client.click(@name, selector, ref: ref)
+      with_selector_fallback(:click, selector, ref) do |sel, r|
+        @client.click(@name, sel, ref: r)
+      end
     end
 
     def snapshot(**)              = unwrap @client.snapshot(@name, **)
@@ -310,21 +320,63 @@ module Browserctl
     def press(key) = unwrap @client.press(@name, key)
 
     def hover(selector = nil, ref: nil)
-      unwrap @client.hover(@name, selector, ref: ref)
+      with_selector_fallback(:hover, selector, ref) do |sel, r|
+        @client.hover(@name, sel, ref: r)
+      end
     end
 
     def upload(selector = nil, path = nil, ref: nil)
-      unwrap @client.upload(@name, selector, path, ref: ref)
+      with_selector_fallback(:upload, selector, ref) do |sel, r|
+        @client.upload(@name, sel, path, ref: r)
+      end
     end
 
     def select(selector = nil, value = nil, ref: nil)
-      unwrap @client.select(@name, selector, value, ref: ref)
+      with_selector_fallback(:select, selector, ref) do |sel, r|
+        @client.select(@name, sel, value, ref: r)
+      end
     end
 
     def dialog_accept(text: nil) = unwrap @client.dialog_accept(@name, text: text)
     def dialog_dismiss           = unwrap @client.dialog_dismiss(@name)
 
     private
+
+    # Issues the wrapped command. If the daemon returns selector_not_found
+    # and a replay context has a fingerprint for this selector, takes a
+    # fresh snapshot, asks the matcher for a candidate, and retries by ref.
+    def with_selector_fallback(cmd, selector, ref)
+      res = yield(selector, ref)
+      return unwrap(res) if !selector_not_found?(res) || ref || !@replay_context || !selector
+
+      fp = @replay_context.fingerprint_for(selector)
+      return unwrap(res) unless fp
+
+      match = @matcher.best(fp, snapshot_entries)
+      unless match
+        @replay_context.record(command: cmd, selector: selector, reason: "no candidate above threshold")
+        return unwrap(res)
+      end
+
+      log_rematch(cmd, selector, match)
+      @replay_context.record(command: cmd, selector: selector,
+                             matched_ref: match.candidate[:ref], score: match.score, reason: "rematch")
+      unwrap(yield(nil, match.candidate[:ref]))
+    end
+
+    def snapshot_entries
+      res = @client.snapshot(@name, format: "elements")
+      Array(res[:snapshot])
+    end
+
+    def selector_not_found?(res)
+      res.is_a?(Hash) && res[:code] == "selector_not_found"
+    end
+
+    def log_rematch(cmd, selector, match)
+      warn "[browserctl replay] #{cmd} selector #{selector.inspect} not found — " \
+           "rematched to ref=#{match.candidate[:ref]} (score=#{format('%.2f', match.score)})"
+    end
 
     def unwrap(res)
       raise WorkflowError, res[:error] if res[:error]

--- a/spec/unit/replay_fallback_spec.rb
+++ b/spec/unit/replay_fallback_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/workflow"
+require "browserctl/replay/context"
+
+RSpec.describe Browserctl::PageProxy, "selector_not_found fallback" do
+  let(:client)  { instance_double(Browserctl::Client) }
+  let(:context) { Browserctl::Replay::Context.new(fingerprints: { "form .submit-old" => recorded_fp }) }
+  let(:proxy)   { described_class.new("login", client, replay_context: context) }
+
+  let(:recorded_fp) do
+    { text: "Sign in", role: "button", neighbors: ["input:"], position: { index: 5, depth: 4 } }
+  end
+
+  let(:live_snapshot) do
+    [
+      { ref: "ea11111", tag: "input", selector: "input.email",
+        fingerprint: { text: "you@example.com", role: "textbox", neighbors: [], position: { index: 1, depth: 4 } } },
+      { ref: "eb22222", tag: "button", selector: "form.v2 .btn-primary",
+        fingerprint: { text: "Sign in", role: "button", neighbors: ["input:"], position: { index: 5, depth: 4 } } }
+    ]
+  end
+
+  describe "#click" do
+    it "rematches via fingerprint when selector fails and retries by ref" do
+      expect(client).to receive(:click).with("login", "form .submit-old", ref: nil)
+                                       .and_return({ error: "selector not found: form .submit-old",
+                                                     code: "selector_not_found" })
+      expect(client).to receive(:snapshot).with("login", format: "elements")
+                                          .and_return({ ok: true, snapshot: live_snapshot })
+      expect(client).to receive(:click).with("login", nil, ref: "eb22222").and_return({ ok: true })
+
+      expect { proxy.click("form .submit-old") }.not_to raise_error
+      expect(context.drift_events.size).to eq(1)
+      expect(context.drift_events.first.matched_ref).to eq("eb22222")
+      expect(context.drift_events.first.score).to be >= 0.6
+    end
+
+    it "raises the original error when no fingerprint is registered for the selector" do
+      ctx = Browserctl::Replay::Context.new(fingerprints: {})
+      proxy = described_class.new("login", client, replay_context: ctx)
+      expect(client).to receive(:click).with("login", "form .other", ref: nil)
+                                       .and_return({ error: "selector not found: form .other",
+                                                     code: "selector_not_found" })
+
+      expect { proxy.click("form .other") }.to raise_error(Browserctl::WorkflowError, /selector not found/)
+      expect(ctx.drift_events).to be_empty
+    end
+
+    it "raises the original error when the matcher finds no candidate above threshold" do
+      cold_snapshot = [
+        { ref: "ec99999", tag: "button", selector: "x",
+          fingerprint: { text: "Cancel", role: "link", neighbors: [], position: { index: 0, depth: 0 } } }
+      ]
+      expect(client).to receive(:click).with("login", "form .submit-old", ref: nil)
+                                       .and_return({ error: "selector not found: form .submit-old",
+                                                     code: "selector_not_found" })
+      expect(client).to receive(:snapshot).and_return({ ok: true, snapshot: cold_snapshot })
+
+      expect { proxy.click("form .submit-old") }.to raise_error(Browserctl::WorkflowError)
+      expect(context.drift_events.first.reason).to eq("no candidate above threshold")
+      expect(context.drift_events.first.matched_ref).to be_nil
+    end
+
+    it "does not attempt fallback when no replay context is attached" do
+      bare = described_class.new("login", client)
+      expect(client).to receive(:click).once
+                                       .and_return({ error: "selector not found: x", code: "selector_not_found" })
+      expect(client).not_to receive(:snapshot)
+      expect { bare.click("x") }.to raise_error(Browserctl::WorkflowError)
+    end
+
+    it "does not attempt fallback for ref-driven calls" do
+      expect(client).to receive(:click).with("login", nil, ref: "eb22222")
+                                       .and_return({ ok: true })
+      expect(client).not_to receive(:snapshot)
+      proxy.click(ref: "eb22222")
+    end
+  end
+
+  describe "#fill" do
+    it "passes the value through on rematch retry" do
+      input_fp = { text: "you@example.com", role: "textbox", neighbors: [], position: { index: 1, depth: 4 } }
+      ctx = Browserctl::Replay::Context.new(fingerprints: { "input.old" => input_fp })
+      proxy = described_class.new("login", client, replay_context: ctx)
+
+      expect(client).to receive(:fill).with("login", "input.old", "me@example.com", ref: nil)
+                                      .and_return({ error: "selector not found: input.old",
+                                                    code: "selector_not_found" })
+      expect(client).to receive(:snapshot).and_return({ ok: true, snapshot: live_snapshot })
+      expect(client).to receive(:fill).with("login", nil, "me@example.com", ref: "ea11111")
+                                      .and_return({ ok: true })
+
+      proxy.fill("input.old", "me@example.com")
+    end
+  end
+end


### PR DESCRIPTION
Wires the WS-2.1 fingerprint matcher (#111) into the workflow runtime. When a recorded selector fails at replay time, PageProxy consults the replay context for a fingerprint, runs the matcher against a live snapshot, and retries the command by stable ref.

## What landed

- \`lib/browserctl/replay/context.rb\` — \`Replay::Context\` holds \`{selector => fingerprint}\` and accumulates \`DriftEvent\`s. The recording log will populate this in WS-3; the workflow runner attaches it to the proxy at run time.
- \`PageProxy\` gains \`replay_context:\` and \`matcher:\` constructor args. Selector-driven methods (\`click\`, \`fill\`, \`hover\`, \`upload\`, \`select\`) route through one \`with_selector_fallback\` helper.
- Daemon handlers (\`navigation.rb\`, \`interaction.rb\`) now tag selector-not-found errors with \`code: \"selector_not_found\"\` so the proxy can recognize them without string matching.

## Fallback policy

Fires **only** when all of:

- response carries \`code: selector_not_found\`
- the original call used a selector (not a ref)
- a \`replay_context\` is attached
- the matcher returns a candidate above its threshold

Anything else passes through to the existing \`WorkflowError\`, preserving non-replay behaviour byte-for-byte.

## Drift events

Both the rematch path (\`reason: \"rematch\"\`, with \`matched_ref\` + \`score\`) and the threshold-miss path (\`reason: \"no candidate above threshold\"\`) are recorded on the context. WS-2.3 will render these into a structured drift report.

## Type of change

- [x] New feature
- [x] Refactor (handler error shape)

## How to test

- \`bundle exec rspec spec/unit/replay_fallback_spec.rb\` — 6 examples cover rematch, missing fingerprint, threshold miss, no context, ref-driven calls, and value passthrough on retry.
- \`bundle exec rspec spec/unit\` — full suite (509 examples) green.

## Checklist

- [x] Tests added or updated
- [x] \`bundle exec rspec\` passes
- [x] \`bundle exec rubocop\` reports no offenses