### PR TITLE
feat: workflow generate (v0.11 WS-3.2)

### DIFF
--- a/lib/browserctl/commands/workflow.rb
+++ b/lib/browserctl/commands/workflow.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "json"
 require_relative "cli_output"
+require_relative "../recording"
 
 module Browserctl
   module Commands
     module Workflow
       extend CliOutput
 
-      USAGE = "Usage: browserctl workflow <run|list|describe> [args]"
+      USAGE = "Usage: browserctl workflow <run|list|describe|generate> [args]"
 
       def self.run(runner, args)
         sub = args.shift or abort USAGE
@@ -16,8 +18,25 @@ module Browserctl
         when "run"      then run_workflow(runner, args)
         when "list"     then run_list(runner)
         when "describe" then run_describe(runner, args)
+        when "generate" then run_generate(args)
         else abort "unknown workflow subcommand '#{sub}'\n#{USAGE}"
         end
+      end
+
+      def self.run_generate(args)
+        name = args.shift or abort \
+          "usage: browserctl workflow generate <recording> [--out PATH]"
+        out_idx = args.index("--out")
+        out = if out_idx
+                args.delete_at(out_idx + 1).tap { args.delete_at(out_idx) }
+              else
+                File.join(".browserctl/workflows", "#{name}.rb")
+              end
+        FileUtils.mkdir_p(File.dirname(out))
+        Browserctl::Recording.generate_workflow(name, output_path: out, keep_log: true)
+        puts JSON.generate({ ok: true, name: name, path: out })
+      rescue StandardError => e
+        abort "Error generating workflow: #{e.message}"
       end
 
       EXIT_CODE = { clean: 0, drift: 2, fail: 1 }.freeze

--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -16,6 +16,11 @@ module Browserctl
 
     SENSITIVE_PARAM_PATTERN = /\A(token|key|secret|auth|code|access_token|api_key|client_secret|state)\z/ix
 
+    # Selector tokens that signal a fill is targeting a secret-shaped field.
+    # The captured group (or matched substring) is used as the inferred field
+    # name; that name later drives the generated `secret_ref:` placeholder.
+    SECRET_FIELD_PATTERN = /\b(password|passwd|api[_-]?key|token|secret|otp|pin|client[_-]?secret|access[_-]?token)\b/i
+
     # Bumped when the recording log shape changes in a way that older
     # tooling (workflow generate, replay) cannot read.
     LOG_FORMAT = "v0.11"
@@ -69,7 +74,7 @@ module Browserctl
       end
     end
 
-    def self.generate_workflow(name, output_path: nil)
+    def self.generate_workflow(name, output_path: nil, keep_log: false)
       log = log_path(name)
       raise "no recording found for '#{name}'" unless File.exist?(log)
 
@@ -77,16 +82,18 @@ module Browserctl
       lines = raw.reject { |l| l[:cmd] == "_meta" }
       ruby  = build_workflow_ruby(name, lines)
       File.write(output_path, ruby) if output_path
-
-      ref_count = lines.count { |l| l[:cmd] == "_ref_interaction" }
-      if ref_count.positive?
-        warn "Warning: #{ref_count} ref-based interaction(s) were captured but cannot be replayed by ref."
-        warn "Search the generated workflow for 'TODO: ref-based' and replace with stable CSS selectors."
-      end
-
+      warn_about_ref_interactions(lines)
       ruby
     ensure
-      FileUtils.rm_f(log) if log
+      FileUtils.rm_f(log) if log && !keep_log
+    end
+
+    def self.warn_about_ref_interactions(lines)
+      ref_count = lines.count { |l| l[:cmd] == "_ref_interaction" }
+      return unless ref_count.positive?
+
+      warn "Warning: #{ref_count} ref-based interaction(s) were captured but cannot be replayed by ref."
+      warn "Search the generated workflow for 'TODO: ref-based' and replace with stable CSS selectors."
     end
 
     class << self
@@ -117,16 +124,27 @@ module Browserctl
       end
 
       def build_workflow_ruby(name, commands)
-        steps = commands.map { |c| build_step(c) }.join("\n\n")
+        steps   = commands.map { |c| build_step(c) }.join("\n\n")
+        secrets = commands.map { |c| c[:secret_field] }.compact.uniq
+        header  = secret_header(secrets)
         <<~RUBY
           # frozen_string_literal: true
