### PR TITLE
feat: enriched recording log (v0.11 WS-3.1)

### DIFF
--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -15,7 +15,7 @@ module Browserctl
 
     def call(cmd, **params)
       result = communicate(JSON.generate({ cmd: cmd }.merge(params)))
-      Recording.append(cmd, **params) if result[:ok]
+      Recording.append(cmd, response: result, **params) if result[:ok]
       result
     rescue Errno::ENOENT, Errno::ECONNREFUSED
       raise DaemonUnavailableError, "browserd is not running — start it with: browserd"

--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "date"
+require "time"
 require "fileutils"
 require "tmpdir"
 require "uri"
@@ -15,6 +16,10 @@ module Browserctl
 
     SENSITIVE_PARAM_PATTERN = /\A(token|key|secret|auth|code|access_token|api_key|client_secret|state)\z/ix
 
+    # Bumped when the recording log shape changes in a way that older
+    # tooling (workflow generate, replay) cannot read.
+    LOG_FORMAT = "v0.11"
+
     def self.start(name)
       FileUtils.mkdir_p(RECORDINGS_DIR, mode: 0o700)
       FileUtils.mkdir_p(File.dirname(STATE_FILE))
@@ -22,6 +27,14 @@ module Browserctl
       FileUtils.rm_f(log_path(name))
       FileUtils.touch(log_path(name))
       File.chmod(0o600, log_path(name))
+      File.open(log_path(name), "a") do |f|
+        f.puts JSON.generate(
+          cmd: "_meta",
+          log_format: LOG_FORMAT,
+          recording: name,
+          started_at: Time.now.utc.iso8601
+        )
+      end
       name
     end
 
@@ -37,20 +50,22 @@ module Browserctl
       File.exist?(STATE_FILE) ? File.read(STATE_FILE).strip : nil
     end
 
-    def self.append(cmd, **attrs)
+    def self.append(cmd, response: nil, **attrs)
       name = active
       return unless name
       return unless RECORDABLE.include?(cmd.to_s)
 
       if %w[click fill].include?(cmd.to_s) && attrs[:selector].nil?
-        record_ref_interaction(name, cmd.to_s, attrs)
+        record_ref_interaction(name, cmd.to_s, attrs, response)
         return
       end
 
       attrs = prepare_attrs(cmd.to_s, attrs)
+      entry = { cmd: cmd.to_s }.merge(attrs.transform_keys(&:to_s))
+      entry.merge!(replay_metadata(response)) if response
 
       File.open(log_path(name), "a") do |f|
-        f.puts JSON.generate({ cmd: cmd.to_s }.merge(attrs.transform_keys(&:to_s)))
+        f.puts JSON.generate(entry)
       end
     end
 
@@ -58,7 +73,8 @@ module Browserctl
       log = log_path(name)
       raise "no recording found for '#{name}'" unless File.exist?(log)
 
-      lines = File.readlines(log).map { |l| JSON.parse(l, symbolize_names: true) }
+      raw   = File.readlines(log).map { |l| JSON.parse(l, symbolize_names: true) }
+      lines = raw.reject { |l| l[:cmd] == "_meta" }
       ruby  = build_workflow_ruby(name, lines)
       File.write(output_path, ruby) if output_path
 
@@ -80,11 +96,24 @@ module Browserctl
         File.join(RECORDINGS_DIR, "#{name}.jsonl")
       end
 
-      def record_ref_interaction(recording_name, cmd, attrs)
+      def record_ref_interaction(recording_name, cmd, attrs, response)
         entry = { cmd: "_ref_interaction", action: cmd, ref: attrs[:ref], name: attrs[:name] }
+        entry.merge!(replay_metadata(response)) if response
         File.open(log_path(recording_name), "a") do |f|
           f.puts JSON.generate(entry)
         end
+      end
+
+      # Pulls the replay-relevant fields out of a daemon response. Each
+      # is optional — older daemons or non-resolving commands may omit
+      # any of them.
+      def replay_metadata(response)
+        meta = {}
+        meta[:ref]                = response[:ref]                if response[:ref]
+        meta[:fingerprint]        = response[:fingerprint]        if response[:fingerprint]
+        meta[:snapshot_id]        = response[:snapshot_id]        if response[:snapshot_id]
+        meta[:postcondition_hint] = response[:postcondition_hint] if response[:postcondition_hint]
+        meta.transform_keys(&:to_s)
       end
 
       def build_workflow_ruby(name, commands)

--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -33,7 +33,8 @@ module Browserctl
             sel = resolve_selector_from(session, req)
             return sel if sel.is_a?(Hash)
 
-            type_into(session.page, sel, req[:value])
+            result = type_into(session.page, sel, req[:value])
+            enrich_with_recording_metadata(result, session, sel, req)
           end
         end
 
