### PR TITLE
feat: trace command

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -31,6 +31,7 @@ require "browserctl/commands/workflow"
 require "browserctl/commands/flow"
 require "browserctl/commands/dialog"
 require "browserctl/commands/ask"
+require "browserctl/commands/trace"
 
 def print_result(res)
   if res.is_a?(Hash) && (res[:error] || res["error"])
@@ -129,6 +130,9 @@ def usage
       flow list
       flow describe <name>
 
+    Trace:
+      trace [<session>]  Pretty timeline of CLI + daemon log events.
+
     Daemon:
       daemon start  [--headed] [--name NAME]
       daemon stop
@@ -172,6 +176,7 @@ when "workflow" then Browserctl::Commands::Workflow.run(runner, args)
 when "record"   then Browserctl::Commands::Record.run(args)
 when "init"     then Browserctl::Commands::Init.run(args)
 when "ask"      then Browserctl::Commands::Ask.run(args)
+when "trace"    then Browserctl::Commands::Trace.run(args)
 
 else
   client = Browserctl::Client.new(Browserctl.socket_path(daemon_name))

--- a/lib/browserctl/commands/trace.rb
+++ b/lib/browserctl/commands/trace.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+require_relative "../logger"
+
+module Browserctl
+  module Commands
+    # `browserctl trace [<session>]` — pretty timeline of structured log events
+    # across cli.log + daemon.log. Defaults to most recent session.
+    #
+    # Loose categorisation by inspecting common keys (event/snapshot/request/
+    # error). No schema is enforced — this command is tolerant of any JSONL
+    # produced by Browserctl::JsonlFormatter.
+    #
+    # TODO(PR#15): redact secrets via `--redact` flag. This PR prints raw
+    # log content as-is.
+    module Trace
+      USAGE = "Usage: browserctl trace [<session>]"
+
+      LEVEL_COLORS = {
+        "DEBUG" => "\e[2;37m", # dim grey
+        "INFO" => "\e[36m",    # cyan
+        "WARN" => "\e[33m",    # yellow
+        "ERROR" => "\e[31m" # red
+      }.freeze
+      RESET = "\e[0m"
+
+      CATEGORY_ICONS = {
+        error: "!",
+        snapshot: "S",
+        network: "N",
+        event: "."
+      }.freeze
+
+      OMIT_KEYS = %w[ts level component event msg].freeze
+
+      def self.run(args, log_dir: Browserctl.log_dir, out: $stdout)
+        abort USAGE if args.include?("-h") || args.include?("--help")
+        session_filter = args.shift
+
+        records = load_records(log_dir)
+        if records.empty?
+          out.puts "No log entries found in #{log_dir}"
+          return
+        end
+
+        records = filter_session(records, session_filter)
+        if records.empty?
+          out.puts "No entries match session=#{session_filter}"
+          return
+        end
+
+        render(records, out: out)
+      end
+
+      def self.load_records(log_dir)
+        paths = Dir.glob(File.join(log_dir, "{cli,daemon}.log"))
+        records = paths.flat_map do |path|
+          File.foreach(path).filter_map { |line| parse_line(line) }
+        end
+        records.sort_by { |r| r["ts"].to_s }
+      end
+
+      def self.parse_line(line)
+        line = line.strip
+        return nil if line.empty?
+
+        JSON.parse(line)
+      rescue JSON::ParserError
+        nil
+      end
+
+      # Session resolution. When session_id is stamped on records (future PR),
+      # filter/select by it. Otherwise, treat the entire merged stream as one
+      # session — caller can scope by tailing/rotating logs.
+      # TODO: stamp session_id on every log line so this scopes correctly.
+      def self.filter_session(records, session_filter)
+        if session_filter
+          records.select { |r| r["session_id"].to_s == session_filter }
+        else
+          ids = records.map { |r| r["session_id"] }.compact.uniq
+          if ids.empty?
+            records
+          else
+            recent = ids.last
+            records.select { |r| r["session_id"] == recent }
+          end
+        end
+      end
+
+      def self.render(records, out:)
+        tty = out.respond_to?(:tty?) && out.tty?
+        records.each { |r| out.puts(format_line(r, tty: tty)) }
+      end
+
+      def self.format_line(record, tty:)
+        level = (record["level"] || "INFO").to_s
+        line  = format("%-12<ts>s %<icon>s %-5<level>s %-7<comp>s %-22<label>s %<ctx>s",
+                       ts: format_ts(record["ts"]),
+                       icon: CATEGORY_ICONS.fetch(categorise(record), "."),
+                       level: level,
+                       comp: (record["component"] || "?").to_s,
+                       label: event_label(record),
+                       ctx: context_snippet(record)).rstrip
+
+        tty ? colourise(line, level) : line
+      end
+
+      def self.format_ts(timestamp)
+        Time.iso8601(timestamp.to_s).strftime("%H:%M:%S.%L")
+      rescue ArgumentError, TypeError
+        "??:??:??.???"
+      end
+
+      def self.categorise(record)
+        return :error    if record["level"] == "ERROR" || record["error"]
+        return :snapshot if record["snapshot"]
+        return :network  if record["request"] || record["response"] || record["url"]
+
+        :event
+      end
+
+      def self.event_label(record)
+        (record["event"] || record["snapshot"] || record["request"] ||
+          record["msg"] || "-").to_s.slice(0, 22)
+      end
+
+      # Compact "k=v k=v" snippet of remaining structured keys, capped to keep
+      # the timeline scannable. Skips fields already shown in fixed columns.
+      def self.context_snippet(record)
+        pairs = record.except(*OMIT_KEYS)
+        return "" if pairs.empty?
+
+        pairs.map { |k, v| "#{k}=#{format_value(v)}" }.join(" ").slice(0, 120)
+      end
+
+      def self.format_value(value)
+        case value
+        when String  then value.length > 40 ? "#{value[0, 37]}..." : value
+        when Array   then "[#{value.length}]"
+        when Hash    then "{#{value.keys.length}}"
+        else value.to_s
+        end
+      end
+
+      def self.colourise(line, level)
+        colour = LEVEL_COLORS[level] || ""
+        "#{colour}#{line}#{RESET}"
+      end
+    end
+  end
+end

