### PR TITLE
feat: workflow promote --as-flow (WS-3.7)

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -122,7 +122,7 @@ def usage
       workflow list
       workflow describe <name>
       workflow generate <recording> [--out PATH]
-      workflow promote  <name> [--force] [--threshold N]
+      workflow promote  <name> [--force] [--threshold N] [--as-flow]
 
     Flow:
       flow run      <name|file> [--page NAME] [--params file] [--key value ...]

--- a/lib/browserctl/commands/workflow.rb
+++ b/lib/browserctl/commands/workflow.rb
@@ -27,9 +27,10 @@ module Browserctl
 
       def self.run_promote(args)
         name = args.shift or abort \
-          "usage: browserctl workflow promote <name> [--force] [--threshold N]"
+          "usage: browserctl workflow promote <name> [--force] [--threshold N] [--as-flow]"
 
-        force = !args.delete("--force").nil?
+        force   = !args.delete("--force").nil?
+        as_flow = !args.delete("--as-flow").nil?
 
         threshold_idx = args.index("--threshold")
         threshold = if threshold_idx
@@ -41,7 +42,7 @@ module Browserctl
                     end
 
         result = Browserctl::Workflow::Promoter.promote(
-          workflow: name, force: force, threshold: threshold
+          workflow: name, force: force, threshold: threshold, as_flow: as_flow
         )
         puts JSON.generate(ok: true, **result)
       rescue Browserctl::Workflow::Promoter::IneligibleError => e