-
+          #{header}
           Browserctl.workflow #{name.inspect} do
             desc "Recorded on #{Date.today}"
-
+          #{secrets.map { |f| "  param :secret_#{f}, secret: true" }.join("\n")}
           #{steps.gsub(/^/, '  ')}
           end
         RUBY
+      end
+
+      def secret_header(secrets)
+        return "" if secrets.empty?
+
+        lines = ["# TODO: review the following secret-shaped fields detected during recording.",
+                 "# Configure a secret_ref: source for each before running:"]
+        secrets.each { |f| lines << "#   - secret_#{f}" }
+        "\n#{lines.join("\n")}\n"
       end
 
       def build_step(cmd)
@@ -142,12 +160,13 @@ module Browserctl
                  "# end"
         end
 
-        url = cmd[:url].to_s
-        if url.include?("[REDACTED]")
-          "# NOTE: sensitive query params were redacted during recording\nstep #{label.inspect} do\n  #{body}\nend"
-        else
-          "step #{label.inspect} do\n  #{body}\nend"
-        end
+        prefix = []
+        prefix << "# NOTE: sensitive query params were redacted during recording" \
+          if cmd[:url].to_s.include?("[REDACTED]")
+        prefix << "# fingerprint fallback: #{cmd[:fingerprint].to_json}" if cmd[:fingerprint]
+
+        head = prefix.empty? ? "" : "#{prefix.join("\n")}\n"
+        "#{head}step #{label.inspect} do\n  #{body}\nend"
       end
 
       def step_parts(cmd)
@@ -172,8 +191,9 @@ module Browserctl
         page = cmd[:name]
         case cmd[:cmd]
         when "fill"
+          value_arg = cmd[:secret_field] ? "params[:secret_#{cmd[:secret_field]}]" : "params[:fill_value]"
           ["fill #{cmd[:selector]} on #{page}",
-           "page(:#{page}).fill(#{cmd[:selector].inspect}, params[:fill_value])"]
+           "page(:#{page}).fill(#{cmd[:selector].inspect}, #{value_arg})"]
         when "click"
           ["click #{cmd[:selector]} on #{page}",
            "page(:#{page}).click(#{cmd[:selector].inspect})"]
@@ -181,9 +201,25 @@ module Browserctl
       end
 
       def prepare_attrs(cmd, attrs)
-        attrs = attrs.except(:value) if cmd == "fill"
+        if cmd == "fill"
+          attrs = attrs.except(:value)
+          field = infer_secret_field(attrs[:selector])
+          if field
+            attrs[:secret_hint]  = true
+            attrs[:secret_field] = field
+          end
+        end
         attrs[:url] = redact_url(attrs[:url]) if %w[navigate page_open].include?(cmd) && attrs[:url]
         attrs
+      end
+
+      def infer_secret_field(selector)
+        return nil unless selector
+
+        match = selector.match(SECRET_FIELD_PATTERN)
+        return nil unless match
+
+        match[1].downcase.gsub(/[^a-z0-9]/, "_")
       end
 
       def redact_url(url)

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -145,6 +145,58 @@ RSpec.describe Browserctl::Recording do
     end
   end
 
