### PR TITLE
docs(adr): record ADR-0016, 0017, 0018 for v0.11 replayable

### DIFF
--- a/docs/architecture/decisions/0016-stable-ref-scheme.md
+++ b/docs/architecture/decisions/0016-stable-ref-scheme.md
@@ -1,0 +1,99 @@
+# ADR-0016: Stable Ref Scheme — Hash Inputs, Collision Handling, Replace-Don't-Version
+
+**Date**: 2026-05-10
+**Status**: accepted
+**Supersedes**: the v0.2–v0.10 incrementing-counter ref scheme from `Snapshot::Builder`.
+**Related**: ADR-0006 (snapshot format), ADR-0017 (fingerprint algorithm — fingerprints are the *fallback* when refs alone aren't enough).
+**Deciders**: Patrick
+
+## Context
+
+Through v0.10, every snapshot assigned refs by walking the DOM in order and emitting `e1`, `e2`, `e3`, ... The refs were stable *within a single snapshot* but had no relationship across snapshots. Two snapshots of the same page taken seconds apart produced refs in arbitrary order whenever the DOM walked differently — a single inserted node could shift every subsequent ref by one.
+
+That was acceptable when a snapshot was always paired with an action in the same turn. v0.11 changes the contract: recorded workflows replay against snapshots taken at a different time, and possibly a different rendering of the same page. A ref captured during recording (`e3`) had no chance of pointing at the same element on replay.
+
+We need refs that are deterministic functions of the element, not of its enumeration order.
+
+## Decision
+
+Refs are derived from a hash of four element signals. Implementation: `lib/browserctl/snapshot/ref.rb`.
+
+### Hash inputs
+
+```
+ref = "e" || hex(SHA-256(role || "|" || accessible_name || "|" || tag || "|" || parent_path))[0, 7]
+```
+
+Each component:
+
+- **`role`** — explicit `@role` if present, otherwise an implicit role from the tag (`a` → `link`, `button` → `button`, `input` → `textbox`, `select` → `combobox`, `textarea` → `textbox`), otherwise the tag name itself. This collapses semantically-equivalent variants (`<a role="button">` and `<button>` both score `role=button`).
+- **`accessible_name`** — first non-empty of `aria-label`, `placeholder`, `alt`, `title`, then trimmed text content (truncated at 80 chars). Mirrors the AT name resolution algorithm rather than reinventing one.
+- **`tag`** — the tag name. Distinguishes elements that share a role but render differently (`<a>` vs `<button>`).
+- **`parent_path`** — chain of ancestor tag names from the element up to `<html>`, joined with `>`. Two `<button>Save</button>` elements in different forms get different refs.
+
+The hash is SHA-256 truncated to 7 hex characters (28 bits, ~268M space). Collisions across pages are not a concern because refs are scoped to a single snapshot. Collisions *within* a snapshot — two visually identical elements at the same parent path — are real and handled below.
+
+### Collision handling
+
+Within a snapshot, the deriver records every emitted ref. If a candidate hash collides with one already taken, the deriver appends `-2`, `-3`, ... until unique:
+
+```
+e1a2b3c        # first occurrence
+e1a2b3c-2      # second occurrence (same role+name+tag+parent_path)
+e1a2b3c-3      # third
+```
+
+The suffix is *not* part of the hashed identity — it's a within-snapshot tiebreaker. Across two snapshots of the same page, both occurrences re-derive to the same `e1a2b3c` and re-acquire suffixes in the same order, so `e1a2b3c-2` in snapshot A and `e1a2b3c-2` in snapshot B point at the same element as long as both occurrences are still present.
+
+When one of the two collides-elements disappears between snapshots, the surviving one keeps its suffix-free `e1a2b3c`. That's the intended behaviour: the suffixed ref means "the second of N siblings I saw," and the meaning is preserved when N changes.
+
+### Why 7 hex characters
+
+Short enough to type, copy, and read in JSON output without dominating the field. Long enough that within-snapshot collision rate is dominated by *real* element duplication (same role+name+tag+parent), not hash collisions. We expect <100 elements per snapshot on average; collision probability is below `100²/2³⁰ ≈ 0.0001%` per snapshot.
+
+### Replace, don't version
+
+The wire format changes incompatibly. Anything that hard-coded `e1`/`e2` in tests, scripts, or stored recordings breaks. We bump `Browserctl::PROTOCOL_VERSION` so clients can detect, but we do **not** ship a "v1 refs vs v2 refs" toggle.
+
+Reasoning: the old refs are not just renamed — they are derived from a different model (enumeration order vs element identity). A flag that flipped between them would be a permanent maintenance tax to support a model that the rest of v0.11 actively abandons. Recordings produced before v0.11 fall back to selector-only replay (fingerprint metadata is empty for old logs); the recording format change is documented in the migration note.
+
+## Alternatives Considered
+
+### Keep the incrementing counter; rebuild a stable index on the side
+- **Pros**: Existing recordings keep working untouched.
+- **Cons**: Two-ref world: callers must know which one to use when. Confusing; bug-prone. The "side index" *is* what we'd build the new ref on top of, so we end up shipping both anyway.
+- **Why not**: Refs are the user-facing identifier; there should be exactly one.
+
+### Hash the element's full XPath
+- **Pros**: Maximally specific — the same XPath is the same element.
+- **Cons**: Brittle in exactly the cases where stability matters most. Inserting a `<div>` for layout shifts the XPath of every nephew. The fingerprint system handles cosmetic drift; the ref system shouldn't compete with it.
+- **Why not**: We want refs to survive cosmetic changes. Parent path (tag chain only, no positions) is the right granularity.
+
+### Use the element's `id` when present, hash otherwise
+- **Pros**: Matches developer intuition — `<button id="save">` deserves a stable ref.
+- **Cons**: Half the elements on a typical page have no `id`. The two paths produce visually different refs (`e_save` vs `e1a2b3c`); telling them apart adds cognitive load. The semantic signal (`role + accessible_name`) is usually as stable as a hand-written `id`.
+- **Why not**: Uniform format wins. Semantic signals are the right input.
+
+### Hash everything (including class names, attribute values)
+- **Pros**: Maximally specific.
+- **Cons**: Tutorials and design systems rotate class names freely (`btn-blue-500` → `btn-primary`); refs would change on cosmetic refactors. That's exactly what fingerprint matching is supposed to absorb.
+- **Why not**: The ref is the fast path; the fingerprint is the slow recovery. Don't put cosmetic signals in the ref.
+
+## Consequences
+
+### Positive
+
+- Same DOM element gets the same ref across snapshots of the same page.
+- Refs are diff-friendly: `git diff` on two snapshot fixtures highlights only the elements that actually changed identity.
+- Recorded workflows can address by ref again, not only by selector — the v0.10 "ref-based interactions cannot replay" warning is largely retired (still applies to elements with no semantic signals at all, which are rare).
+- The ref encodes the four signals in its derivation, so a divergence between recorded and live refs tells you *why* without further inspection (different role? different accessible name?).
+
+### Negative
+
+- Wire format break. v0.10 fixtures and any external test harnesses asserting on `e1` need updating. Scope is contained because pre-v0.11 refs were already documented as snapshot-local.
+- The hash is opaque. `e1a2b3c` doesn't tell a human reading the snapshot what the element is — they need the rest of the JSON record. (The old `e1` was equally opaque, so this is parity, not a regression.)
+
+### Risks
+
+- **Within-snapshot collision storm.** A page with 50 visually-identical "Delete" buttons in the same parent table produces `eXX-2`, `eXX-3`, ... up to `eXX-50`. Refs remain unique but suffixes become a poor key. Mitigation: this is the correct failure mode — when the page itself can't tell elements apart, neither can we, and the fingerprint system is responsible for the recovery via neighbors and position.
+- **Accessible-name changes that propagate.** A page rename ("Save" → "Save changes") changes the ref for that element. By design — it's a different element semantically, even if the underlying DOM node is the same. Recorded workflows fall through to fingerprint match, which is exactly what fingerprints exist for.

--- a/docs/architecture/decisions/0017-fingerprint-algorithm.md
+++ b/docs/architecture/decisions/0017-fingerprint-algorithm.md
@@ -1,0 +1,118 @@
+# ADR-0017: Fingerprint Algorithm — Signal Selection, Weighting, Threshold Defaults
+
+**Date**: 2026-05-10
+**Status**: accepted
+**Pairs with**: ADR-0016 (stable refs are the fast path; fingerprints are the recovery path).
+**Deciders**: Patrick
+
+## Context
+
+Even with stable refs (ADR-0016), a recorded workflow can encounter an element whose ref has changed between recording and replay. Real causes: a renamed accessible name, a refactored parent chain, a redesign that re-shuffled headings. The ref doesn't resolve, and the workflow either fails or — worse — fails silently if the test only checks for "no exception."
+
+The fingerprint system is the recovery path. Each interacted element ships a fingerprint at recording time. At replay, when a ref or selector misses, the matcher scores live snapshot elements against the recorded fingerprint and picks the best above a threshold. Implementation: `lib/browserctl/replay/fingerprint_matcher.rb`, `lib/browserctl/snapshot/fingerprint.rb`.
+
+The choice is what signals to include, how to weight them, and where to set the threshold.
+
+## Decision
+
+### Signals
+
+A fingerprint carries four fields, all on the wire as part of the snapshot element record:
+
+```json
+{
+  "text": "Save changes",
+  "role": "button",
+  "neighbors": ["form", "Email", "Password", "Save changes", "Forgot password?"],
+  "position": { "index": 12, "depth": 4 }
+}
+```
+
+- **`text`** — visible text content, lowercased and trimmed. The single strongest signal. A user describing "the Save button" almost always means a button whose visible text is "Save" or close to it.
+- **`role`** — same role used in ref derivation (ARIA role, explicit or implicit). Catches the "renamed but still a button" case.
+- **`neighbors`** — siblings + parent text, as a small array. Captures the *neighbourhood* of the element — what surrounds it on the page. The matcher uses Jaccard similarity, so order doesn't matter and superset/subset relationships score gracefully.
+- **`position`** — `{index, depth}` of the element in its parent and in the document. The weakest signal. Used as a tiebreaker; never decisive on its own.
+
+Deliberately excluded:
+- **CSS classes / attribute values.** Rotate too freely; including them would re-import the brittleness ADR-0016 worked to remove.
+- **Pixel coordinates.** Layout-dependent; useless across viewport changes.
+- **Computed styles.** Same problem, plus expensive to capture.
+
+### Weights
+
+```
+text       0.40
+role       0.20
+neighbors  0.25
+position   0.15
+total      1.00
+```
+
+Reasoning: text + role together (0.60) clear the default threshold (0.60). That means a renamed neighbour or a shifted index alone never breaks replay — the canonical "same button, different surroundings" case scores `1.0 × 0.40 + 1.0 × 0.20 = 0.60` minimum and gets through. Conversely, an element with the same text but a different role (e.g. a `<span>` styled as a button replaced by an actual `<button>`) scores `0.40` and falls through, which is the correct outcome — semantically they are different elements.
+
+The weights are exposed via `FingerprintMatcher.new(weights: …)` for tuning, but the defaults are intentional and the public API treats them as stable.
+
+### Threshold default
+
+`DEFAULT_THRESHOLD = 0.6`.
+
+Below this number, the matcher returns no match (the element is treated as gone). The choice is calibrated to:
+
+- Accept the canonical "renamed neighbour" case (text + role match → 0.60).
+- Reject "wrong element on the page that happens to share half the signals" (text match alone is 0.40 — below threshold — so a stray element with the same text but different role/neighbors does not get hit).
+- Leave headroom for tightening (a workflow can pass `threshold: 0.75` for stricter matches).
+
+We deliberately did **not** adopt a higher default like 0.75. A 0.75 threshold would refuse the very drift case the system exists to absorb (one cosmetic change is enough to drop the score below 0.75 with the current weights), turning fingerprint matching from a recovery path into a noisy "almost passed" signal.
+
+### False-positive bound
+
+Fingerprint matching is allowed to fail silently in two ways:
+
+1. **Match the wrong element.** Two elements share text, role, and most neighbours; the matcher picks the wrong one. Mitigation: `position` is included so when neighbour Jaccard is tied, the closer element wins. Empirically this catches the duplicated-button-in-a-table case unless every neighbour is also identical (in which case the elements are interchangeable).
+2. **Match no element above threshold when one exists.** A redesign rewrote everything; the right candidate exists but scores 0.55. Mitigation: the drift report surfaces "no candidate above threshold" as `unresolved`, and the skill teaches agents to re-record on unresolved events.
+
+We accept these failure modes as the price of working at all. The alternative — refuse to fall back unless we're certain — is the v0.10 behaviour we're trying to fix.
+
+### Score is reported, not just thresholded
+
+Every fingerprint match decision lands in the drift report as `{matched_ref, score, reason}`. Agents and humans can see *how confident* the match was, not just whether it passed. A 0.62 rematch reads differently from a 0.92 rematch even though both clear the threshold. The skill (ADR-adjacent docs in `skills/automate/SKILL.md`) explains how to act on score bands.
+
+## Alternatives Considered
+
+### Use a single distance metric (e.g. Levenshtein on a serialised element)
+- **Pros**: One number, easy to reason about.
+- **Cons**: A renamed CSS class and a renamed accessible name would distort the metric equally, even though one is cosmetic and the other is semantic. The decomposed weighted sum lets us encode "I trust text more than position" as a configurable weight.
+- **Why not**: We want the weights *to be visible* — both for tuning and for explaining decisions.
+
+### Use the OS accessibility tree directly
+- **Pros**: Pre-computed semantic tree; matches what screen readers see.
+- **Cons**: Different across browsers, slower to capture, requires CDP `Accessibility.getFullAXTree` traversal per snapshot. The signals we want (text, role, neighbours) are derivable from the DOM at much lower cost.
+- **Why not**: Cost-benefit. We already walk the DOM; computing fingerprints in the same pass is essentially free.
+
+### Train a model
+- **Pros**: Could learn weights from real drift cases.
+- **Cons**: Model artefact in the gem; dataset to curate; explainability collapses. The space of features (text, role, neighbours, position) is small enough that hand-tuned weights are within a reasonable factor of optimal, and tunable per-workflow if needed.
+- **Why not**: Costs outweigh benefit at this scale.
+
+### Per-workflow override stored in the workflow file
+- **Pros**: Workflows that sit on stable pages can crank the threshold up; flaky pages can lower it.
+- **Cons**: Extra surface area for a feature that we don't have evidence we need yet.
+- **Why not yet**: Open question deferred to a future ADR. The `FingerprintMatcher` constructor already accepts `threshold:` and `weights:`, so the runtime hook is in place when we're ready.
+
+## Consequences
+
+### Positive
+
+- Replay survives cosmetic drift (renamed classes, restructured neighbours) without human intervention.
+- Drift is observable — the matcher's confidence is reported per event, so failures and near-misses look different in logs.
+- Weights and threshold are tunable knobs, not magic constants. Tests can pin specific scoring behaviours.
+
+### Negative
+
+- A drift report on every check run that has *any* drift events. Workflows that ride out cosmetic churn produce noisier ledgers than workflows on stable pages. Acceptable; the report is read-on-demand.
+- The matcher is per-element, not per-workflow. We can't say "this workflow is allowed up to 3 unresolved drifts before flagging" — every unresolved event surfaces. Mitigation: the workflow-level verdict (`:clean` / `:drift` / `:fail`) rolls up the events into a single signal that the promotion gate consumes.
+
+### Risks
+
+- **Adversarial pages.** A page that randomises text content on every load (e.g. a captcha or A/B test) defeats fingerprinting by design. The matcher will report `unresolved` and the workflow drops to `:fail`. This is correct — fingerprint matching is for cosmetic drift, not for content the page is intentionally varying.
+- **Threshold drift over time.** As we encounter real-world drift cases, the right default may shift. The current default is anchored in the weighting model: as long as text + role = threshold, the canonical case works. Future weight changes must preserve this invariant or pick a new one.

--- a/docs/architecture/decisions/0018-promotion-gates.md
+++ b/docs/architecture/decisions/0018-promotion-gates.md
@@ -1,0 +1,137 @@
+# ADR-0018: Promotion Gates — N Successful Runs, `--force`, Disqualifications
+
+**Date**: 2026-05-10
+**Status**: accepted
+**Pairs with**: ADR-0016 (stable refs), ADR-0017 (fingerprint algorithm). Promotion is the moment a workflow becomes "real" — globally invocable, callable from other workflows, optionally wrapped as a flow.
+**Deciders**: Patrick
+
+## Context
+
+v0.11's pipeline turns recordings into promoted, replayable artefacts:
+
+```
+record start → record stop → workflow generate → workflow run --check (× N) → workflow promote
+```
+
+The generator emits a workflow file from a single recording. That file may pass `--check` once and break the next time — a single clean run is not enough evidence that the workflow is durable. We need a gate that promotes only workflows whose `--check` history shows reliable behaviour.
+
+The gate has to be cheap to operate (no separate CI), interpretable (a developer can see why a workflow is or isn't promotable), and overridable (sometimes you need to ship a workflow you know works despite the report saying otherwise).
+
+## Decision
+
+Promotion is gated by an append-only check ledger that records every `--check` run's verdict. Implementation: `lib/browserctl/workflow/promotion_ledger.rb`, `lib/browserctl/workflow/promoter.rb`.
+
+### Ledger
+
+`~/.browserctl/check_ledger.jsonl` — one JSONL line per check run:
+
+```json
+{"ts": "2026-05-10T12:00:00Z", "workflow": "scrape_issues", "verdict": "clean"}
+```
+
+Verdicts mirror the runner's three outcomes from ADR-0017's drift contract:
+
+- `clean` — every step passed, no drift events recorded.
+- `drift` — every step passed, but at least one fingerprint rematch occurred *or* a snapshot diff was non-empty.
+- `fail` — a step raised.
+
+The ledger is append-only and per-user (not per-project). Switching projects or branches does not reset history; deleting the file does. There is no rotation; the file grows linearly with check runs and is JSONL so it can be inspected with `tail` / `jq`.
+
+### Gate: N consecutive `:clean` runs
+
+`workflow promote <name>` is allowed iff the workflow's *trailing streak* of `:clean` verdicts is `>= threshold` (default 3). A `:drift` or `:fail` resets the streak.
+
+> **Trailing streak**, not cumulative count. A workflow that has 50 clean runs followed by one drift run has a streak of 0 and is not promotable. The point of the gate is "the workflow is reliable *now*," not "was reliable at some point."
+
+### Why N = 3
+
+- **N = 1** is too lax. A single clean run is consistent with a happy-path replay against an unchanged page; it gives no signal about robustness.
+- **N = 5+** is too strict. A workflow on a moderately-flaky page may never accumulate 5 in a row even when it works correctly most of the time, and the agent loop runs out of patience.
+- **N = 3** matches "informal QA." If you can replay the workflow three times in a row without seeing drift, you have evidence that the page is stable enough to bind a workflow to.
+
+The threshold is configurable per-promote (`--threshold N`) so a project can dial it up for high-stakes workflows or down for smoke-test workflows. The default is the value that should ship with no flag.
+
+### Why `:drift` resets the streak
+
+A drift event is *successful behaviour*, but it is also *evidence that the page is moving*. Promotion is the moment we lock the workflow file in as the canonical version. Locking in a version that just experienced cosmetic drift is choosing to bake the drift into the workflow. The streak reset forces the user to either:
+
+1. Accept the drift as the new normal — let it run clean three times in a row (the fingerprint rematches are by then producing a stable view), then promote.
+2. Update the workflow file to match the new selectors or fingerprints, then re-check.
+
+Either path produces a more durable artefact than promoting on a drift run.
+
+`--force` exists for the case where the user knows the drift is benign and is willing to ship anyway.
+
+### Why `--force` exists
+
+The gate is opinionated, but it is not a security boundary. A user who has read the drift report and decided "yes, this is fine, ship it" should not be forced to fake clean runs to land their work. `--force` makes the override explicit and visible: the resulting promote response includes `forced: true`, so anyone reading the JSON output can tell the gate was bypassed.
+
+What `--force` does **not** do:
+
+- Skip recording the verdict in the ledger. The history remains accurate.
+- Skip the file-not-found check. A force-promote of a non-existent workflow still errors.
+- Promote a workflow that doesn't exist in the project source dir.
+
+### What disqualifies a workflow
+
+The gate checks the streak. It does **not** check:
+
+- Workflow content (we don't lint generated Ruby).
+- Whether the workflow's params resolve at runtime.
+- Whether the page targeted is still online.
+- Whether secrets are wired up correctly (`secret: true` placeholders are valid until used).
+
+These are runtime concerns and would couple promotion to network state. The gate is a binary decision based on observable replay history; everything else is the user's call.
+
+There is also no concept of "expired clean runs." A streak from a year ago is as good as a streak from yesterday. Recordings against pages that have since changed will produce drift on the next check, and the streak resets naturally. We do not invent a TTL because the operational signal already exists.
+
+### `--as-flow` and the promotion contract
+
+When `--as-flow` is set, after the gate passes and the workflow file is copied, a flow wrapper is generated alongside (`~/.browserctl/flows/<name>.rb`). This is mechanically a separate step but conceptually part of the same promotion: we are saying "this workflow is reliable enough to be a globally-callable flow." The wrapper introduces no additional gates — if the workflow is promotable, it is wrappable.
+
+## Alternatives Considered
+
+### Cumulative count instead of trailing streak
+- **Pros**: Workflows accumulate evidence over time; transient drift doesn't penalise a long-running workflow.
+- **Cons**: The signal we want is "reliable *now*," not "was reliable historically." A workflow with 100 clean runs and one recent drift is in exactly the state we don't want to lock in.
+- **Why not**: Trailing streak captures recency without bookkeeping.
+
+### CI integration: gate on a green build
+- **Pros**: Familiar model; exposes promotion to existing pipelines.
+- **Cons**: browserctl runs locally against live pages by design. Pulling promotion into CI requires either (a) running real browser automation in CI (slow, flaky, expensive), or (b) recording-replay infrastructure (complex). The local ledger achieves the same goal for the workflow's actual environment.
+- **Why not**: The local environment *is* the test environment. Adding CI doesn't make the signal stronger here.
+
+### Configurable per-workflow threshold via a header comment
+- **Pros**: Different workflows have different reliability needs.
+- **Cons**: Couples the workflow file to its promotion policy; surface area we can't take back.
+- **Why not yet**: Open question deferred. `--threshold` on the CLI covers the same need without persisting policy in the workflow file. If repeated need emerges, a `# @promotion_threshold 5` directive can be added without breaking existing files.
+
+### No gate; promote is just a copy command
+- **Pros**: Maximally simple. Trust the user.
+- **Cons**: The pipeline asks the user to record once and promote later. Without a gate, the user is the only thing standing between "I just made a recording" and "this is now my canonical workflow." The gate makes the implicit acceptance criterion explicit and observable.
+- **Why not**: The whole reason `--check` exists is to produce evidence; throwing the evidence away at promote-time wastes the work.
+
+### Reset the streak on `:fail` only, not `:drift`
+- **Pros**: Drift is "still passing"; not penalising it would let workflows promote through cosmetic churn.
+- **Cons**: Promoting on drift bakes the cosmetic state into the canonical workflow. The next replay will likely drift again — the workflow has now codified the drift, not absorbed it.
+- **Why not**: Drift is signal that the page is moving. Promotion should happen from a stable view of the page, not a moving one. The `--force` escape hatch covers the "I know what I'm doing" case.
+
+## Consequences
+
+### Positive
+
+- Promotion is evidence-driven and the evidence is inspectable (`tail ~/.browserctl/check_ledger.jsonl`).
+- The gate aligns naturally with the agent loop: an AI agent that runs `--check` until clean and then promotes is doing the right thing without any extra reasoning.
+- `--force` keeps the gate from being adversarial. Users retain agency.
+- The ledger is also a passive observability tool: how often does this workflow drift? when did it start drifting? — the answers are in the file.
+
+### Negative
+
+- The ledger is per-user, so a CI machine and a developer's laptop have independent histories. A workflow promoted on the developer's laptop is not "automatically promotable" on CI. Acceptable: promotion is a deliberate act, and the history follows the actor doing the deliberating.
+- New users meet the gate immediately. The first time someone runs `workflow promote`, they get an "ineligible" message because the streak is 0. The error message tells them what to run; the friction is intentional but real.
+
+### Risks
+
+- **Ledger corruption.** If the JSONL file is truncated or has a malformed line, the streak query skips the bad line rather than aborting. Trade-off accepted for robustness over strictness — a corrupted line should not lock a user out of promoting.
+- **Streak gaming.** A user could `tail` then `head` the file to fake a streak. We are not defending against this; the user owns their own ledger and `--force` is the documented escape hatch. The gate is a hint, not an enforcement boundary.
+- **Threshold drift.** If 3 turns out to be wrong (too lax in practice; too strict in agent loops), we'll change it. The default is encoded in `PromotionLedger::DEFAULT_THRESHOLD` and is a single point of change.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -17,3 +17,6 @@
 | [0013](0013-flow-dsl.md) | Flow DSL — separate registry, lifetime, stdlib split | accepted | 2026-05-09 |
 | [0014](0014-bctl-bundle-format.md) | `.bctl` bundle format — HMAC, manifest, transports, origin scope | accepted | 2026-05-09 |
 | [0015](0015-auth-required-detection.md) | `auth_required` detection — signals, false positives, pluggability | accepted | 2026-05-09 |
+| [0016](0016-stable-ref-scheme.md) | Stable ref scheme — hash inputs, collision handling, replace don't version | accepted | 2026-05-10 |
+| [0017](0017-fingerprint-algorithm.md) | Fingerprint algorithm — signal selection, weighting, threshold defaults | accepted | 2026-05-10 |
+| [0018](0018-promotion-gates.md) | Promotion gates — N successful runs, `--force`, disqualifications | accepted | 2026-05-10 |


### PR DESCRIPTION
## Summary

Records three architectural decisions from the v0.11 replayable milestone. They ride together because they're a single system: the ref scheme is the fast path, the fingerprint algorithm is the recovery path, and the promotion gate is the contract that decides when a workflow becomes canonical.

- **[ADR-0016 — Stable Ref Scheme](docs/architecture/decisions/0016-stable-ref-scheme.md)** — SHA-256(role, accessible_name, tag, parent_path), 7-hex truncation, within-snapshot suffixing for collisions, replace-don't-version rationale.
- **[ADR-0017 — Fingerprint Algorithm](docs/architecture/decisions/0017-fingerprint-algorithm.md)** — Four signals (text, role, neighbors, position), weights chosen so text+role together clear the default threshold (canonical drift case), threshold default 0.6, false-positive bound, score-per-event reporting.
- **[ADR-0018 — Promotion Gates](docs/architecture/decisions/0018-promotion-gates.md)** — Append-only check ledger, trailing streak of N=3 clean runs, why drift resets the streak, `--force` as the explicit override, no CI dependency.

> Plan-numbered as 0015/0016/0017 in `docs/plans/v0.11-replayable.md`, but ADR-0015 was already taken by `auth-required-detection`. Bumped to 0016/0017/0018.

Closes the ADR portion of the v0.11 plan.

## Test plan

- [x] `docs/architecture/decisions/README.md` index updated
- [ ] Manual: read each ADR for internal consistency / cross-references