### PR TITLE
feat: workflow run --check + drift report (v0.11 WS-2.3)

### DIFF
--- a/lib/browserctl/commands/workflow.rb
+++ b/lib/browserctl/commands/workflow.rb
@@ -20,13 +20,18 @@ module Browserctl
         end
       end
 
+      EXIT_CODE = { clean: 0, drift: 2, fail: 1 }.freeze
+
       def self.run_workflow(runner, args)
-        name = args.shift or abort "usage: browserctl workflow run <name|file> [--params file] [--key value ...]"
+        name = args.shift or abort \
+          "usage: browserctl workflow run <name|file> [--check] [--params file] [--key value ...]"
         if File.exist?(name)
           before = Browserctl.registry_snapshot.keys
           load File.expand_path(name)
           name = (Browserctl.registry_snapshot.keys - before).first || File.basename(name, ".rb")
         end
+
+        check = !args.delete("--check").nil?
 
         params_file_idx = args.index("--params")
         file_params = {}
@@ -47,8 +52,8 @@ module Browserctl
         end
 
         params = file_params.merge(cli_params)
-        success = runner.run_workflow(name, **params)
-        exit(success ? 0 : 1)
+        verdict = runner.run_workflow(name, check: check, **params)
+        exit(EXIT_CODE.fetch(verdict, 1))
       end
 
       def self.run_list(runner)

--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -14,13 +14,17 @@ module Browserctl
     # Runs a named workflow with the given parameters.
     # @param name [String] workflow name (must match /\A[a-zA-Z0-9_-]+\z/)
     # @param params [Hash] keyword arguments passed to the workflow
-    # @return [Boolean] true if all steps succeeded
+    # @param check [Boolean] when true, attaches a Replay::Context, renders
+    #   a drift report after the run, and signals drift via exit code 2.
+    # @return [Symbol] :clean (all ok, no drift), :drift (all ok, drift seen), :fail (any step failed)
     # @raise [WorkflowError] if the name is invalid or a step fails
-    def run_workflow(name, **params)
+    def run_workflow(name, check: false, **params)
       defn    = fetch_workflow(name)
-      results = defn.call(params, Client.new)
+      ctx     = check ? Browserctl::Replay::Context.new : nil
+      results = defn.call(params, Client.new, replay_context: ctx)
       print_results(results)
-      results.all?(&:ok)
+      print_drift_report(ctx) if check
+      verdict(results, ctx)
     end
 
     # Lists all registered workflows from the standard search paths.
@@ -107,6 +111,24 @@ module Browserctl
       label = result.ok ? "[ok]  " : "[fail]"
       msg   = result.ok ? result.name : "#{result.name}: #{result.error}"
       $stdout.puts "  #{label} #{msg}"
+    end
+
+    def print_drift_report(ctx)
+      events = ctx&.drift_events || []
+      report = {
+        drift: events.any?,
+        rematches: events.count { |e| e.reason == "rematch" },
+        unresolved: events.count { |e| e.reason == "no candidate above threshold" },
+        events: events.map(&:to_h)
+      }
+      $stdout.puts JSON.pretty_generate(report)
+    end
+
+    def verdict(results, ctx)
+      return :fail unless results.all?(&:ok)
+      return :drift if ctx&.drift_events&.any?
+
+      :clean
     end
 
     def format_params(defn)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -15,11 +15,12 @@ module Browserctl
   StepDef = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
 
   class WorkflowContext
-    attr_reader :client
+    attr_reader :client, :replay_context
 
-    def initialize(params, client)
+    def initialize(params, client, replay_context: nil)
       @params = params
       @client = client
+      @replay_context = replay_context
     end
 
     def store(key, value)
@@ -47,7 +48,7 @@ module Browserctl
     end
 
     def page(name)
-      PageProxy.new(name.to_s, @client)
+      PageProxy.new(name.to_s, @client, replay_context: @replay_context)
     end
 
     def open_page(page_name, url: nil)
@@ -416,8 +417,8 @@ module Browserctl
       @steps.concat(source.steps)
     end
 
