### PR TITLE
feat: crash reports

### DIFF
--- a/bin/browserd
+++ b/bin/browserd
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "optimist"
 require "nokogiri"
+require "browserctl/crash_report"
 require "browserctl/logger"
 require "browserctl/server"
 require "browserctl/version"
@@ -35,7 +36,9 @@ end
 
 log_path = Browserctl.log_path(assigned_name)
 warn "browserd starting — log: #{log_path}"
+warn "  if browserd crashes, attach the crash report from ~/.browserctl/logs/crash-*.json"
 Browserctl.logger = Browserctl.build_logger(opts[:log_level], log_path: log_path, component: "daemon")
+daemon_jsonl_log = File.join(Browserctl.log_dir, "daemon.log")
 begin
   Browserctl::Server.new(
     headless: !opts[:headed],
@@ -45,4 +48,8 @@ begin
   ).run
 rescue Browserctl::BrowserNotFound => e
   abort e.message
+rescue Exception => e # rubocop:disable Lint/RescueException
+  crash_path = Browserctl::CrashReport.write(error: e, log_path: daemon_jsonl_log)
+  warn "browserd crashed — crash report: #{crash_path}" if crash_path
+  raise
 end

--- a/lib/browserctl/crash_report.rb
+++ b/lib/browserctl/crash_report.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+require "fileutils"
+require "etc"
+
+require_relative "version"
+require_relative "logger"
+
+module Browserctl
+  # Writes a local crash report JSON file when the daemon panics. No telemetry,
+  # no upload — purely a local artifact users can attach to bug reports.
+  #
+  # The writer is intentionally defensive: it must never raise. If anything
+  # goes wrong while writing the file, it falls back to a single
+  # `[crash-report-failed]` line on stderr and returns nil.
+  module CrashReport
+    SCHEMA_VERSION = 1
+    LAST_EVENTS_LIMIT = 50
+
+    # @param error [Exception] the unhandled exception that took the daemon down
+    # @param log_path [String, nil] path to the daemon's JSONL log; the last
+    #   {LAST_EVENTS_LIMIT} valid records are tailed in
+    # @return [String, nil] the path of the written crash file, or nil on failure
+    def self.write(error:, log_path: nil)
+      ts = Time.now.utc
+      filename = "crash-#{ts.iso8601(3).gsub(':', '-')}.json"
+      dir = Browserctl.log_dir
+      FileUtils.mkdir_p(dir, mode: 0o700)
+      path = File.join(dir, filename)
+
+      payload = {
+        schema_version: SCHEMA_VERSION,
+        ts: ts.iso8601(3),
+        daemon_version: Browserctl::VERSION,
+        ruby_version: RUBY_VERSION,
+        os: os_info,
+        error: error_info(error),
+        backtrace: Array(error.backtrace),
+        last_events: tail_events(log_path)
+      }
+
+      File.open(path, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |f|
+        f.write(JSON.pretty_generate(payload))
+      end
+      path
+    rescue StandardError => e
+      warn "[crash-report-failed] #{e.class}: #{e.message}"
+      nil
+    end
+
+    def self.os_info
+      info = { platform: RUBY_PLATFORM }
+      uname = Etc.uname
+      info[:version] = uname[:version] if uname.is_a?(Hash) && uname[:version]
+      info[:sysname] = uname[:sysname] if uname.is_a?(Hash) && uname[:sysname]
+      info
+    rescue StandardError
+      { platform: RUBY_PLATFORM }
+    end
+    private_class_method :os_info
+
+    def self.error_info(error)
+      info = {
+        class: error.class.name,
+        message: error.message.to_s
+      }
+      info[:code] = error.code if error.respond_to?(:code) && error.code
+      info
+    end
+    private_class_method :error_info
+
+    def self.tail_events(log_path)
+      return [] unless log_path && File.exist?(log_path)
+
+      lines = File.readlines(log_path).last(LAST_EVENTS_LIMIT * 2)
+      events = []
+      lines.reverse_each do |line|
+        line = line.strip
+        next if line.empty?
+
+        begin
+          events.unshift(JSON.parse(line))
+        rescue JSON::ParserError
+          next
+        end
+        break if events.length >= LAST_EVENTS_LIMIT
+      end
+      events
+    rescue StandardError
+      []
+    end
+    private_class_method :tail_events
+  end
+end

--- a/spec/unit/crash_report_spec.rb
+++ b/spec/unit/crash_report_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/crash_report"
+require "browserctl/errors"
+require "json"
+require "tmpdir"
+
+RSpec.describe Browserctl::CrashReport do
+  let(:tmp_home) { Dir.mktmpdir("browserctl-crash") }
+  let(:log_dir)  { File.join(tmp_home, "logs") }
+  let(:log_path) { File.join(log_dir, "daemon.log") }
+
+  before do
+    stub_const("Browserctl::BROWSERCTL_DIR", tmp_home)
+    FileUtils.mkdir_p(log_dir)
+  end
+
+  after { FileUtils.remove_entry(tmp_home) if File.directory?(tmp_home) }
+
+  def make_error(klass = RuntimeError, msg = "boom")
+    raise klass, msg
+  rescue klass => e
+    e
+  end
+
+  it "writes a crash file with the documented schema" do
+    err = make_error
+    path = described_class.write(error: err, log_path: nil)
+
+    expect(path).to start_with(log_dir)
+    expect(File.basename(path)).to match(/\Acrash-\d{4}-\d{2}-\d{2}T.*\.json\z/)
+    payload = JSON.parse(File.read(path))
+    expect(payload).to include(
+      "schema_version" => 1,
+      "daemon_version" => Browserctl::VERSION,
+      "ruby_version" => RUBY_VERSION
+    )
+    expect(payload["ts"]).to match(/\A\d{4}-\d{2}-\d{2}T.*Z\z/)
+    expect(payload["os"]).to include("platform" => RUBY_PLATFORM)
+    expect(payload["error"]).to include("class" => "RuntimeError", "message" => "boom")
+    expect(payload["backtrace"]).to be_an(Array)
+    expect(payload["last_events"]).to eq([])
+  end
+
+  it "passes through the error code for Browserctl::Error subclasses" do
+    err = begin
+      raise Browserctl::TimeoutError, "stuck"
+    rescue Browserctl::TimeoutError => e
+      e
+    end
+    path = described_class.write(error: err, log_path: nil)
+    payload = JSON.parse(File.read(path))
+    expect(payload["error"]).to include(
+      "class" => "Browserctl::TimeoutError",
+      "message" => "stuck",
+      "code" => "timeout"
+    )
+  end
+
+  it "tails the last 50 valid JSONL events from the daemon log" do
+    File.open(log_path, "w") do |f|
+      1.upto(75) do |i|
+        f.puts JSON.generate(ts: "2026-05-10T12:00:#{format('%02d', i % 60)}.000Z",
+                             level: "INFO", component: "daemon", msg: "event-#{i}", n: i)
+      end
+    end
+
+    path = described_class.write(error: make_error, log_path: log_path)
+    payload = JSON.parse(File.read(path))
+    expect(payload["last_events"].length).to eq(50)
+    expect(payload["last_events"].first).to include("n" => 26)
+    expect(payload["last_events"].last).to include("n" => 75)
+  end
+
+  it "includes whatever events exist when fewer than 50 are present" do
+    File.open(log_path, "w") do |f|
+      1.upto(3) { |i| f.puts JSON.generate(msg: "event-#{i}") }
+    end
+    path = described_class.write(error: make_error, log_path: log_path)
+    payload = JSON.parse(File.read(path))
+    expect(payload["last_events"].length).to eq(3)
+  end
+
+  it "skips invalid JSON lines silently" do
+    File.open(log_path, "w") do |f|
+      f.puts "this is not json"
+      f.puts JSON.generate(msg: "ok")
+      f.puts "{ partial"
+    end
+    path = described_class.write(error: make_error, log_path: log_path)
+    payload = JSON.parse(File.read(path))
+    expect(payload["last_events"]).to eq([{ "msg" => "ok" }])
+  end
+
+  it "returns nil and warns instead of raising when writing fails" do
+    allow(File).to receive(:open).and_raise(Errno::EACCES, "denied")
+
+    output = StringIO.new
+    orig = $stderr
+    $stderr = output
+    begin
+      result = described_class.write(error: make_error, log_path: nil)
+      expect(result).to be_nil
+      expect(output.string).to include("[crash-report-failed]")
+    ensure
+      $stderr = orig
+    end
+  end
+
+  it "writes the crash file with 0600 permissions" do
+    path = described_class.write(error: make_error, log_path: nil)
+    mode = File.stat(path).mode & 0o777
+    expect(mode).to eq(0o600)
+  end
+end


### PR DESCRIPTION
## Summary

Implements WS-3 / PR #14 of the v0.12 Solid milestone: when the daemon panics, write a local `crash-<ts>.json` to `~/.browserctl/logs/` so users can attach it to bug reports.

- `Browserctl::CrashReport.write(error:, log_path:)` — schema_version 1, daemon/ruby/os info, error class/message/code, backtrace, and the last 50 valid JSONL events from the daemon log.
- `bin/browserd` wraps the top-level run in a rescue that writes the file and re-raises, so the existing exit behaviour is preserved.
- Startup banner now hints: "if browserd crashes, attach the crash report from ~/.browserctl/logs/crash-*.json".
- Writer is fully defensive: never raises. Falls back to a `[crash-report-failed]` stderr line if the filesystem write fails.
- No telemetry, no upload — local file only. `crash submit` is explicitly deferred to post-1.0 per the plan.

## Test plan

- [x] `bundle exec rspec spec/unit/crash_report_spec.rb` (7 examples, 0 failures)
- [x] `bundle exec rspec` full suite (684 examples, 0 failures, 54 pending — all integration skips for missing Chrome)
- [x] `bundle exec rubocop lib/browserctl/crash_report.rb spec/unit/crash_report_spec.rb bin/browserd` — clean
- [x] Spec covers: schema shape, `Browserctl::Error` code passthrough, 50-event tail behaviour, fewer-than-50 case, invalid-line skipping, write-failure fallback, 0600 permissions