### PR TITLE
feat: inferred waits (v0.11 WS-3.3)

### DIFF
--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -21,6 +21,13 @@ module Browserctl
     # name; that name later drives the generated `secret_ref:` placeholder.
     SECRET_FIELD_PATTERN = /\b(password|passwd|api[_-]?key|token|secret|otp|pin|client[_-]?secret|access[_-]?token)\b/i
 
+    # Conservative thresholds for inferring an explicit wait between recorded
+    # steps. Gaps shorter than the threshold come from natural input cadence;
+    # gaps above it usually mean the page actually had work to do.
+    WAIT_THRESHOLD_SECONDS = 1.5
+    WAIT_PADDING_SECONDS   = 5
+    WAIT_FLOOR_SECONDS     = 5
+
     # Bumped when the recording log shape changes in a way that older
     # tooling (workflow generate, replay) cannot read.
     LOG_FORMAT = "v0.11"
@@ -66,7 +73,7 @@ module Browserctl
       end
 
       attrs = prepare_attrs(cmd.to_s, attrs)
-      entry = { cmd: cmd.to_s }.merge(attrs.transform_keys(&:to_s))
+      entry = { cmd: cmd.to_s, ts: now }.merge(attrs.transform_keys(&:to_s))
       entry.merge!(replay_metadata(response)) if response
 
       File.open(log_path(name), "a") do |f|
@@ -104,7 +111,7 @@ module Browserctl
       end
 
       def record_ref_interaction(recording_name, cmd, attrs, response)
-        entry = { cmd: "_ref_interaction", action: cmd, ref: attrs[:ref], name: attrs[:name] }
+        entry = { cmd: "_ref_interaction", ts: now, action: cmd, ref: attrs[:ref], name: attrs[:name] }
         entry.merge!(replay_metadata(response)) if response
         File.open(log_path(recording_name), "a") do |f|
           f.puts JSON.generate(entry)
@@ -114,6 +121,10 @@ module Browserctl
       # Pulls the replay-relevant fields out of a daemon response. Each
       # is optional — older daemons or non-resolving commands may omit
       # any of them.
+      def now
+        Time.now.utc.to_f
+      end
+
       def replay_metadata(response)
         meta = {}
         meta[:ref]                = response[:ref]                if response[:ref]
@@ -124,7 +135,7 @@ module Browserctl
       end
 
       def build_workflow_ruby(name, commands)
-        steps   = commands.map { |c| build_step(c) }.join("\n\n")
+        steps   = annotated_steps(commands).join("\n\n")
         secrets = commands.map { |c| c[:secret_field] }.compact.uniq
         header  = secret_header(secrets)
         <<~RUBY
@@ -136,6 +147,44 @@ module Browserctl
           #{steps.gsub(/^/, '  ')}
           end
         RUBY