-    def call(params, client)
-      ctx = WorkflowContext.new(resolve_params(params), client)
+    def call(params, client, replay_context: nil)
+      ctx = WorkflowContext.new(resolve_params(params), client, replay_context: replay_context)
       execute_steps(ctx)
     end
 

--- a/spec/unit/runner_check_spec.rb
+++ b/spec/unit/runner_check_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/runner"
+
+RSpec.describe Browserctl::Runner, "#run_workflow with check: true" do
+  subject(:runner) { described_class.new }
+
+  let(:client) { instance_double(Browserctl::Client) }
+
+  before { allow(Browserctl::Client).to receive(:new).and_return(client) }
+
+  def define_workflow(name, &block)
+    Browserctl.workflow(name) do
+      step("do thing", &block)
+    end
+  end
+
+  it "returns :clean and emits a no-drift report when no drift events are recorded" do
+    define_workflow("clean_run") { nil }
+    verdict = nil
+    expect { verdict = runner.run_workflow("clean_run", check: true) }
+      .to output(include('"drift": false')).to_stdout
+    expect(verdict).to eq(:clean)
+  end
+
+  it "returns :drift and rolls drift events into the report" do
+    define_workflow("drifty") do
+      replay_context.record(command: :click, selector: "form .old",
+                            matched_ref: "ea11111", score: 0.92, reason: "rematch")
+    end
+    captured = nil
+    expect { captured = runner.run_workflow("drifty", check: true) }
+      .to output(/"drift": true.*"rematches": 1/m).to_stdout
+    expect(captured).to eq(:drift)
+  end
+
+  it "returns :fail when a step raises, regardless of drift" do
+    define_workflow("breaks") { raise Browserctl::WorkflowError, "boom" }
+    expect { runner.run_workflow("breaks", check: true) }
+      .to raise_error(Browserctl::WorkflowError)
+  end
+
+  it "does not allocate a replay context when check is false" do
+    seen = nil
+    define_workflow("no_check") { seen = replay_context }
+    expect(runner.run_workflow("no_check")).to eq(:clean)
+    expect(seen).to be_nil
+  end
+end


### PR DESCRIPTION
\`browserctl workflow run --check <name>\` attaches a \`Replay::Context\` to the workflow, accumulates drift events from the WS-2.2 fallback, and emits a structured JSON report at end-of-run.

## Report shape

\`\`\`json
{
  \"drift\": true,
  \"rematches\": 2,
  \"unresolved\": 0,
  \"events\": [
    { \"command\": \"click\", \"selector\": \"form .old\",
      \"matched_ref\": \"ea11111\", \"score\": 0.92, \"reason\": \"rematch\" }
  ]
}
\`\`\`

## Exit codes

| Code | Verdict | Meaning                                           |
|------|---------|---------------------------------------------------|
| 0    | clean   | all steps ok, no drift                            |
| 1    | fail    | a step raised (existing behaviour, unchanged)     |
| 2    | drift   | all steps ok, but ≥1 selector rematched / unresolved |

Without \`--check\`, behaviour is unchanged: no replay context is allocated, no report is rendered, exit code stays 0/1.

## Plumbing

- \`Runner#run_workflow\` gains \`check:\` keyword; returns \`:clean\` | \`:drift\` (or raises on failure).
- \`WorkflowDefinition#call\` accepts \`replay_context:\`.
- \`WorkflowContext\` exposes \`replay_context\` and threads it into \`PageProxy\` via \`page()\`.

Recording-log → context population (the bit that actually populates \`{selector => fingerprint}\`) lands in WS-3. For now an empty context exercises the plumbing — \`--check\` of a fresh workflow produces a no-drift report and exit 0.

## Type of change

- [x] New feature

## How to test

- \`bundle exec rspec spec/unit/runner_check_spec.rb\` — 4 examples cover :clean, :drift, raise, and \"no context unless asked\".
- Full suite: \`bundle exec rspec spec/unit\` — 513 examples green.

## Checklist

- [x] Tests added or updated
- [x] \`bundle exec rspec\` passes
- [x] \`bundle exec rubocop\` reports no offenses