### PR TITLE
feat: drift telemetry (v0.11 WS-2.4)

### DIFF
--- a/lib/browserctl/replay/telemetry.rb
+++ b/lib/browserctl/replay/telemetry.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require_relative "../constants"
+
+module Browserctl
+  module Replay
+    # Append-only JSONL log of replay drift events for offline analysis.
+    # Local-only; nothing is uploaded. One line per event.
+    module Telemetry
+      LOG_BASENAME = "replay_drift.jsonl"
+
+      module_function
+
+      def log_path
+        File.join(Browserctl::BROWSERCTL_DIR, LOG_BASENAME)
+      end
+
+      # Write each drift event from a Replay::Context as its own JSONL line.
+      # @param ctx [Browserctl::Replay::Context, nil]
+      # @param workflow [String] workflow name for cross-reference
+      # @param path [String] override the destination (testing)
+      # @return [Integer] number of events written
+      def emit(ctx, workflow:, path: log_path)
+        events = ctx&.drift_events
+        return 0 if events.nil? || events.empty?
+
+        ensure_log_file(path)
+        ts = Time.now.utc.iso8601
+        File.open(path, "a") do |f|
+          events.each do |e|
+            f.puts JSON.generate(
+              event: "replay_drift",
+              ts: ts,
+              workflow: workflow,
+              command: e.command.to_s,
+              selector: e.selector,
+              matched_ref: e.matched_ref,
+              score: e.score,
+              reason: e.reason
+            )
+          end
+        end
+        events.size
+      rescue SystemCallError, IOError
+        # Telemetry must never break a run.
+        0
+      end
+
+      def ensure_log_file(path)
+        FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
+        return if File.exist?(path)
+
+        FileUtils.touch(path)
+        File.chmod(0o600, path)
+      end
+    end
+  end
+end

--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -3,6 +3,7 @@
 require "json"
 require_relative "workflow"
 require_relative "client"
+require_relative "replay/telemetry"
 
 module Browserctl
   class Runner
@@ -23,7 +24,10 @@ module Browserctl
       ctx     = check ? Browserctl::Replay::Context.new : nil
       results = defn.call(params, Client.new, replay_context: ctx)
       print_results(results)
-      print_drift_report(ctx) if check
+      if check
+        print_drift_report(ctx)
+        Browserctl::Replay::Telemetry.emit(ctx, workflow: name.to_s)
+      end
       verdict(results, ctx)
     end
 

--- a/spec/unit/replay_telemetry_spec.rb
+++ b/spec/unit/replay_telemetry_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "browserctl/replay/context"
+require "browserctl/replay/telemetry"
+
+RSpec.describe Browserctl::Replay::Telemetry do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:path)   { File.join(tmpdir, "replay_drift.jsonl") }
+
+  after { FileUtils.remove_entry(tmpdir) if File.directory?(tmpdir) }
+
+  it "writes one JSONL line per drift event" do
+    ctx = Browserctl::Replay::Context.new
+    ctx.record(command: :click, selector: ".old", matched_ref: "ea1", score: 0.91, reason: "rematch")
+    ctx.record(command: :fill, selector: "#email", matched_ref: nil,
+               score: 0.40, reason: "no candidate above threshold")
+
+    written = described_class.emit(ctx, workflow: "demo", path: path)
+    expect(written).to eq(2)
+
+    lines = File.readlines(path).map { |l| JSON.parse(l) }
+    expect(lines.size).to eq(2)
+    expect(lines[0]).to include(
+      "event" => "replay_drift",
+      "workflow" => "demo",
+      "command" => "click",
+      "selector" => ".old",
+      "matched_ref" => "ea1",
+      "score" => 0.91,
+      "reason" => "rematch"
+    )
+    expect(lines[0]).to have_key("ts")
+    expect(lines[1]["reason"]).to eq("no candidate above threshold")
+  end
+
+  it "appends to an existing log without truncating prior runs" do
+    File.write(path, %({"event":"replay_drift","workflow":"prior"}\n))
+    ctx = Browserctl::Replay::Context.new
+    ctx.record(command: :click, selector: ".x", matched_ref: "ea2", score: 0.95, reason: "rematch")
+
+    described_class.emit(ctx, workflow: "demo", path: path)
+    lines = File.readlines(path)
+    expect(lines.size).to eq(2)
+    expect(JSON.parse(lines[0])["workflow"]).to eq("prior")
+    expect(JSON.parse(lines[1])["workflow"]).to eq("demo")
+  end
+
+  it "is a no-op when there are no drift events" do
+    ctx = Browserctl::Replay::Context.new
+    expect(described_class.emit(ctx, workflow: "demo", path: path)).to eq(0)
+    expect(File.exist?(path)).to be(false)
+  end
+
+  it "is a no-op when ctx is nil" do
+    expect(described_class.emit(nil, workflow: "demo", path: path)).to eq(0)
+    expect(File.exist?(path)).to be(false)
+  end
+
+  it "creates the log file with 0600 permissions on first write" do
+    ctx = Browserctl::Replay::Context.new
+    ctx.record(command: :click, selector: ".x", matched_ref: "ea2", score: 0.95, reason: "rematch")
+    described_class.emit(ctx, workflow: "demo", path: path)
+    mode = File.stat(path).mode & 0o777
+    expect(mode).to eq(0o600)
+  end
+end