@@ -42,8 +43,24 @@ module Browserctl
             sel = resolve_selector_from(session, req)
             return sel if sel.is_a?(Hash)
 
-            click_element(session.page, sel)
+            result = click_element(session.page, sel)
+            enrich_with_recording_metadata(result, session, sel, req)
           end
+        end
+
+        # Adds ref / fingerprint / snapshot_id / postcondition_hint to a successful
+        # click/fill response. Recording uses these to build a self-healing log.
+        def enrich_with_recording_metadata(result, session, selector, req)
+          return result unless result[:ok]
+
+          ref = req[:ref] || session.ref_registry.invert[selector]
+          fp  = (ref && session.fingerprint_index[ref]) || session.fingerprint_index[selector]
+          result.merge(
+            ref: ref,
+            fingerprint: fp,
+            snapshot_id: session.snapshot_id,
+            postcondition_hint: { url: session.page.current_url }
+          ).compact
         end
 
         def cmd_url(req)

--- a/lib/browserctl/server/handlers/observation.rb
+++ b/lib/browserctl/server/handlers/observation.rb
@@ -44,13 +44,30 @@ module Browserctl
 
           snapshot = @snapshot_builder.call(session.page)
           registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }
+          fp_index = build_fingerprint_index(snapshot)
 
           prev = session.prev_snapshot
-          session.ref_registry  = registry
-          session.prev_snapshot = snapshot
+          session.ref_registry      = registry
+          session.fingerprint_index = fp_index
+          session.snapshot_id       = nonce
+          session.prev_snapshot     = snapshot
           result = diff && prev ? compute_diff(prev, snapshot) : snapshot
 
           { ok: true, snapshot: result, challenge: challenge, nonce: nonce }
+        end
+
+        def build_fingerprint_index(snapshot)
+          index = {}
+          snapshot.each do |el|
+            ref = el[:ref]
+            sel = el[:selector]
+            fp  = el[:fingerprint]
+            next unless fp
+
+            index[ref] = fp if ref
+            index[sel] = fp if sel
+          end
+          index
         end
 
         def compute_diff(prev, current)

--- a/lib/browserctl/server/page_session.rb
+++ b/lib/browserctl/server/page_session.rb
@@ -3,15 +3,17 @@
 module Browserctl
   class PageSession
     attr_reader :page, :mutex, :pause_cv
-    attr_accessor :ref_registry, :prev_snapshot
+    attr_accessor :ref_registry, :prev_snapshot, :fingerprint_index, :snapshot_id
 
     def initialize(page)
-      @page          = page
-      @mutex         = Mutex.new
-      @pause_cv      = ConditionVariable.new
-      @ref_registry  = {}
-      @prev_snapshot = nil
-      @paused        = false
+      @page              = page
+      @mutex             = Mutex.new
+      @pause_cv          = ConditionVariable.new
+      @ref_registry      = {}
+      @fingerprint_index = {}
+      @snapshot_id       = nil
+      @prev_snapshot     = nil
+      @paused            = false
     end
 
     def paused? = @paused

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe Browserctl::Recording do
       described_class.start("test")
       described_class.append("ping")
       log = File.join(@tmp_dir, "test.jsonl")
-      expect(File.read(log)).to be_empty
+      lines = File.readlines(log).map { |l| JSON.parse(l) }
+      expect(lines.size).to eq(1) # only the _meta header
+      expect(lines.first["cmd"]).to eq("_meta")
     end
 
     it "does nothing when no active recording" do
@@ -92,6 +94,57 @@ RSpec.describe Browserctl::Recording do
     end
   end
 
+  describe "enriched recording log (v0.11)" do
+    before { described_class.start("rich") }
+
+    it "writes a _meta header as the first line on start" do
+      log = File.readlines(File.join(@tmp_dir, "rich.jsonl"))
+      meta = JSON.parse(log.first)
+      expect(meta).to include(
+        "cmd" => "_meta",
+        "log_format" => Browserctl::Recording::LOG_FORMAT,
+        "recording" => "rich"
+      )
+      expect(meta["started_at"]).to match(/\A\d{4}-\d{2}-\d{2}T/)
+    end
+
+    it "captures ref / fingerprint / snapshot_id / postcondition_hint from the daemon response" do
+      response = {
+        ok: true,
+        ref: "ea1b2c3",
+        fingerprint: { text: "Sign in", role: "button" },
+        snapshot_id: "deadbeef00",
+        postcondition_hint: { url: "https://example.com/dashboard" }
+      }
+      described_class.append("click", response: response, name: "main", selector: "button.sign-in")
+      log = File.readlines(File.join(@tmp_dir, "rich.jsonl"))
+      entry = JSON.parse(log.last)
+      expect(entry).to include(
+        "cmd" => "click",
+        "selector" => "button.sign-in",
+        "ref" => "ea1b2c3",
+        "snapshot_id" => "deadbeef00"
+      )
+      expect(entry["fingerprint"]).to include("text" => "Sign in", "role" => "button")
+      expect(entry["postcondition_hint"]).to eq({ "url" => "https://example.com/dashboard" })
+    end
+
+    it "omits replay metadata fields the response doesn't supply" do
+      described_class.append("click", response: { ok: true }, name: "main", selector: "button")
+      entry = JSON.parse(File.readlines(File.join(@tmp_dir, "rich.jsonl")).last)
+      expect(entry).not_to have_key("ref")
+      expect(entry).not_to have_key("fingerprint")
+      expect(entry).not_to have_key("snapshot_id")
+    end
+
+    it "skips _meta lines when generating a workflow" do
+      described_class.append("page_open", name: "cart", url: "https://example.com/cart")
+      ruby = described_class.generate_workflow("rich")
+      expect(ruby).not_to include("_meta")
+      expect(ruby).to include('page(:cart).navigate("https://example.com/cart")')
+    end
+  end
+
   describe "secure file permissions" do
     it "creates the JSONL file with mode 0600" do
       described_class.start("secure_test")
