### PR TITLE
feat: workflow promote (WS-3.6)

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -118,9 +118,11 @@ def usage
       record status
 
     Workflow:
-      workflow run      <name|file> [--params file] [--key value ...]
+      workflow run      <name|file> [--check] [--params file] [--key value ...]
       workflow list
       workflow describe <name>
+      workflow generate <recording> [--out PATH]
+      workflow promote  <name> [--force] [--threshold N]
 
     Flow:
       flow run      <name|file> [--page NAME] [--params file] [--key value ...]

--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -50,7 +50,8 @@ module Browserctl
     def click(name, selector = nil, ref: nil)
       raise ArgumentError, "click: provide selector or ref:" unless selector || ref
 
-      call("click", name: name, selector: selector, ref: ref)
+      call("click", name: name, selector: selector, ref: ref,
+                    capture_post_snapshot: Recording.active ? true : nil)
     end
 
     # Fills an input element with a value.
@@ -62,7 +63,8 @@ module Browserctl
     def fill(name, selector = nil, value = nil, ref: nil)
       raise ArgumentError, "fill: provide selector or ref:" unless selector || ref
 
-      call("fill", name: name, selector: selector, ref: ref, value: value)
+      call("fill", name: name, selector: selector, ref: ref, value: value,
+                   capture_post_snapshot: Recording.active ? true : nil)
     end
 
     # Takes a screenshot of a named page.

--- a/lib/browserctl/commands/workflow.rb
+++ b/lib/browserctl/commands/workflow.rb
@@ -4,13 +4,14 @@ require "fileutils"
 require "json"
 require_relative "cli_output"
 require_relative "../recording"
+require_relative "../workflow/promoter"
 
 module Browserctl
   module Commands
     module Workflow
       extend CliOutput
 
-      USAGE = "Usage: browserctl workflow <run|list|describe|generate> [args]"
+      USAGE = "Usage: browserctl workflow <run|list|describe|generate|promote> [args]"
 
       def self.run(runner, args)
         sub = args.shift or abort USAGE
@@ -19,8 +20,40 @@ module Browserctl
         when "list"     then run_list(runner)
         when "describe" then run_describe(runner, args)
         when "generate" then run_generate(args)
+        when "promote"  then run_promote(args)
         else abort "unknown workflow subcommand '#{sub}'\n#{USAGE}"
         end
+      end
+
+      def self.run_promote(args)
+        name = args.shift or abort \
+          "usage: browserctl workflow promote <name> [--force] [--threshold N]"
+
+        force = !args.delete("--force").nil?
+
+        threshold_idx = args.index("--threshold")
+        threshold = if threshold_idx
+                      val = args.delete_at(threshold_idx + 1)
+                      args.delete_at(threshold_idx)
+                      Integer(val)
+                    else
+                      Browserctl::Workflow::PromotionLedger::DEFAULT_THRESHOLD
+                    end
+
+        result = Browserctl::Workflow::Promoter.promote(
+          workflow: name, force: force, threshold: threshold
+        )
+        puts JSON.generate(ok: true, **result)
+      rescue Browserctl::Workflow::Promoter::IneligibleError => e
+        puts JSON.generate(
+          ok: false, error: "ineligible",
+          message: e.message, streak: e.streak, threshold: e.threshold
+        )
+        exit 1
+      rescue Browserctl::Workflow::Promoter::NotFoundError => e
+        abort "Error: #{e.message}"
+      rescue ArgumentError => e
+        abort "Error: invalid --threshold value: #{e.message}"
       end
 
       def self.run_generate(args)

--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -8,7 +8,7 @@ require "tmpdir"
 require "uri"
 
 module Browserctl
-  class Recording
+  class Recording # rubocop:disable Metrics/ClassLength
     RECORDINGS_DIR = File.join(Dir.tmpdir, "browserctl-recordings")
     STATE_FILE     = File.expand_path("~/.browserctl/active_recording")
 
