### PR TITLE
feat: postcondition extraction (v0.11 WS-3.4)

### DIFF
--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -149,18 +149,68 @@ module Browserctl
         RUBY
       end
 
-      # Walks the recorded events and inserts an inferred wait step before
-      # selector-driven actions whose preceding gap exceeds the threshold.
-      # Returns the rendered step strings in order.
+      # Walks the recorded events and emits the rendered step strings,
+      # interleaving inferred waits before selector-driven actions whose
+      # preceding gap exceeds WAIT_THRESHOLD_SECONDS, and inferred URL
+      # postconditions after click/fill steps that triggered navigation.
       def annotated_steps(commands)
+        last_url = {}
         commands.each_with_index.flat_map do |cmd, i|
           rendered = []
           if i.positive? && (wait = inferred_wait_step(commands[i - 1], cmd))
             rendered << wait
           end
           rendered << build_step(cmd)
+          if (post = url_postcondition_step(cmd, last_url))
+            rendered << post
+          end
+          update_last_url!(cmd, last_url)
           rendered
         end
+      end
+
+      # Emits a postcondition assertion when a click/fill resulted in a URL
+      # change. Compares the canonical (scheme+host+path) form so query
+      # strings and fragments don't make every replay flaky.
+      def url_postcondition_step(cmd, last_url)
+        return nil unless %w[click fill].include?(cmd[:cmd])
+        return nil unless cmd[:postcondition_hint] && cmd[:postcondition_hint][:url]
+
+        page = cmd[:name]
+        observed = cmd[:postcondition_hint][:url]
+        prior    = last_url[page]
+        return nil if canonical_url(observed) == canonical_url(prior)
+
+        prefix = canonical_url(observed)
+        return nil unless prefix
+
+        <<~RUBY.chomp
+          step "assert url after #{cmd[:cmd]} on #{page}" do
+            current = page(:#{page}).url
+            assert current.start_with?(#{prefix.inspect}), "expected URL to start with #{prefix}, got \#{current}"
+          end
+        RUBY
+      end
+
+      def update_last_url!(cmd, last_url)
+        case cmd[:cmd]
+        when "navigate", "page_open"
+          last_url[cmd[:name]] = cmd[:url] if cmd[:url]
+        when "click", "fill"
+          observed = cmd[:postcondition_hint] && cmd[:postcondition_hint][:url]
+          last_url[cmd[:name]] = observed if observed
+        end
+      end
+
+      def canonical_url(url)
+        return nil if url.nil? || url.empty?
+
+        uri = URI.parse(url)
+        path = uri.path.to_s
+        path = "/" if path.empty?
+        "#{uri.scheme}://#{uri.host}#{path}"
+      rescue URI::InvalidURIError
+        nil
       end
 
       def inferred_wait_step(prev, current)

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -247,6 +247,63 @@ RSpec.describe Browserctl::Recording do
     end
   end
 
+  describe "postcondition extraction (v0.11 WS-3.4)" do
+    before { described_class.start("post") }
+
+    def write_event(entry)
+      File.open(File.join(@tmp_dir, "post.jsonl"), "a") { |f| f.puts JSON.generate(entry) }
+    end
+
+    it "asserts url_matches after a click that triggered navigation" do
+      write_event(cmd: "navigate", ts: 1.0, name: "main", url: "https://example.com/login")
+      write_event(
+        cmd: "click", ts: 2.0, name: "main", selector: "button.go",
+        postcondition_hint: { url: "https://example.com/dashboard?u=42" }
+      )
+      ruby = described_class.generate_workflow("post", keep_log: true)
+      expect(ruby).to include('step "assert url after click on main"')
+      expect(ruby).to include("current = page(:main).url")
+      expect(ruby).to include('assert current.start_with?("https://example.com/dashboard")')
+    end
+
+    it "skips the assertion when click did not change the URL" do
+      write_event(cmd: "navigate", ts: 1.0, name: "main", url: "https://example.com/page")
+      write_event(
+        cmd: "click", ts: 2.0, name: "main", selector: ".reveal",
+        postcondition_hint: { url: "https://example.com/page#section" }
+      )
+      ruby = described_class.generate_workflow("post", keep_log: true)
+      expect(ruby).not_to include("assert url after click")
+    end
+
+    it "skips the assertion when no postcondition_hint was recorded" do
+      write_event(cmd: "navigate", ts: 1.0, name: "main", url: "https://example.com/login")
+      write_event(cmd: "click", ts: 2.0, name: "main", selector: "button.go")
+      ruby = described_class.generate_workflow("post", keep_log: true)
+      expect(ruby).not_to include("assert url after click")
+    end
+
+    it "tracks URL across consecutive clicks" do
+      write_event(cmd: "navigate", ts: 1.0, name: "main", url: "https://example.com/a")
+      write_event(
+        cmd: "click", ts: 2.0, name: "main", selector: ".one",
+        postcondition_hint: { url: "https://example.com/b" }
+      )
+      write_event(
+        cmd: "click", ts: 3.0, name: "main", selector: ".two",
+        postcondition_hint: { url: "https://example.com/b" } # no change
+      )
+      write_event(
+        cmd: "click", ts: 4.0, name: "main", selector: ".three",
+        postcondition_hint: { url: "https://example.com/c" }
+      )
+      ruby = described_class.generate_workflow("post", keep_log: true)
+      expect(ruby.scan("assert url after click on main").size).to eq(2)
+      expect(ruby).to include('"https://example.com/b"')
+      expect(ruby).to include('"https://example.com/c"')
+    end
+  end
+
   describe "secure file permissions" do
     it "creates the JSONL file with mode 0600" do
       described_class.start("secure_test")


### PR DESCRIPTION
## Summary

Generator now emits a follow-up assertion step after each \`click\` / \`fill\` whose recorded \`postcondition_hint.url\` differs from the page's prior canonical URL:

\`\`\`ruby
step \"assert url after click on main\" do
  current = page(:main).url
  assert current.start_with?(\"https://example.com/dashboard\"),
         \"expected URL to start with …\"
end
\`\`\`

- Compares the **canonical** scheme+host+path form, so query strings and fragments don't make replays flaky.
- Tracks the last-known URL per page across the recording, so a sequence of clicks gets one assertion per actual transition (not after no-op clicks).
- No assertion when no postcondition_hint was recorded (works on legacy logs without breakage).
- \`selector_present\` postconditions are deferred — the recording layer doesn't yet capture a post-action snapshot, so URL is the only deterministic signal we currently have. Plumbing for that can land alongside \`workflow run --check\` snapshot diffs.

Implements PR #13 of \`docs/plans/v0.11-replayable.md\` (WS-3 · recording → workflow → flow pipeline).

## Test plan

- [x] \`spec/unit/recording_spec.rb\` — assert emitted on URL change, skipped on same-URL/fragment-only change, skipped without hint, prefix tracked across multiple clicks
- [x] Full \`bundle exec rspec spec/unit\` (541 examples, 0 failures)
- [x] \`bundle exec rubocop lib spec\` clean