### PR TITLE
feat: bundle format version

### DIFF
--- a/docs/reference/format-versions.md
+++ b/docs/reference/format-versions.md
@@ -35,7 +35,7 @@ source of truth for the convention:
 
 | Format         | File pattern                        | Current version | Source of truth (post-WS-1)          |
 | -------------- | ----------------------------------- | --------------- | ------------------------------------ |
-| State bundle   | `*.bctl` manifest                   | `1` (reserved)  | `lib/browserctl/state.rb` (PR #2)    |
+| State bundle   | `*.bctl` manifest                   | `1` (live)      | `lib/browserctl/state/bundle.rb`     |
 | Recording log  | `recordings/<session>.log`          | `1` (reserved)  | `lib/browserctl/recording.rb` (PR #3)|
 | Workflow file  | `workflows/*.rb` (front-matter)     | `1` (reserved)  | `lib/browserctl/workflow.rb` (PR #4) |
 | Drift report   | `drift-*.json`                      | `1` (reserved)  | `lib/browserctl/replay/` (PR #3)     |

--- a/lib/browserctl/state/bundle.rb
+++ b/lib/browserctl/state/bundle.rb
@@ -4,6 +4,7 @@ require "json"
 require "openssl"
 require "securerandom"
 require_relative "../errors"
+require_relative "../error/codes"
 
 module Browserctl
   module State
@@ -42,6 +43,12 @@ module Browserctl
     class Bundle
       MAGIC          = "BCTL\x00".b.freeze
       VERSION        = 1
+      # Manifest-level format version, written as `format_version` and
+      # validated on decode. Distinct from the wire-format byte `VERSION`
+      # above (which gates the binary envelope shape) — this gates the
+      # manifest schema. See docs/reference/format-versions.md.
+      BUNDLE_FORMAT_VERSION = 1
+      SUPPORTED_FORMAT_VERSIONS = [BUNDLE_FORMAT_VERSION].freeze
       FLAG_ENCRYPTED = 0x01
       HEADER_SIZE    = MAGIC.bytesize + 3 # version + flags + reserved
       LEN_SIZE       = 4
@@ -63,6 +70,7 @@ module Browserctl
       #   the footer is an HMAC. When nil, payload is plaintext and the
       #   footer is a SHA-256 digest.
       def self.encode(manifest:, payload:, passphrase: nil)
+        manifest = stamp_format_version(manifest)
         manifest_bytes = JSON.generate(manifest).b
         payload_json   = JSON.generate(payload).b
         flags          = 0
@@ -96,7 +104,8 @@ module Browserctl
         verify_footer!(body, footer, encrypted: encrypted, passphrase: passphrase)
 
         manifest = JSON.parse(manifest_bytes, symbolize_names: true)
-        payload  = decode_payload(payload_bytes, encrypted: encrypted, passphrase: passphrase)
+        verify_format_version!(manifest)
+        payload = decode_payload(payload_bytes, encrypted: encrypted, passphrase: passphrase)
 
         { manifest: manifest, payload: payload, magic: magic, version: version, encrypted: encrypted }
       end
@@ -108,8 +117,40 @@ module Browserctl
         raise BundleError, "unsupported bundle version #{version}" unless version == VERSION
 
         manifest_bytes, = read_sections!(blob)
-        JSON.parse(manifest_bytes, symbolize_names: true)
+        manifest = JSON.parse(manifest_bytes, symbolize_names: true)
+        verify_format_version!(manifest)
+        manifest
       end
+
+      # Returns the manifest with `format_version` set as the first key. When
+      # the caller already provided a value we keep it (so encoders can stamp
+      # a future version explicitly); otherwise we stamp the current one.
+      def self.stamp_format_version(manifest)
+        existing = manifest[:format_version] || manifest["format_version"]
+        version = existing || BUNDLE_FORMAT_VERSION
+        rest = manifest.except(:format_version, "format_version")
+        { format_version: version }.merge(rest)
+      end
+      private_class_method :stamp_format_version
+
+      # Raises Browserctl::ProtocolMismatch when the manifest declares no
+      # format_version or one this build does not support. The error carries
+      # the canonical PROTOCOL_MISMATCH code from the v0.12 error taxonomy.
+      def self.verify_format_version!(manifest, path: nil)
+        version = manifest[:format_version] || manifest["format_version"]
+        return if version && SUPPORTED_FORMAT_VERSIONS.include?(version)
+
+        where = path ? " at #{path}" : ""
+        msg = if version.nil?
+                "bundle manifest#{where} is missing format_version " \
+                  "(supported: #{SUPPORTED_FORMAT_VERSIONS.inspect})"
+              else
+                "bundle manifest#{where} declares format_version=#{version.inspect}, " \
+                  "this build supports #{SUPPORTED_FORMAT_VERSIONS.inspect}"
+              end
+        raise Browserctl::ProtocolMismatch.new(msg, code: Browserctl::Error::Codes::PROTOCOL_MISMATCH)
+      end
+      private_class_method :verify_format_version!
 
       def self.build_body(flags, manifest_bytes, payload_bytes)
         header = MAGIC + [VERSION, flags, 0].pack("CCC")

--- a/spec/unit/state/bundle_spec.rb
+++ b/spec/unit/state/bundle_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Browserctl::State::Bundle do
       blob = described_class.encode(manifest: manifest, payload: payload)
       out  = described_class.decode(blob)
 
-      expect(out[:manifest]).to eq(manifest)
+      expect(out[:manifest]).to eq(manifest.merge(format_version: described_class::BUNDLE_FORMAT_VERSION))
       expect(out[:payload]).to eq(payload)
       expect(out[:encrypted]).to be false
     end
@@ -64,7 +64,7 @@ RSpec.describe Browserctl::State::Bundle do
       blob = described_class.encode(manifest: manifest, payload: payload, passphrase: passphrase)
       out  = described_class.decode(blob, passphrase: passphrase)
 
-      expect(out[:manifest]).to eq(manifest)
+      expect(out[:manifest]).to eq(manifest.merge(format_version: described_class::BUNDLE_FORMAT_VERSION))
       expect(out[:payload]).to eq(payload)
       expect(out[:encrypted]).to be true
     end
@@ -107,14 +107,15 @@ RSpec.describe Browserctl::State::Bundle do
 
       m = described_class.peek_manifest(blob)
 
-      expect(m).to eq(manifest)
+      expect(m).to eq(manifest.merge(format_version: described_class::BUNDLE_FORMAT_VERSION))
     end
   end
 
   describe ".peek_manifest" do
     it "reads the manifest from a plaintext bundle" do
       blob = described_class.encode(manifest: manifest, payload: payload)
-      expect(described_class.peek_manifest(blob)).to eq(manifest)
+      expect(described_class.peek_manifest(blob))
+        .to eq(manifest.merge(format_version: described_class::BUNDLE_FORMAT_VERSION))
     end
 
     it "raises BundleError on a non-bundle blob" do
@@ -138,6 +139,65 @@ RSpec.describe Browserctl::State::Bundle do
 
       expect { described_class.decode(blob) }
         .to raise_error(described_class::BundleError, /unsupported bundle version/)
+    end
+  end
+
+  describe "manifest format_version" do
+    it "stamps format_version: 1 as the first manifest key on encode" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      m = described_class.peek_manifest(blob)
+
+      expect(m[:format_version]).to eq(1)
+      expect(m.keys.first).to eq(:format_version)
+    end
+
+    it "round-trips with format_version: 1" do
+      blob = described_class.encode(manifest: manifest, payload: payload)
+      out  = described_class.decode(blob)
+
+      expect(out[:manifest][:format_version]).to eq(described_class::BUNDLE_FORMAT_VERSION)
+    end
+
+    it "raises ProtocolMismatch with PROTOCOL_MISMATCH code when format_version is unknown" do
+      blob = described_class.encode(
+        manifest: manifest.merge(format_version: 999),
+        payload: payload
+      )
+
+      expect { described_class.decode(blob) }
+        .to raise_error(Browserctl::ProtocolMismatch, /999/) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::PROTOCOL_MISMATCH)
+          expect(e.message).to match(/format_version/)
+        end
+    end
+
+    it "raises ProtocolMismatch when format_version is missing (legacy bundle)" do
+      # Hand-build a blob whose manifest has no format_version, simulating a
+      # pre-WS-1 bundle on disk.
+      legacy_manifest = manifest.except(:format_version)
+      manifest_bytes = JSON.generate(legacy_manifest).b
+      payload_bytes  = JSON.generate(payload).b
+      header = described_class::MAGIC + [described_class::VERSION, 0, 0].pack("CCC")
+      body = header +
+             [manifest_bytes.bytesize].pack("N") + manifest_bytes +
+             [payload_bytes.bytesize].pack("N") + payload_bytes
+      footer = OpenSSL::Digest.digest("SHA256", body)
+      blob = body + footer
+
+      expect { described_class.decode(blob) }
+        .to raise_error(Browserctl::ProtocolMismatch, /missing format_version/) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::PROTOCOL_MISMATCH)
+        end
+    end
+
+    it "raises ProtocolMismatch from peek_manifest on an unknown format_version" do
+      blob = described_class.encode(
+        manifest: manifest.merge(format_version: 999),
+        payload: payload
+      )
+
+      expect { described_class.peek_manifest(blob) }
+        .to raise_error(Browserctl::ProtocolMismatch)
     end
   end
 end


### PR DESCRIPTION
## Summary

WS-1 PR #2 of the [v0.12 Solid milestone](../blob/main/docs/plans/v0.12-solid.md). The `.bctl` bundle manifest now carries an explicit `format_version`, and the codec rejects unknown or missing values with a typed `ProtocolMismatch` error.

- `Browserctl::State::Bundle.encode` stamps `format_version: 1` (new `BUNDLE_FORMAT_VERSION` / `SUPPORTED_FORMAT_VERSIONS` constants) as the first key of the manifest.
- `decode` and `peek_manifest` validate the value and raise `Browserctl::ProtocolMismatch` (code `Browserctl::Error::Codes::PROTOCOL_MISMATCH`) when it is missing or unknown — message names the supported set and the value found.
- Per the plan's Format / breaking changes, legacy bundles without a version are rejected outright. No auto-migration here — that lands in WS-1 PR #5.
- `docs/reference/format-versions.md` flipped from `1 (reserved)` to `1 (live)` for the bundle row.

## Acceptance

- [x] `format_version` written by codec on every fresh encode.
- [x] Reading version `999` raises `ProtocolMismatch` / `PROTOCOL_MISMATCH` (also via `peek_manifest`).
- [x] Reading a manifest with no version raises `ProtocolMismatch` (legacy bundle hand-built in spec).
- [x] Round-trip preserves `format_version: 1` in the decoded manifest.
- [x] `bundle exec rspec` green (664 examples, 0 failures, 54 pending).
- [x] `bundle exec rubocop` clean.

## Notes

- Kept the wire-format byte `Bundle::VERSION` (envelope shape) untouched — this PR only adds the manifest-schema `format_version` since that's what the plan calls for and the doc convention specifies.
- Did not touch recording / workflow / migrations (PRs #3 / #4 / #5).