--- a/spec/unit/trace_spec.rb
+++ b/spec/unit/trace_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/commands/trace"
+require "json"
+require "stringio"
+require "tmpdir"
+
+RSpec.describe Browserctl::Commands::Trace do
+  let(:tmp_dir) { Dir.mktmpdir("browserctl-trace") }
+  let(:out)     { StringIO.new }
+
+  after { FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir) }
+
+  def write_log(name, records)
+    File.open(File.join(tmp_dir, name), "w") do |f|
+      records.each { |r| f.puts(JSON.generate(r)) }
+    end
+  end
+
+  describe ".run" do
+    it "prints an empty-state notice when no log files exist" do
+      described_class.run([], log_dir: tmp_dir, out: out)
+      expect(out.string).to include("No log entries found")
+    end
+
+    it "merges cli + daemon logs by timestamp and renders a timeline" do
+      write_log("daemon.log", [
+                  { ts: "2026-05-10T06:21:48.500Z", level: "INFO", component: "daemon", event: "ready", port: 1234 },
+                  { ts: "2026-05-10T06:21:50.000Z", level: "ERROR", component: "daemon", msg: "kaboom" }
+                ])
+      write_log("cli.log", [
+                  { ts: "2026-05-10T06:21:49.000Z", level: "INFO", component: "cli", event: "click",
+                    selector: "#submit" }
+                ])
+
+      described_class.run([], log_dir: tmp_dir, out: out)
+      lines = out.string.lines.map(&:rstrip)
+
+      # Three records, ordered by ts.
+      expect(lines.length).to eq(3)
+      expect(lines[0]).to include("06:21:48.500", "daemon", "ready", "port=1234")
+      expect(lines[1]).to include("06:21:49.000", "cli", "click", "selector=#submit")
+      expect(lines[2]).to include("06:21:50.000", "ERROR", "kaboom")
+    end
+
+    it "tolerates malformed JSON lines without crashing" do
+      File.open(File.join(tmp_dir, "daemon.log"), "w") do |f|
+        f.puts("not json")
+        f.puts(JSON.generate(ts: "2026-05-10T06:00:00.000Z", level: "INFO", component: "daemon", event: "ok"))
+        f.puts("")
+      end
+
+      described_class.run([], log_dir: tmp_dir, out: out)
+      expect(out.string.lines.length).to eq(1)
+      expect(out.string).to include("ok")
+    end
+
+    it "filters by session_id when one is provided" do
+      write_log("daemon.log", [
+                  { ts: "2026-05-10T06:00:00.000Z", level: "INFO", component: "daemon",
+                    event: "a", session_id: "s1" },
+                  { ts: "2026-05-10T06:00:01.000Z", level: "INFO", component: "daemon",
+                    event: "b", session_id: "s2" }
+                ])
+
+      described_class.run(["s2"], log_dir: tmp_dir, out: out)
+      expect(out.string).to include("b")
+      expect(out.string).not_to include("event=a")
+    end
+
+    it "categorises errors with an icon prefix in the rendered line" do
+      write_log("daemon.log", [
+                  { ts: "2026-05-10T06:00:00.000Z", level: "ERROR", component: "daemon", error: "boom" }
+                ])
+
+      described_class.run([], log_dir: tmp_dir, out: out)
+      # Error category icon "!" appears between timestamp and level column.
+      expect(out.string).to match(/06:00:00\.000\s+!\s+ERROR/)
+    end
+
+    it "does not emit ANSI colour codes when out is not a TTY" do
+      write_log("cli.log", [
+                  { ts: "2026-05-10T06:00:00.000Z", level: "INFO", component: "cli", event: "x" }
+                ])
+
+      described_class.run([], log_dir: tmp_dir, out: out)
+      expect(out.string).not_to include("\e[")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`browserctl trace [<session>]` prints a pretty, time-ordered timeline by merging `~/.browserctl/logs/cli.log` and `daemon.log` (the JSONL streams added in PR #12). Categorises events loosely (events / snapshots / network / errors) via a single-character icon column. ANSI colour only when stdout is a TTY. No new gem deps.

Defaults to the most recent session when log lines carry a `session_id` (future PR will stamp this); otherwise treats the whole merged stream as one session and notes the gap with a TODO. Pass an explicit `<session>` to filter by `session_id`.

Plan: [docs/plans/v0.12-solid.md](../blob/main/docs/plans/v0.12-solid.md) — WS-3.

## Sample output

```
$ browserctl trace
06:21:48.500 . INFO  daemon  ready                  port=1234 daemon=browserd
06:21:49.000 . INFO  cli     click                  selector=#submit page=home
06:21:49.812 N INFO  daemon  page_open              page=home url=https://example.com
06:21:49.900 . INFO  cli     fill                   selector=input[name=q] value=hello
06:21:50.043 S INFO  daemon  home                   snapshot=home fingerprint=abc123 elements=42
06:21:50.500 ! ERROR daemon  selector not found     selector=#missing
```

Icon legend: `.` event  `S` snapshot  `N` network  `!` error.

## Acceptance

- [x] New CLI verb `trace [<session>]`, registered in `bin/browserctl`.
- [x] Reads `cli.log` + `daemon.log` from `Browserctl.log_dir`, merges by `ts`.
- [x] Tolerant of malformed JSON lines (skips them).
- [x] Loose categorisation via inspection of `event` / `snapshot` / `request` / `error` / `level==ERROR`.
- [x] ANSI colour only when `$stdout.tty?`.
- [x] No secret redaction (deferred to PR #15 — TODO comment in source).
- [x] No crash report writing (deferred to PR #14).
- [x] RSpec covers ordering, malformed lines, session filtering, error icon, no-TTY no-colour.
- [x] `bundle exec rspec` green; `bundle exec rubocop` clean.

## Test plan

- [ ] `bundle exec rspec spec/unit/trace_spec.rb`
- [ ] `bundle exec rubocop lib/browserctl/commands/trace.rb`
- [ ] Manual: write a few JSONL lines under `~/.browserctl/logs/`, run `browserctl trace` and confirm the timeline.