### PR TITLE
feat: error code enum

### DIFF
--- a/lib/browserctl/error/codes.rb
+++ b/lib/browserctl/error/codes.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Browserctl
+  class Error < StandardError
+    # Canonical enum of stable error code strings emitted on the wire and in
+    # CLI stderr payloads. Codes are SCREAMING_SNAKE_CASE and must remain
+    # stable across releases — agents branch on these deterministically.
+    #
+    # The full sweep that wires every raise site to one of these codes lands
+    # in PR #8 of the v0.12 "Solid" milestone. This module is the single
+    # source of truth those raises will reference.
+    module Codes
+      AUTH_REQUIRED            = "AUTH_REQUIRED"
+      SELECTOR_NOT_FOUND       = "SELECTOR_NOT_FOUND"
+      STATE_EXPIRED            = "STATE_EXPIRED"
+      SECRET_RESOLUTION_FAILED = "SECRET_RESOLUTION_FAILED"
+      DAEMON_UNREACHABLE       = "DAEMON_UNREACHABLE"
+      PROTOCOL_MISMATCH        = "PROTOCOL_MISMATCH"
+
+      ALL = [
+        AUTH_REQUIRED,
+        SELECTOR_NOT_FOUND,
+        STATE_EXPIRED,
+        SECRET_RESOLUTION_FAILED,
+        DAEMON_UNREACHABLE,
+        PROTOCOL_MISMATCH
+      ].freeze
+
+      def self.all
+        ALL
+      end
+
+      def self.valid?(code)
+        ALL.include?(code)
+      end
+    end
+  end
+end

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
+require_relative "error/codes"
+
 module Browserctl
   # Base error class for all browserctl daemon errors.
   # Subclasses carry a machine-readable `code` that appears in wire responses.
+  # The canonical enum of stable codes lives in {Browserctl::Error::Codes};
+  # the sweep that retrofits every raise to use those codes lands in a later
+  # v0.12 PR.
   # @attr_reader code [String] machine-readable error code
   class Error < StandardError
     def self.default_code = "error"
@@ -63,4 +68,10 @@ module Browserctl
   class FlowPreconditionError < FlowError; def self.default_code = "flow_precondition_failed" end
   class FlowStepError < FlowError; def self.default_code = "flow_step_failed" end
   class FlowPostconditionError < FlowError; def self.default_code = "flow_postcondition_failed" end
+
+  # Raised when a persisted artifact (bundle, recording, workflow, etc.) has a
+  # `version:` header that this build does not know how to read. The full error
+  # code taxonomy lands in WS-2 (PR #7); this class is a forward-reference stub
+  # so WS-1 PRs can already raise the canonical code.
+  class ProtocolMismatch < Error; def self.default_code = "PROTOCOL_MISMATCH" end
 end

--- a/spec/unit/error_codes_spec.rb
+++ b/spec/unit/error_codes_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Browserctl::Error::Codes do
   describe "constants" do
     it "exposes every canonical v0.12 code as a frozen string" do
       {
-        AUTH_REQUIRED:            "AUTH_REQUIRED",
-        SELECTOR_NOT_FOUND:       "SELECTOR_NOT_FOUND",
-        STATE_EXPIRED:            "STATE_EXPIRED",
+        AUTH_REQUIRED: "AUTH_REQUIRED",
+        SELECTOR_NOT_FOUND: "SELECTOR_NOT_FOUND",
+        STATE_EXPIRED: "STATE_EXPIRED",
         SECRET_RESOLUTION_FAILED: "SECRET_RESOLUTION_FAILED",
-        DAEMON_UNREACHABLE:       "DAEMON_UNREACHABLE",
-        PROTOCOL_MISMATCH:        "PROTOCOL_MISMATCH"
+        DAEMON_UNREACHABLE: "DAEMON_UNREACHABLE",
+        PROTOCOL_MISMATCH: "PROTOCOL_MISMATCH"
       }.each do |const, value|
         actual = described_class.const_get(const)
         expect(actual).to eq(value)