+      end
+
+      # Walks the recorded events and inserts an inferred wait step before
+      # selector-driven actions whose preceding gap exceeds the threshold.
+      # Returns the rendered step strings in order.
+      def annotated_steps(commands)
+        commands.each_with_index.flat_map do |cmd, i|
+          rendered = []
+          if i.positive? && (wait = inferred_wait_step(commands[i - 1], cmd))
+            rendered << wait
+          end
+          rendered << build_step(cmd)
+          rendered
+        end
+      end
+
+      def inferred_wait_step(prev, current)
+        return nil unless %w[fill click].include?(current[:cmd])
+        return nil unless current[:selector]
+
+        delta = elapsed(prev, current)
+        return nil unless delta && delta >= WAIT_THRESHOLD_SECONDS
+
+        timeout = [WAIT_FLOOR_SECONDS, delta.ceil + WAIT_PADDING_SECONDS].max
+        page = current[:name]
+        sel  = current[:selector]
+        <<~RUBY.chomp
+          # inferred wait: prior step took ~#{format('%.1f', delta)}s
+          step "wait for #{sel} on #{page}" do
+            page(:#{page}).wait(#{sel.inspect}, timeout: #{timeout})
+          end
+        RUBY
+      end
+
+      def elapsed(prev, current)
+        return nil unless prev && current && prev[:ts] && current[:ts]
+
+        current[:ts] - prev[:ts]
       end
 
       def secret_header(secrets)

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -197,6 +197,56 @@ RSpec.describe Browserctl::Recording do
     end
   end
 
+  describe "inferred waits (v0.11 WS-3.3)" do
+    before { described_class.start("waits") }
+
+    def write_event(entry)
+      File.open(File.join(@tmp_dir, "waits.jsonl"), "a") { |f| f.puts JSON.generate(entry) }
+    end
+
+    it "inserts a wait before a selector step when the preceding gap exceeds the threshold" do
+      t0 = 1_000_000.0
+      write_event(cmd: "navigate", ts: t0, name: "main", url: "https://example.com")
+      write_event(cmd: "click", ts: t0 + 3.4, name: "main", selector: "button.go")
+      ruby = described_class.generate_workflow("waits", keep_log: true)
+      expect(ruby).to match(/# inferred wait: prior step took ~3\.4s/)
+      expect(ruby).to match(/page\(:main\)\.wait\("button\.go", timeout: \d+\)/)
+      # Wait must come before the click
+      expect(ruby.index('page(:main).wait("button.go"')).to be < ruby.index('page(:main).click("button.go"')
+    end
+
+    it "does not insert a wait when the gap is below the threshold" do
+      t0 = 1_000_000.0
+      write_event(cmd: "click", ts: t0,        name: "main", selector: "a.link")
+      write_event(cmd: "click", ts: t0 + 0.3,  name: "main", selector: "button.go")
+      ruby = described_class.generate_workflow("waits", keep_log: true)
+      expect(ruby).not_to include("inferred wait")
+      expect(ruby).not_to match(/page\(:main\)\.wait\(/)
+    end
+
+    it "does not insert a wait before non-selector steps (e.g. screenshot)" do
+      t0 = 1_000_000.0
+      write_event(cmd: "navigate",   ts: t0,        name: "main", url: "https://example.com")
+      write_event(cmd: "screenshot", ts: t0 + 5.0,  name: "main")
+      ruby = described_class.generate_workflow("waits", keep_log: true)
+      expect(ruby).not_to include("inferred wait")
+    end
+
+    it "is a no-op when timestamps are missing (legacy logs)" do
+      write_event(cmd: "navigate", name: "main", url: "https://example.com")
+      write_event(cmd: "click",    name: "main", selector: "button.go")
+      ruby = described_class.generate_workflow("waits", keep_log: true)
+      expect(ruby).not_to include("inferred wait")
+    end
+
+    it "stamps each appended event with a ts field" do
+      described_class.append("click", name: "main", selector: "a")
+      entry = JSON.parse(File.readlines(File.join(@tmp_dir, "waits.jsonl")).last)
+      expect(entry["ts"]).to be_a(Numeric)
+      expect(entry["ts"]).to be > 0
+    end
+  end
+
   describe "secure file permissions" do
     it "creates the JSONL file with mode 0600" do
       described_class.start("secure_test")


### PR DESCRIPTION
## Summary

Recording stamps each event with a \`ts\` (UTC epoch float). The generator inspects the gap before every selector-driven step and, when it exceeds 1.5s, emits an explicit \`page(:x).wait(<selector>, timeout: ...)\` ahead of the action.

- **Threshold:** 1.5s (gaps below this come from natural input cadence and don't need a wait).
- **Timeout:** ceil of the observed delay plus a 5s pad, floored at 5s. Conservative enough to absorb network jitter without masking genuine failures.
- **Scope:** only inserted before \`fill\` / \`click\` steps that have a selector. Non-selector steps (screenshot, evaluate, navigate) get no wait.
- **Backwards-compatible:** legacy v0.2 logs without \`ts\` fields fall back to no-wait silently — no error, no spurious waits.

Implements PR #12 of \`docs/plans/v0.11-replayable.md\` (WS-3 · recording → workflow → flow pipeline).

## Test plan

- [x] \`spec/unit/recording_spec.rb\` — wait inserted on >threshold gaps, skipped on small gaps and non-selector steps, omitted when timestamps missing, \`ts\` stamped on each appended event
- [x] Full \`bundle exec rspec spec/unit\` (537 examples, 0 failures)
- [x] \`bundle exec rubocop lib spec\` clean