--- a/lib/browserctl/workflow/flow_wrapper.rb
+++ b/lib/browserctl/workflow/flow_wrapper.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require_relative "../constants"
+
+module Browserctl
+  module Workflow
+    # Renders a `Browserctl.flow` definition that wraps a promoted workflow.
+    # The flow becomes a globally-registered, parameterised handle that runs
+    # the underlying workflow via `Runner#run_workflow`. Params are inferred
+    # from the workflow's `param_defs` so callers see the same surface area
+    # they would on the workflow itself.
+    #
+    # Wrapping (rather than translating step-by-step) keeps the workflow as
+    # the single source of truth: edits to the workflow file flow through
+    # to the wrapper without regeneration.
+    module FlowWrapper
+      module_function
+
+      def target_dir
+        File.join(Browserctl::BROWSERCTL_DIR, "flows")
+      end
+
+      def target_path(name)
+        File.join(target_dir, "#{name}.rb")
+      end
+
+      # @param defn [Browserctl::WorkflowDefinition]
+      # @return [String] Ruby source for a flow file
+      def render(defn)
+        params = defn.param_defs.values.map { |p| render_param(p) }.join("\n")
+        desc   = defn.description || "Promoted from workflow '#{defn.name}'"
+        <<~RUBY
+          # frozen_string_literal: true
+
+          require "browserctl/flow"
+          require "browserctl/runner"
+
+          # Auto-generated flow wrapper for workflow '#{defn.name}'.
+          # Edit the underlying workflow file rather than this wrapper.
+          Browserctl.flow(#{defn.name.inspect}) do
+            version "1.0.0"
+            requires_browserctl "0.11.0"
+            desc #{desc.inspect}
+
+          #{params.gsub(/^/, '  ') unless params.empty?}
+
+            step("run workflow #{defn.name}") do
+              Browserctl::Runner.new.run_workflow(#{defn.name.inspect}, **params)
+            end
+          end
+        RUBY
+      end
+
+      # @param defn [Browserctl::WorkflowDefinition]
+      # @param overwrite [Boolean]
+      # @param dir [String, nil] override target dir (testing)
+      # @return [String] path written
+      def write(defn, overwrite: true, dir: nil)
+        path = dir ? File.join(dir, "#{defn.name}.rb") : target_path(defn.name)
+        if File.exist?(path) && !overwrite
+          raise "flow wrapper already exists at #{path} (pass overwrite: true to replace)"
+        end
+
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, render(defn))
+        path
+      end
+
+      def render_param(param)
+        opts = []
+        opts << "required: true" if param.required
+        opts << "secret: true"   if param.secret && !param.secret_ref
+        opts << "secret_ref: #{param.secret_ref.inspect}" if param.secret_ref
+        opts << "default: #{param.default.inspect}" unless param.default.nil?
+        suffix = opts.empty? ? "" : ", #{opts.join(', ')}"
+        "param :#{param.name}#{suffix}"
+      end
+    end
+  end
+end

--- a/lib/browserctl/workflow/promoter.rb
+++ b/lib/browserctl/workflow/promoter.rb
@@ -3,6 +3,7 @@
 require "fileutils"
 require_relative "../constants"
 require_relative "promotion_ledger"
+require_relative "flow_wrapper"
 
 module Browserctl
   module Workflow
@@ -52,8 +53,9 @@ module Browserctl
       # @param source_dir [String] override the source directory (testing)
       # @param ledger_path [String] override the ledger path (testing)
       # @return [Hash] `{ workflow:, source:, target:, streak:, threshold:, forced: }`
-      def promote(workflow:, force: false, threshold: PromotionLedger::DEFAULT_THRESHOLD,
-                  source_dir: DEFAULT_SOURCE_DIR, ledger_path: PromotionLedger.ledger_path)
+      def promote(workflow:, force: false, threshold: PromotionLedger::DEFAULT_THRESHOLD, # rubocop:disable Metrics/ParameterLists
+                  as_flow: false, source_dir: DEFAULT_SOURCE_DIR,
+                  ledger_path: PromotionLedger.ledger_path, flow_dir: nil)
         src = source_path(workflow, source_dir: source_dir)
         raise NotFoundError, "workflow file not found: #{src}" unless File.exist?(src)
 
@@ -66,7 +68,7 @@ module Browserctl
         FileUtils.mkdir_p(File.dirname(dst))
         FileUtils.cp(src, dst)
 
-        {
+        result = {
           workflow: workflow,
           source: src,
           target: dst,
@@ -74,6 +76,20 @@ module Browserctl
           threshold: threshold,
           forced: force && streak < threshold
         }
+
+        result[:flow] = wrap_as_flow(workflow, dst, flow_dir) if as_flow
+        result
+      end
+
+      # Loads the just-promoted workflow file, infers params from its
+      # WorkflowDefinition, and writes a flow wrapper at `flow_dir`
+      # (defaults to `~/.browserctl/flows/<name>.rb`).
+      def wrap_as_flow(workflow, workflow_path, flow_dir)
+        load workflow_path
+        defn = Browserctl.lookup_workflow(workflow.to_s) or
+          raise NotFoundError, "workflow '#{workflow}' did not register after load"
+
+        FlowWrapper.write(defn, overwrite: true, dir: flow_dir)
       end
     end
   end

--- a/spec/unit/flow_wrapper_spec.rb
+++ b/spec/unit/flow_wrapper_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "browserctl/workflow/flow_wrapper"
+
+RSpec.describe Browserctl::Workflow::FlowWrapper do
+  def make_workflow(name, &block)
+    block ||= -> {}
+    Browserctl.workflow(name, &block)
+    Browserctl.lookup_workflow(name)
+  end
+
+  describe ".render" do
+    it "wraps a parameter-free workflow as a runnable flow" do
+      defn = make_workflow("plain") { desc "does a thing" }
+      ruby = described_class.render(defn)
+      expect(ruby).to include('Browserctl.flow("plain")')
+      expect(ruby).to include('version "1.0.0"')
+      expect(ruby).to include('requires_browserctl "0.11.0"')
+      expect(ruby).to include('desc "does a thing"')
+      expect(ruby).to include('Browserctl::Runner.new.run_workflow("plain", **params)')
+    end
+
+    it "renders required, secret, default and secret_ref params" do
+      defn = make_workflow("typed") do
+        param :url,      required: true
+        param :token,    secret: true
+        param :limit,    default: 10
+        param :api_key,  secret_ref: "op://Vault/Item/key"
+      end
+      ruby = described_class.render(defn)
+      expect(ruby).to include("param :url, required: true")
+      expect(ruby).to include("param :token, secret: true")
+      expect(ruby).to include("param :limit, default: 10")
+      expect(ruby).to include('param :api_key, secret_ref: "op://Vault/Item/key"')
+      expect(ruby).not_to match(/param :api_key,.*secret: true/)
+    end
+
+    it "falls back to a default description when the workflow has none" do
+      defn = make_workflow("no_desc")
+      ruby = described_class.render(defn)
+      expect(ruby).to include(%(desc "Promoted from workflow 'no_desc'"))
+    end
+  end
+
+  describe ".write" do
+    it "writes the rendered flow file under the configured directory" do
+      Dir.mktmpdir do |dir|
+        defn = make_workflow("writable") { desc "x" }
+        path = described_class.write(defn, dir: dir)
+        expect(path).to eq(File.join(dir, "writable.rb"))
+        expect(File.read(path)).to include('Browserctl.flow("writable")')
+      end
+    end
+
+    it "is idempotent under overwrite: true" do
+      Dir.mktmpdir do |dir|
+        defn = make_workflow("idem") { desc "first" }
+        described_class.write(defn, dir: dir)
+        defn2 = make_workflow("idem") { desc "second" }
+        described_class.write(defn2, dir: dir)
+        expect(File.read(File.join(dir, "idem.rb"))).to include('"second"')
+      end
+    end
+
+    it "refuses to overwrite when overwrite: false" do
+      Dir.mktmpdir do |dir|
+        defn = make_workflow("guarded") { desc "x" }
+        described_class.write(defn, dir: dir)
+        expect do
+          described_class.write(defn, dir: dir, overwrite: false)
+        end.to raise_error(/already exists/)
+      end
+    end
+  end
+
+  describe ".render_param" do
+    it "treats secret_ref as implying secret without emitting both flags" do
+      param = Browserctl::ParamDef.new(
+        name: :k, required: false, secret: true, default: nil, secret_ref: "env://K"
+      )
+      expect(described_class.render_param(param)).to eq(
+        'param :k, secret_ref: "env://K"'
+      )
+    end
+  end
+end

--- a/spec/unit/workflow_promoter_spec.rb
+++ b/spec/unit/workflow_promoter_spec.rb
@@ -71,6 +71,25 @@ RSpec.describe Browserctl::Workflow::Promoter do
     end.to raise_error(described_class::NotFoundError, /missing/)
   end
 
+  it "writes a flow wrapper when as_flow: true" do
+    File.write(File.join(@source_dir, "wf.rb"), <<~RUBY)
+      Browserctl.workflow("wf") do
+        desc "wrapped flow"
+        param :token, secret: true
+      end
+    RUBY
+    record_clean("wf", 3)
+    flow_dir = File.join(@tmp, "flows")
+    result = described_class.promote(
+      workflow: "wf", source_dir: @source_dir, ledger_path: @ledger, as_flow: true,
+      flow_dir: flow_dir
+    )
+    expect(File.exist?(File.join(flow_dir, "wf.rb"))).to be(true)
+    expect(File.read(File.join(flow_dir, "wf.rb"))).to include('Browserctl.flow("wf")')
+    expect(File.read(File.join(flow_dir, "wf.rb"))).to include("param :token, secret: true")
+    expect(result[:flow]).to eq(File.join(flow_dir, "wf.rb"))
+  end
+
   it "does not count drift runs toward the streak" do
     record_clean("wf", 2)
     Browserctl::Workflow::PromotionLedger.record(workflow: "wf", verdict: :drift, path: @ledger)


### PR DESCRIPTION
## Summary

- Adds `--as-flow` to `browserctl workflow promote`: after copying the workflow into `~/.browserctl/workflows/`, generates a thin flow wrapper at `~/.browserctl/flows/<name>.rb` that runs the workflow via `Browserctl::Runner#run_workflow`.
- Params (required / secret / default / `secret_ref`) are inferred from the workflow's `WorkflowDefinition.param_defs`, so flow callers see the same surface area as workflow callers.
- Wrapping (not step-by-step translation) keeps the workflow as the single source of truth — edits to the workflow flow through without regeneration.

Implements PR 16 from `docs/plans/v0.11-replayable.md`. Closes the loop with v0.10 flows.

## Test plan

- [x] `bundle exec rspec spec/unit` — 579 examples, 0 failures (8 new)
- [x] `bundle exec rubocop` clean
- [ ] Manual: promote a workflow with `--as-flow` → flow file appears in `~/.browserctl/flows/`, `browserctl flow run <name>` works