@@ -106,8 +159,8 @@ RSpec.describe Browserctl::Recording do
 
     it "redacts sensitive query params in navigate URLs" do
       described_class.append("navigate", name: "main", url: "https://example.com/auth?token=abc123&page=1")
-      log = File.read(File.join(@tmp_dir, "redact_test.jsonl"))
-      parsed = JSON.parse(log.strip)
+      log = File.readlines(File.join(@tmp_dir, "redact_test.jsonl"))
+      parsed = JSON.parse(log.last)
       expect(parsed["url"]).to include("[REDACTED]")
       expect(parsed["url"]).not_to include("abc123")
       expect(parsed["url"]).to include("page=1")
@@ -115,24 +168,24 @@ RSpec.describe Browserctl::Recording do
 
     it "redacts sensitive params in page_open URLs" do
       described_class.append("page_open", name: "main", url: "https://example.com/?code=xyz&ref=home")
-      log = File.read(File.join(@tmp_dir, "redact_test.jsonl"))
-      parsed = JSON.parse(log.strip)
+      log = File.readlines(File.join(@tmp_dir, "redact_test.jsonl"))
+      parsed = JSON.parse(log.last)
       expect(parsed["url"]).to include("[REDACTED]")
       expect(parsed["url"]).to include("ref=home")
     end
 
     it "does not redact clean URLs" do
       described_class.append("navigate", name: "main", url: "https://example.com/path?page=2&sort=asc")
-      log = File.read(File.join(@tmp_dir, "redact_test.jsonl"))
-      parsed = JSON.parse(log.strip)
+      log = File.readlines(File.join(@tmp_dir, "redact_test.jsonl"))
+      parsed = JSON.parse(log.last)
       expect(parsed["url"]).to eq("https://example.com/path?page=2&sort=asc")
     end
 
     it "returns the original URL on malformed input" do
       bad_url = "not a valid url ][]["
       described_class.append("navigate", name: "main", url: bad_url)
-      log = File.read(File.join(@tmp_dir, "redact_test.jsonl"))
-      parsed = JSON.parse(log.strip)
+      log = File.readlines(File.join(@tmp_dir, "redact_test.jsonl"))
+      parsed = JSON.parse(log.last)
       expect(parsed["url"]).to eq(bad_url)
     end
 


### PR DESCRIPTION
## Summary

Recording log now captures the replay-relevant metadata each event needs to self-heal under drift:

- `ref` + `fingerprint` — pulled from the latest snapshot's index, kept on `PageSession`
- `snapshot_id` — the nonce returned by the snapshot command, so events tie back to a specific DOM observation
- `postcondition_hint: { url: ... }` — the page URL after a `click` / `fill`, used by `workflow run --check` to detect post-step drift
- `_meta` header line written on `record start`, carrying `log_format` and `started_at`

Server-side: `cmd_click` / `cmd_fill` enrich the response with the four fields above. `cmd_snapshot` builds a fingerprint index on the session keyed by both ref and selector.

Client-side: `Client#call` forwards the daemon response into `Recording.append` so the new fields land in the JSONL log without leaking into request params.

This replaces the v0.2 log format; bumps `Recording::LOG_FORMAT` to `v0.11`. Generators ignore `_meta` lines, so the format change is transparent to existing `workflow generate` output. Implements PR #10 of `docs/plans/v0.11-replayable.md` (WS-3 · recording → workflow → flow pipeline).

## Test plan

- [x] `spec/unit/recording_spec.rb` — _meta header on start, replay-metadata round-trip, missing-fields tolerated, `_meta` skipped in generated workflow
- [x] Existing redaction / fill / generate specs updated to match the new file shape
- [x] Full `bundle exec rspec spec/unit` (524 examples, 0 failures)
- [x] `bundle exec rubocop lib spec` clean