--- a/spec/unit/error_codes_spec.rb
+++ b/spec/unit/error_codes_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/errors"
+
+RSpec.describe Browserctl::Error::Codes do
+  describe "constants" do
+    it "exposes every canonical v0.12 code as a frozen string" do
+      {
+        AUTH_REQUIRED:            "AUTH_REQUIRED",
+        SELECTOR_NOT_FOUND:       "SELECTOR_NOT_FOUND",
+        STATE_EXPIRED:            "STATE_EXPIRED",
+        SECRET_RESOLUTION_FAILED: "SECRET_RESOLUTION_FAILED",
+        DAEMON_UNREACHABLE:       "DAEMON_UNREACHABLE",
+        PROTOCOL_MISMATCH:        "PROTOCOL_MISMATCH"
+      }.each do |const, value|
+        actual = described_class.const_get(const)
+        expect(actual).to eq(value)
+        expect(actual).to be_frozen
+      end
+    end
+  end
+
+  describe ".all" do
+    it "returns the full frozen set of codes" do
+      expect(described_class.all).to contain_exactly(
+        "AUTH_REQUIRED",
+        "SELECTOR_NOT_FOUND",
+        "STATE_EXPIRED",
+        "SECRET_RESOLUTION_FAILED",
+        "DAEMON_UNREACHABLE",
+        "PROTOCOL_MISMATCH"
+      )
+      expect(described_class.all).to be_frozen
+    end
+  end
+
+  describe ".valid?" do
+    it "accepts every enum member" do
+      described_class.all.each do |code|
+        expect(described_class.valid?(code)).to be(true)
+      end
+    end
+
+    it "rejects unknown codes" do
+      expect(described_class.valid?("NOT_A_REAL_CODE")).to be(false)
+      expect(described_class.valid?(nil)).to be(false)
+      expect(described_class.valid?("")).to be(false)
+      expect(described_class.valid?("auth_required")).to be(false) # case-sensitive
+    end
+  end
+end
+
+RSpec.describe Browserctl::Error, "code: kwarg integration" do
+  it "stores and exposes a canonical code passed to the base initializer" do
+    err = described_class.new(
+      "auth required",
+      code: Browserctl::Error::Codes::AUTH_REQUIRED
+    )
+    expect(err.code).to eq("AUTH_REQUIRED")
+    expect(err.message).to eq("auth required")
+    expect(Browserctl::Error::Codes.valid?(err.code)).to be(true)
+  end
+
+  it "still defaults to the class default_code when no code is supplied" do
+    expect(Browserctl::PageNotFound.new("x").code).to eq("page_not_found")
+  end
+end


### PR DESCRIPTION
## Summary

Introduce \`Browserctl::Error::Codes\` — the canonical enum of stable SCREAMING_SNAKE_CASE error code strings that v0.12 raises will use on the wire and in CLI stderr payloads.

This is **PR #7** of the v0.12 "Solid" milestone (WS-2). See [`docs/plans/v0.12-solid.md`](../blob/main/docs/plans/v0.12-solid.md).

Intentionally minimal — the sweep that retrofits raise sites lands in PR #8.

## Changes

- \`lib/browserctl/error/codes.rb\` — module with constants for the v0.12 set (\`AUTH_REQUIRED\`, \`SELECTOR_NOT_FOUND\`, \`STATE_EXPIRED\`, \`SECRET_RESOLUTION_FAILED\`, \`DAEMON_UNREACHABLE\`, \`PROTOCOL_MISMATCH\`), plus \`.all\` and \`.valid?\`.
- \`lib/browserctl/errors.rb\` — \`require_relative\` the codes module so consumers don't need a second require. \`Browserctl::Error\` already accepts a \`code:\` kwarg and exposes \`#code\`, so no behavioural change there.
- RSpec covering every constant, \`.all\` membership and frozenness, \`.valid?\` (positive + negative + case-sensitivity), and the base error \`code:\` integration.

## Out of scope (later v0.12 PRs)

- PR #8: sweep \`raise\` sites to use the enum.
- PR #9: structured error payload \`{code, message, context, suggested_action}\`.
- PRs #10-#11: exit-code map and \`docs/reference/errors.md\`.

## Acceptance

- [x] Constants exist and are frozen strings
- [x] \`.all\` returns the full set; \`.valid?\` rejects unknown / case-mismatched codes
- [x] \`Browserctl::Error.new(msg, code: ...)\` stores and exposes the code
- [x] Full suite green (641 examples, 0 failures)