+  describe "workflow generate (v0.11 WS-3.2)" do
+    before { described_class.start("gen") }
+
+    it "marks fills against secret-shaped fields with secret_hint and secret_field" do
+      described_class.append("fill", name: "login", selector: 'input[name="password"]', value: "hunter2")
+      entry = JSON.parse(File.readlines(File.join(@tmp_dir, "gen.jsonl")).last)
+      expect(entry).to include("secret_hint" => true, "secret_field" => "password")
+      expect(entry).not_to have_key("value")
+    end
+
+    it "ignores non-secret fills" do
+      described_class.append("fill", name: "login", selector: 'input[name="email"]', value: "a@b.c")
+      entry = JSON.parse(File.readlines(File.join(@tmp_dir, "gen.jsonl")).last)
+      expect(entry).not_to have_key("secret_hint")
+    end
+
+    it "emits secret_ref params and TODO header in the generated workflow" do
+      described_class.append("fill", name: "login", selector: 'input[name="api_key"]', value: "k")
+      described_class.append("fill", name: "login", selector: 'input[type="password"]', value: "p")
+      ruby = described_class.generate_workflow("gen", keep_log: true)
+      expect(ruby).to include("# TODO: review the following secret-shaped fields")
+      expect(ruby).to include("#   - secret_api_key")
+      expect(ruby).to include("#   - secret_password")
+      expect(ruby).to include("param :secret_api_key, secret: true")
+      expect(ruby).to include("page(:login).fill(\"input[name=\\\"api_key\\\"]\", params[:secret_api_key])")
+      expect(ruby).to include("page(:login).fill(\"input[type=\\\"password\\\"]\", params[:secret_password])")
+    end
+
+    it "emits a fingerprint fallback comment when the recorded event has one" do
+      described_class.append(
+        "click",
+        response: { ok: true, fingerprint: { text: "Sign in", role: "button" } },
+        name: "login", selector: "button.go"
+      )
+      ruby = described_class.generate_workflow("gen", keep_log: true)
+      expect(ruby).to match(/# fingerprint fallback: \{.*"text":"Sign in".*\}/)
+      expect(ruby).to include('page(:login).click("button.go")')
+    end
+
+    it "keeps the recording log when keep_log: true" do
+      described_class.append("click", name: "p", selector: "a")
+      described_class.generate_workflow("gen", keep_log: true)
+      expect(File.exist?(File.join(@tmp_dir, "gen.jsonl"))).to be(true)
+    end
+
+    it "deletes the log by default (record stop semantics)" do
+      described_class.append("click", name: "p", selector: "a")
+      described_class.generate_workflow("gen")
+      expect(File.exist?(File.join(@tmp_dir, "gen.jsonl"))).to be(false)
+    end
+  end
+
   describe "secure file permissions" do
     it "creates the JSONL file with mode 0600" do
       described_class.start("secure_test")

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -153,4 +153,23 @@ RSpec.describe Browserctl::Commands::Workflow do
       expect(parsed["workflows"].first["name"]).to eq("login")
     end
   end
+
+  describe ".run generate" do
+    it "calls Recording.generate_workflow with keep_log: true and reports the output path" do
+      allow(FileUtils).to receive(:mkdir_p)
+      expect(Browserctl::Recording).to receive(:generate_workflow)
+        .with("checkout", output_path: a_string_including("checkout.rb"), keep_log: true)
+      output = capture_stdout { described_class.run(double, %w[generate checkout]) }
+      parsed = JSON.parse(output)
+      expect(parsed).to include("ok" => true, "name" => "checkout")
+      expect(parsed["path"]).to include("checkout.rb")
+    end
+
+    it "honours --out PATH" do
+      allow(FileUtils).to receive(:mkdir_p)
+      expect(Browserctl::Recording).to receive(:generate_workflow)
+        .with("checkout", output_path: "/tmp/foo.rb", keep_log: true)
+      capture_stdout { described_class.run(double, %w[generate checkout --out /tmp/foo.rb]) }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds \`browserctl workflow generate <recording> [--out PATH]\` — a non-destructive generator that emits a Ruby workflow from a recording log without deleting it.

- **Stable selectors first.** The CSS selector recorded at capture time drives \`page(:x).fill/click\`.
- **Fingerprint fallback as comments.** When the recording carries a fingerprint (from WS-3.1), the generator surfaces it as a \`# fingerprint fallback: …\` comment above the step body so a reader understands what the replay layer will rematch against.
- **Auto-detect secret-shaped fills.** Selectors targeting password / api_key / token / otp / pin / client_secret / access_token rewrite \`params[:fill_value]\` to \`params[:secret_<field>]\`, declare \`param :secret_<field>, secret: true\`, and add a top-of-file TODO block listing every detected candidate so the user knows which secret_refs to wire up before running.
- \`Recording.generate_workflow\` gains \`keep_log:\` (default \`false\` preserves the v0.2 \`record stop\` behaviour). The new CLI passes \`keep_log: true\` so the recording can be regenerated.

Implements PR #11 of \`docs/plans/v0.11-replayable.md\` (WS-3 · recording → workflow → flow pipeline).

## Test plan

- [x] \`spec/unit/recording_spec.rb\` — secret-field inference, fingerprint comment emission, secret_ref param + TODO header, log keep/delete semantics
- [x] \`spec/unit/runner_spec.rb\` — \`workflow generate <name>\` and \`--out PATH\` invoke \`Recording.generate_workflow\` with \`keep_log: true\`
- [x] Full \`bundle exec rspec spec/unit\` (532 examples, 0 failures)
- [x] \`bundle exec rubocop lib spec\` clean