--- a/spec/unit/runner_check_spec.rb
+++ b/spec/unit/runner_check_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe Browserctl::Runner, "#run_workflow with check: true" do
 
   let(:client) { instance_double(Browserctl::Client) }
 
-  before { allow(Browserctl::Client).to receive(:new).and_return(client) }
+  before do
+    allow(Browserctl::Client).to receive(:new).and_return(client)
+    allow(Browserctl::Replay::Telemetry).to receive(:emit).and_return(0)
+  end
 
   def define_workflow(name, &block)
     Browserctl.workflow(name) do
@@ -33,6 +36,24 @@ RSpec.describe Browserctl::Runner, "#run_workflow with check: true" do
     expect { captured = runner.run_workflow("drifty", check: true) }
       .to output(/"drift": true.*"rematches": 1/m).to_stdout
     expect(captured).to eq(:drift)
+  end
+
+  it "emits drift telemetry on the check path" do
+    define_workflow("telemetry") do
+      replay_context.record(command: :click, selector: ".old",
+                            matched_ref: "eabc", score: 0.9, reason: "rematch")
+    end
+    expect(Browserctl::Replay::Telemetry).to receive(:emit) do |ctx, workflow:|
+      expect(workflow).to eq("telemetry")
+      expect(ctx.drift_events.size).to eq(1)
+    end.and_return(1)
+    expect { runner.run_workflow("telemetry", check: true) }.to output.to_stdout
+  end
+
+  it "does not emit telemetry when check is false" do
+    define_workflow("no_check_telemetry") { nil }
+    expect(Browserctl::Replay::Telemetry).not_to receive(:emit)
+    runner.run_workflow("no_check_telemetry")
   end
 
   it "returns :fail when a step raises, regardless of drift" do


### PR DESCRIPTION
## Summary

- Append `replay_drift` events to `~/.browserctl/replay_drift.jsonl` as one JSON object per line for offline analysis.
- Local only — nothing is uploaded.
- Wired into `Runner#run_workflow` only on the `--check` path, after the human-readable drift report is printed.
- Telemetry write failures are swallowed: a broken log file must never break a workflow run.

Implements PR #9 of `docs/plans/v0.11-replayable.md` (WS-2 · Self-healing replay).

### Event shape

```json
{"event":"replay_drift","ts":"2026-05-10T01:23:45Z","workflow":"my_flow","command":"click","selector":".old","matched_ref":"eabc123","score":0.91,"reason":"rematch"}
```

`reason` is either `"rematch"` (fingerprint match succeeded) or `"no candidate above threshold"` (drift seen but unresolved).

## Test plan

- [x] `spec/unit/replay_telemetry_spec.rb` — JSONL shape, append semantics, no-op on empty/nil, 0600 perms on first write
- [x] `spec/unit/runner_check_spec.rb` — telemetry emitted only on `--check`, never on plain runs
- [x] Full `bundle exec rspec spec/unit` (520 examples, 0 failures)
- [x] `bundle exec rubocop` clean