@@ -127,10 +127,11 @@ module Browserctl
 
       def replay_metadata(response)
         meta = {}
-        meta[:ref]                = response[:ref]                if response[:ref]
-        meta[:fingerprint]        = response[:fingerprint]        if response[:fingerprint]
-        meta[:snapshot_id]        = response[:snapshot_id]        if response[:snapshot_id]
-        meta[:postcondition_hint] = response[:postcondition_hint] if response[:postcondition_hint]
+        meta[:ref]                  = response[:ref]                  if response[:ref]
+        meta[:fingerprint]          = response[:fingerprint]          if response[:fingerprint]
+        meta[:snapshot_id]          = response[:snapshot_id]          if response[:snapshot_id]
+        meta[:postcondition_hint]   = response[:postcondition_hint]   if response[:postcondition_hint]
+        meta[:post_snapshot_digest] = response[:post_snapshot_digest] if response[:post_snapshot_digest]
         meta.transform_keys(&:to_s)
       end
 
@@ -164,6 +165,9 @@ module Browserctl
           if (post = url_postcondition_step(cmd, last_url))
             rendered << post
           end
+          if (snap = snapshot_postcondition_step(cmd))
+            rendered << snap
+          end
           update_last_url!(cmd, last_url)
           rendered
         end
@@ -188,6 +192,23 @@ module Browserctl
           step "assert url after #{cmd[:cmd]} on #{page}" do
             current = page(:#{page}).url
             assert current.start_with?(#{prefix.inspect}), "expected URL to start with #{prefix}, got \#{current}"
+          end
+        RUBY
+      end
+
+      # Emits an assert_snapshot_stable step when the recording captured a
+      # post-step DOM digest. Under workflow run --check the helper records
+      # drift on mismatch instead of raising, so a wiggly page surfaces in
+      # the report rather than failing the run outright.
+      def snapshot_postcondition_step(cmd)
+        return nil unless %w[click fill].include?(cmd[:cmd])
+        return nil unless cmd[:post_snapshot_digest]
+
+        page = cmd[:name]
+        digest = cmd[:post_snapshot_digest]
+        <<~RUBY.chomp
+          step "assert post-snapshot stable on #{page}" do
+            assert_snapshot_stable(:#{page}, expected_digest: #{digest.inspect})
           end
         RUBY
       end
@@ -300,6 +321,7 @@ module Browserctl
       end
 
       def prepare_attrs(cmd, attrs)
+        attrs = attrs.except(:capture_post_snapshot)
         if cmd == "fill"
           attrs = attrs.except(:value)
           field = infer_secret_field(attrs[:selector])

--- a/lib/browserctl/replay/snapshot_diff.rb
+++ b/lib/browserctl/replay/snapshot_diff.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Browserctl
+  module Replay
+    # Stable digest + element-set comparison for post-step snapshots.
+    #
+    # The digest is intentionally cheap and stable across cosmetic DOM noise:
+    # only the (selector, role, tag) triples drive the hash, sorted to remove
+    # ordering effects. That's enough to flag structural drift (a step that
+    # used to land on /dashboard now lands on /login) without flapping on
+    # every reflow or class rename.
+    module SnapshotDiff
+      module_function
+
+      def digest(snapshot)
+        return nil if snapshot.nil?
+
+        keys = Array(snapshot).map { |el| identity_tuple(el) }.compact.sort
+        Digest::SHA1.hexdigest(keys.join("\n"))[0, 16]
+      end
+
+      # Returns { added: [...], removed: [...] } of element selectors that
+      # differ between two snapshots. Empty arrays mean structurally identical.
+      def compare(prev, current)
+        prev_set    = element_set(prev)
+        current_set = element_set(current)
+        {
+          added: (current_set - prev_set).sort,
+          removed: (prev_set - current_set).sort
+        }
+      end
+
+      def identity_tuple(entry)
+        return nil unless entry.is_a?(Hash)
+
+        sel = entry[:selector] || entry["selector"]
+        role = entry[:role] || entry["role"]
+        tag = entry[:tag] || entry["tag"]
+        return nil unless sel
+
+        "#{sel}|#{role}|#{tag}"
+      end
+
+      def element_set(snapshot)
+        Array(snapshot).map { |entry| entry[:selector] || entry["selector"] }.compact
+      end
+    end
+  end
+end

--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require_relative "workflow"
+require_relative "workflow/promotion_ledger"
 require_relative "client"
 require_relative "replay/telemetry"
 
@@ -22,13 +23,20 @@ module Browserctl
     def run_workflow(name, check: false, **params)
       defn    = fetch_workflow(name)
       ctx     = check ? Browserctl::Replay::Context.new : nil
-      results = defn.call(params, Client.new, replay_context: ctx)
+      begin
+        results = defn.call(params, Client.new, replay_context: ctx)
+      rescue StandardError
+        Browserctl::Workflow::PromotionLedger.record(workflow: name.to_s, verdict: :fail) if check
+        raise
+      end
       print_results(results)
+      v = verdict(results, ctx)
       if check
         print_drift_report(ctx)
         Browserctl::Replay::Telemetry.emit(ctx, workflow: name.to_s)
+        Browserctl::Workflow::PromotionLedger.record(workflow: name.to_s, verdict: v)
       end
-      verdict(results, ctx)
+      v
     end
 
     # Lists all registered workflows from the standard search paths.

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -15,6 +15,7 @@ require_relative "handlers/state"
 require_relative "handlers/interaction"
 require_relative "../detectors"
 require_relative "../policy"
+require_relative "../replay/snapshot_diff"
 
 module Browserctl
   class CommandDispatcher

--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -50,17 +50,29 @@ module Browserctl
 
         # Adds ref / fingerprint / snapshot_id / postcondition_hint to a successful
         # click/fill response. Recording uses these to build a self-healing log.
+        # When req[:capture_post_snapshot] is true, also takes a fresh snapshot
+        # and attaches its digest so workflow run --check can diff DOM state
+        # against the recorded baseline.
         def enrich_with_recording_metadata(result, session, selector, req)
           return result unless result[:ok]
 
           ref = req[:ref] || session.ref_registry.invert[selector]
           fp  = (ref && session.fingerprint_index[ref]) || session.fingerprint_index[selector]
-          result.merge(
+          enriched = result.merge(
             ref: ref,
             fingerprint: fp,
             snapshot_id: session.snapshot_id,
             postcondition_hint: { url: session.page.current_url }
-          ).compact
+          )
+          enriched[:post_snapshot_digest] = capture_post_snapshot_digest(session) if req[:capture_post_snapshot]
+          enriched.compact
+        end
+
+        def capture_post_snapshot_digest(session)
+          snapshot = @snapshot_builder.call(session.page)
+          Browserctl::Replay::SnapshotDiff.digest(snapshot)
+        rescue StandardError
+          nil
         end
 
         def cmd_url(req)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -6,6 +6,7 @@ require_relative "errors"
 require_relative "flow_registry"
 require_relative "replay/context"
 require_relative "replay/fingerprint_matcher"
+require_relative "replay/snapshot_diff"
 require_relative "secret_resolvers"
 require_relative "session"
 
@@ -144,6 +145,25 @@ module Browserctl
 
     def assert(condition, msg = "assertion failed")
       raise WorkflowError, msg unless condition
+    end
+
+    # Snapshots the named page and compares its digest against `expected_digest`.
+    # Under `workflow run --check` (a replay context is attached), a mismatch is
+    # recorded as a drift event with reason "post-snapshot mismatch" and the
+    # step still passes. Outside --check, mismatch raises WorkflowError so the
+    # workflow fails fast.
+    def assert_snapshot_stable(page_name, expected_digest:)
+      res = @client.snapshot(page_name.to_s, format: "elements")
+      snapshot = res[:snapshot]
+      actual = Replay::SnapshotDiff.digest(snapshot)
+      return if actual == expected_digest
+
+      msg = "post-snapshot mismatch on :#{page_name} — expected #{expected_digest}, got #{actual}"
+      raise WorkflowError, msg unless @replay_context
+
+      @replay_context.record(command: :assert_snapshot_stable, selector: page_name.to_s,
+                             matched_ref: nil, score: nil, reason: "post-snapshot mismatch")
+      warn "[browserctl replay] #{msg}"
     end
 
     def compose(*)

--- a/lib/browserctl/workflow/promoter.rb
+++ b/lib/browserctl/workflow/promoter.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require_relative "../constants"
+require_relative "promotion_ledger"
+
+module Browserctl
+  module Workflow
+    # Promotes a workflow file from the project-local `.browserctl/workflows/`
+    # directory to the user-global `~/.browserctl/workflows/` directory, where
+    # it is invocable from any project.
+    #
+    # Promotion is gated by `PromotionLedger.clean_streak`: a workflow must
+    # have at least `threshold` consecutive clean `--check` runs before it
+    # can be promoted. `--force` overrides the gate.
+    module Promoter
+      class IneligibleError < StandardError
+        attr_reader :streak, :threshold
+
+        def initialize(workflow:, streak:, threshold:)
+          @streak = streak
+          @threshold = threshold
+          super(
+            "workflow '#{workflow}' has #{streak} clean --check run(s); " \
+            "needs #{threshold}. Run `browserctl workflow run #{workflow} --check` " \
+            "until clean, or pass --force to override."
+          )
+        end
+      end
+
+      class NotFoundError < StandardError; end
+
+      module_function
+
+      DEFAULT_SOURCE_DIR = ".browserctl/workflows"
+
+      def target_dir
+        File.join(Browserctl::BROWSERCTL_DIR, "workflows")
+      end
+
+      def source_path(workflow, source_dir: DEFAULT_SOURCE_DIR)
+        File.join(source_dir, "#{workflow}.rb")
+      end
+
+      def target_path(workflow)
+        File.join(target_dir, "#{workflow}.rb")
+      end
+
+      # @param workflow [String]
+      # @param force [Boolean]
+      # @param threshold [Integer]
+      # @param source_dir [String] override the source directory (testing)
+      # @param ledger_path [String] override the ledger path (testing)
+      # @return [Hash] `{ workflow:, source:, target:, streak:, threshold:, forced: }`
+      def promote(workflow:, force: false, threshold: PromotionLedger::DEFAULT_THRESHOLD,
+                  source_dir: DEFAULT_SOURCE_DIR, ledger_path: PromotionLedger.ledger_path)
+        src = source_path(workflow, source_dir: source_dir)
+        raise NotFoundError, "workflow file not found: #{src}" unless File.exist?(src)
+
+        streak = PromotionLedger.clean_streak(workflow: workflow, path: ledger_path)
+        unless force || streak >= threshold
+          raise IneligibleError.new(workflow: workflow, streak: streak, threshold: threshold)
+        end
+
+        dst = target_path(workflow)
+        FileUtils.mkdir_p(File.dirname(dst))
+        FileUtils.cp(src, dst)
+
+        {
+          workflow: workflow,
+          source: src,
+          target: dst,
+          streak: streak,
+          threshold: threshold,
+          forced: force && streak < threshold
+        }
+      end
+    end
+  end
+end

--- a/lib/browserctl/workflow/promotion_ledger.rb
+++ b/lib/browserctl/workflow/promotion_ledger.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require "time"
+require_relative "../constants"
+
+module Browserctl
+  module Workflow
+    # Append-only JSONL ledger of `workflow run --check` outcomes per workflow.
+    # Used as the gate for `workflow promote`: only workflows with a sufficient
+    # streak of clean runs are eligible for promotion to `~/.browserctl/workflows/`.
+    #
+    # Record schema (one JSONL line):
+    #   { "ts": "2026-05-10T12:00:00Z", "workflow": "name", "verdict": "clean" }
+    module PromotionLedger
+      LEDGER_BASENAME = "check_ledger.jsonl"
+      DEFAULT_THRESHOLD = 3
+      VALID_VERDICTS = %i[clean drift fail].freeze
+
+      module_function
+
+      def ledger_path
+        File.join(Browserctl::BROWSERCTL_DIR, LEDGER_BASENAME)
+      end
+
+      # Append a verdict for a workflow run.
+      # @param workflow [String]
+      # @param verdict [Symbol] :clean, :drift, or :fail
+      # @param path [String] override (testing)
+      def record(workflow:, verdict:, path: ledger_path, at: Time.now.utc)
+        return unless VALID_VERDICTS.include?(verdict)
+
+        FileUtils.mkdir_p(File.dirname(path))
+        File.open(path, "a") do |f|
+          f.puts JSON.generate(
+            ts: at.iso8601,
+            workflow: workflow.to_s,
+            verdict: verdict.to_s
+          )
+        end
+      end
+
+      # Count the trailing streak of :clean verdicts for a workflow.
+      # A non-clean verdict resets the streak. Drift and fail both break it
+      # — the gate is intentionally strict; users can override with --force.
+      # @return [Integer]
+      def clean_streak(workflow:, path: ledger_path)
+        return 0 unless File.exist?(path)
+
+        streak = 0
+        File.foreach(path) do |line|
+          entry = parse(line) or next
+          next unless entry["workflow"] == workflow.to_s
+
+          if entry["verdict"] == "clean"
+            streak += 1
+          else
+            streak = 0
+          end
+        end
+        streak
+      end
+
+      def parse(line)
+        JSON.parse(line)
+      rescue JSON::ParserError
+        nil
+      end
+    end
+  end
+end

--- a/spec/unit/assert_snapshot_stable_spec.rb
+++ b/spec/unit/assert_snapshot_stable_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/workflow"
+
+RSpec.describe Browserctl::WorkflowContext, "#assert_snapshot_stable" do
+  let(:client) { instance_double(Browserctl::Client) }
+  let(:snapshot) { [{ selector: "#a", role: "button", tag: "button" }] }
+  let(:digest) { Browserctl::Replay::SnapshotDiff.digest(snapshot) }
+
+  before do
+    allow(client).to receive(:snapshot).with("main", format: "elements")
+                                       .and_return({ snapshot: snapshot })
+  end
+
+  context "without a replay context (normal run)" do
+    let(:ctx) { described_class.new({}, client) }
+
+    it "passes silently when digests match" do
+      expect { ctx.assert_snapshot_stable(:main, expected_digest: digest) }.not_to raise_error
+    end
+
+    it "raises WorkflowError when digests differ" do
+      expect { ctx.assert_snapshot_stable(:main, expected_digest: "deadbeef") }
+        .to raise_error(Browserctl::WorkflowError, /post-snapshot mismatch on :main/)
+    end
+  end
+
+  context "with a replay context (workflow run --check)" do
+    let(:replay_ctx) { Browserctl::Replay::Context.new }
+    let(:ctx) { described_class.new({}, client, replay_context: replay_ctx) }
+
+    it "records a drift event and does not raise on mismatch" do
+      expect { ctx.assert_snapshot_stable(:main, expected_digest: "deadbeef") }
+        .to output(/post-snapshot mismatch/).to_stderr
+      expect(replay_ctx.drift_events.size).to eq(1)
+      expect(replay_ctx.drift_events.first.reason).to eq("post-snapshot mismatch")
+      expect(replay_ctx.drift_events.first.command).to eq(:assert_snapshot_stable)
+    end
+
+    it "is silent when the digest matches" do
+      expect { ctx.assert_snapshot_stable(:main, expected_digest: digest) }.not_to output.to_stderr
+      expect(replay_ctx.drift_events).to be_empty
+    end
+  end
+end

--- a/spec/unit/promotion_ledger_spec.rb
+++ b/spec/unit/promotion_ledger_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "browserctl/workflow/promotion_ledger"
+
+RSpec.describe Browserctl::Workflow::PromotionLedger do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @ledger = File.join(dir, "check_ledger.jsonl")
+      example.run
+    end
+  end
+
+  describe ".record" do
+    it "appends a JSONL line per call" do
+      described_class.record(workflow: "wf", verdict: :clean, path: @ledger)
+      described_class.record(workflow: "wf", verdict: :drift, path: @ledger)
+
+      lines = File.readlines(@ledger).map { |l| JSON.parse(l) }
+      expect(lines.size).to eq(2)
+      expect(lines[0]).to include("workflow" => "wf", "verdict" => "clean")
+      expect(lines[1]).to include("workflow" => "wf", "verdict" => "drift")
+      expect(lines[0]["ts"]).to match(/\d{4}-\d{2}-\d{2}T/)
+    end
+
+    it "ignores unknown verdicts" do
+      described_class.record(workflow: "wf", verdict: :weird, path: @ledger)
+      expect(File.exist?(@ledger)).to be(false)
+    end
+
+    it "creates the parent directory if missing" do
+      nested = File.join(File.dirname(@ledger), "deep", "log.jsonl")
+      described_class.record(workflow: "wf", verdict: :clean, path: nested)
+      expect(File.exist?(nested)).to be(true)
+    end
+  end
+
+  describe ".clean_streak" do
+    it "returns 0 when the ledger does not exist" do
+      expect(described_class.clean_streak(workflow: "wf", path: @ledger)).to eq(0)
+    end
+
+    it "counts a trailing run of clean verdicts" do
+      3.times { described_class.record(workflow: "wf", verdict: :clean, path: @ledger) }
+      expect(described_class.clean_streak(workflow: "wf", path: @ledger)).to eq(3)
+    end
+
+    it "resets the streak when drift or fail appears" do
+      described_class.record(workflow: "wf", verdict: :clean, path: @ledger)
+      described_class.record(workflow: "wf", verdict: :drift, path: @ledger)
+      described_class.record(workflow: "wf", verdict: :clean, path: @ledger)
+      expect(described_class.clean_streak(workflow: "wf", path: @ledger)).to eq(1)
+
+      described_class.record(workflow: "wf", verdict: :fail, path: @ledger)
+      described_class.record(workflow: "wf", verdict: :clean, path: @ledger)
+      described_class.record(workflow: "wf", verdict: :clean, path: @ledger)
+      expect(described_class.clean_streak(workflow: "wf", path: @ledger)).to eq(2)
+    end
+
+    it "scopes to the named workflow" do
+      described_class.record(workflow: "a", verdict: :clean, path: @ledger)
+      described_class.record(workflow: "b", verdict: :fail, path: @ledger)
+      described_class.record(workflow: "a", verdict: :clean, path: @ledger)
+      expect(described_class.clean_streak(workflow: "a", path: @ledger)).to eq(2)
+      expect(described_class.clean_streak(workflow: "b", path: @ledger)).to eq(0)
+    end
+
+    it "skips malformed lines without raising" do
+      File.write(@ledger, "{not json}\n")
+      described_class.record(workflow: "wf", verdict: :clean, path: @ledger)
+      expect(described_class.clean_streak(workflow: "wf", path: @ledger)).to eq(1)
+    end
+  end
+end

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -304,6 +304,41 @@ RSpec.describe Browserctl::Recording do
     end
   end
 
+  describe "snapshot-diff postcondition (v0.11 WS-3.5)" do
+    before { described_class.start("snap") }
+
+    it "captures post_snapshot_digest from the daemon response" do
+      response = { ok: true, post_snapshot_digest: "abc123def456" }
+      described_class.append("click", response: response, name: "main", selector: ".go")
+      entry = JSON.parse(File.readlines(File.join(@tmp_dir, "snap.jsonl")).last)
+      expect(entry["post_snapshot_digest"]).to eq("abc123def456")
+    end
+
+    it "emits an assert_snapshot_stable step in the generated workflow" do
+      described_class.append(
+        "click",
+        response: { ok: true, post_snapshot_digest: "abc123def456" },
+        name: "main", selector: ".go"
+      )
+      ruby = described_class.generate_workflow("snap", keep_log: true)
+      expect(ruby).to include('step "assert post-snapshot stable on main"')
+      expect(ruby).to include('assert_snapshot_stable(:main, expected_digest: "abc123def456")')
+    end
+
+    it "does not emit an assert when no digest was recorded" do
+      described_class.append("click", response: { ok: true }, name: "main", selector: ".go")
+      ruby = described_class.generate_workflow("snap", keep_log: true)
+      expect(ruby).not_to include("assert_snapshot_stable")
+    end
+
+    it "strips capture_post_snapshot from the recorded entry" do
+      described_class.append("click", response: { ok: true },
+                                      name: "main", selector: ".go", capture_post_snapshot: true)
+      entry = JSON.parse(File.readlines(File.join(@tmp_dir, "snap.jsonl")).last)
+      expect(entry).not_to have_key("capture_post_snapshot")
+    end
+  end
+
   describe "secure file permissions" do
     it "creates the JSONL file with mode 0600" do
       described_class.start("secure_test")

--- a/spec/unit/replay_snapshot_diff_spec.rb
+++ b/spec/unit/replay_snapshot_diff_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/replay/snapshot_diff"
+
+RSpec.describe Browserctl::Replay::SnapshotDiff do
+  let(:snap_a) do
+    [
+      { selector: "#a", role: "button", tag: "button" },
+      { selector: "#b", role: "link",   tag: "a" }
+    ]
+  end
+  let(:snap_b_reordered) do
+    [
+      { selector: "#b", role: "link",   tag: "a" },
+      { selector: "#a", role: "button", tag: "button" }
+    ]
+  end
+  let(:snap_c_added) do
+    snap_a + [{ selector: "#c", role: "img", tag: "img" }]
+  end
+
+  describe ".digest" do
+    it "returns nil for nil input" do
+      expect(described_class.digest(nil)).to be_nil
+    end
+
+    it "is stable under element ordering" do
+      expect(described_class.digest(snap_a)).to eq(described_class.digest(snap_b_reordered))
+    end
+
+    it "changes when an element is added" do
+      expect(described_class.digest(snap_a)).not_to eq(described_class.digest(snap_c_added))
+    end
+
+    it "skips entries without a selector" do
+      noisy = snap_a + [{ role: "button", tag: "button" }] # no selector
+      expect(described_class.digest(noisy)).to eq(described_class.digest(snap_a))
+    end
+
+    it "accepts string-keyed snapshots from JSON" do
+      stringy = snap_a.map { |h| h.transform_keys(&:to_s) }
+      expect(described_class.digest(stringy)).to eq(described_class.digest(snap_a))
+    end
+  end
+
+  describe ".compare" do
+    it "reports added and removed selectors" do
+      diff = described_class.compare(snap_a, snap_c_added)
+      expect(diff).to eq(added: ["#c"], removed: [])
+    end
+
+    it "is empty when snapshots are identical" do
+      expect(described_class.compare(snap_a, snap_b_reordered)).to eq(added: [], removed: [])
+    end
+  end
+end

--- a/spec/unit/workflow_promoter_spec.rb
+++ b/spec/unit/workflow_promoter_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "browserctl/workflow/promoter"
+
+RSpec.describe Browserctl::Workflow::Promoter do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmp = dir
+      @source_dir = File.join(dir, "src")
+      @target_dir = File.join(dir, "target")
+      @ledger     = File.join(dir, "ledger.jsonl")
+      FileUtils.mkdir_p(@source_dir)
+      File.write(File.join(@source_dir, "wf.rb"), "# workflow body\n")
+      example.run
+    end
+  end
+
+  before do
+    stub_const("Browserctl::BROWSERCTL_DIR", @target_dir)
+  end
+
+  def record_clean(workflow, count)
+    count.times { Browserctl::Workflow::PromotionLedger.record(workflow: workflow, verdict: :clean, path: @ledger) }
+  end
+
+  it "promotes a workflow when the streak meets the threshold" do
+    record_clean("wf", 3)
+    result = described_class.promote(
+      workflow: "wf", source_dir: @source_dir, ledger_path: @ledger
+    )
+    expect(File.exist?(File.join(@target_dir, "workflows", "wf.rb"))).to be(true)
+    expect(result).to include(workflow: "wf", streak: 3, threshold: 3, forced: false)
+  end
+
+  it "leaves the source file in place after promote (copy, not move)" do
+    record_clean("wf", 3)
+    described_class.promote(workflow: "wf", source_dir: @source_dir, ledger_path: @ledger)
+    expect(File.exist?(File.join(@source_dir, "wf.rb"))).to be(true)
+  end
+
+  it "raises IneligibleError when streak is below threshold" do
+    record_clean("wf", 2)
+    expect do
+      described_class.promote(workflow: "wf", source_dir: @source_dir, ledger_path: @ledger)
+    end.to raise_error(described_class::IneligibleError, /2 clean.*needs 3/)
+  end
+
+  it "honours --force even when ineligible" do
+    record_clean("wf", 0)
+    result = described_class.promote(
+      workflow: "wf", force: true, source_dir: @source_dir, ledger_path: @ledger
+    )
+    expect(result[:forced]).to be(true)
+    expect(File.exist?(File.join(@target_dir, "workflows", "wf.rb"))).to be(true)
+  end
+
+  it "respects a custom --threshold" do
+    record_clean("wf", 1)
+    expect do
+      described_class.promote(
+        workflow: "wf", threshold: 1, source_dir: @source_dir, ledger_path: @ledger
+      )
+    end.not_to raise_error
+  end
+
+  it "raises NotFoundError when the source file does not exist" do
+    expect do
+      described_class.promote(workflow: "missing", source_dir: @source_dir, ledger_path: @ledger)
+    end.to raise_error(described_class::NotFoundError, /missing/)
+  end
+
+  it "does not count drift runs toward the streak" do
+    record_clean("wf", 2)
+    Browserctl::Workflow::PromotionLedger.record(workflow: "wf", verdict: :drift, path: @ledger)
+    record_clean("wf", 2)
+    expect do
+      described_class.promote(workflow: "wf", source_dir: @source_dir, ledger_path: @ledger)
+    end.to raise_error(described_class::IneligibleError, /2 clean/)
+  end
+end


### PR DESCRIPTION
## Summary

- `browserctl workflow promote <name>` copies a generated workflow from `.browserctl/workflows/` to `~/.browserctl/workflows/`, making it invocable across projects.
- Promotion is gated by a new append-only check ledger (`~/.browserctl/check_ledger.jsonl`). Every `workflow run --check` records its verdict (`:clean` / `:drift` / `:fail`); promote requires N consecutive `:clean` runs (default 3). `--force` bypasses the gate; `--threshold N` overrides the default.
- `:drift` and `:fail` both reset the streak — the gate is intentionally strict.

Implements PR 15 from `docs/plans/v0.11-replayable.md`.

## Test plan

- [x] `bundle exec rspec spec/unit` — 571 + 14 new = 585 examples, 0 failures
- [x] `bundle exec rubocop` clean
- [ ] Manual: generate a workflow, run `--check` 3× clean, then `workflow promote` → file appears in `~/.browserctl/workflows/`
- [ ] Manual: `workflow promote` with insufficient streak → exits 1 with `ineligible` JSON
- [ ] Manual: `workflow promote --force` → succeeds regardless of streak