### PR TITLE
feat: recording format version

### DIFF
--- a/docs/reference/format-versions.md
+++ b/docs/reference/format-versions.md
@@ -36,7 +36,7 @@ source of truth for the convention:
 | Format         | File pattern                        | Current version | Source of truth (post-WS-1)          |
 | -------------- | ----------------------------------- | --------------- | ------------------------------------ |
 | State bundle   | `*.bctl` manifest                   | `1` (live)      | `lib/browserctl/state/bundle.rb`     |
-| Recording log  | `recordings/<session>.log`          | `1` (reserved)  | `lib/browserctl/recording.rb` (PR #3)|
+| Recording log  | `recordings/<session>.jsonl`        | `1` (live)      | `lib/browserctl/recording.rb`        |
 | Workflow file  | `workflows/*.rb` (front-matter)     | `1` (reserved)  | `lib/browserctl/workflow.rb` (PR #4) |
 | Drift report   | `drift-*.json`                      | `1` (reserved)  | `lib/browserctl/replay/` (PR #3)     |
 | Daemon state   | `~/.browserctl/state.json`          | `1` (reserved)  | `lib/browserctl/state.rb` (PR #2)    |

--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -7,11 +7,20 @@ require "fileutils"
 require "tmpdir"
 require "uri"
 require_relative "errors"
+require_relative "error/codes"
 
 module Browserctl
   class Recording # rubocop:disable Metrics/ClassLength
     RECORDINGS_DIR = File.join(Dir.tmpdir, "browserctl-recordings")
     STATE_FILE     = File.expand_path("~/.browserctl/active_recording")
+
+    # Recording-log format version, written into the `_meta` header and
+    # validated when generate_workflow loads a recording. Distinct from
+    # LOG_FORMAT below — that string ("v0.11") tracks the human-readable
+    # log shape; this integer is the machine-readable schema gate per the
+    # WS-1 format-version convention. See docs/reference/format-versions.md.
+    RECORDING_FORMAT_VERSION = 1
+    SUPPORTED_FORMAT_VERSIONS = [RECORDING_FORMAT_VERSION].freeze
 
     RECORDABLE = %w[page_open navigate fill click screenshot evaluate].freeze
 
@@ -43,6 +52,7 @@ module Browserctl
       File.open(log_path(name), "a") do |f|
         f.puts JSON.generate(
           cmd: "_meta",
+          format_version: RECORDING_FORMAT_VERSION,
           log_format: LOG_FORMAT,
           recording: name,
           started_at: Time.now.utc.iso8601
@@ -87,6 +97,7 @@ module Browserctl
       raise Browserctl::Error, "no recording found for '#{name}'" unless File.exist?(log)
 
       raw   = File.readlines(log).map { |l| JSON.parse(l, symbolize_names: true) }
+      verify_format_version!(raw, path: log)
       lines = raw.reject { |l| l[:cmd] == "_meta" }
       ruby  = build_workflow_ruby(name, lines)
       File.write(output_path, ruby) if output_path
@@ -106,6 +117,25 @@ module Browserctl
 
     class << self
       private
+
+      # Raises Browserctl::ProtocolMismatch when the recording log's _meta
+      # header is missing or declares a format_version this build does not
+      # support. Mirrors Browserctl::State::Bundle.verify_format_version!.
+      def verify_format_version!(raw_lines, path: nil)
+        meta = raw_lines.first
+        version = meta && meta[:cmd] == "_meta" ? meta[:format_version] : nil
+        return if version && SUPPORTED_FORMAT_VERSIONS.include?(version)
+
+        where = path ? " at #{path}" : ""
+        msg = if version.nil?
+                "recording log#{where} is missing format_version " \
+                  "(supported: #{SUPPORTED_FORMAT_VERSIONS.inspect})"
+              else
+                "recording log#{where} declares format_version=#{version.inspect}, " \
+                  "this build supports #{SUPPORTED_FORMAT_VERSIONS.inspect}"
+              end
+        raise Browserctl::ProtocolMismatch.new(msg, code: Browserctl::Error::Codes::PROTOCOL_MISMATCH)
+      end
 
       def log_path(name)
         File.join(RECORDINGS_DIR, "#{name}.jsonl")

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -339,6 +339,48 @@ RSpec.describe Browserctl::Recording do
     end
   end
 
+  describe "format version (v0.12 WS-1)" do
+    it "stamps RECORDING_FORMAT_VERSION in the _meta header on start" do
+      described_class.start("fmt")
+      meta = JSON.parse(File.readlines(File.join(@tmp_dir, "fmt.jsonl")).first)
+      expect(meta["format_version"]).to eq(Browserctl::Recording::RECORDING_FORMAT_VERSION)
+      expect(Browserctl::Recording::RECORDING_FORMAT_VERSION).to eq(1)
+    end
+
+    it "round-trips: a freshly recorded log loads without raising" do
+      described_class.start("rt")
+      described_class.append("page_open", name: "main", url: "https://example.com")
+      expect { described_class.generate_workflow("rt", keep_log: true) }.not_to raise_error
+    end
+
+    it "raises ProtocolMismatch when the log declares an unsupported format_version" do
+      log = File.join(@tmp_dir, "future.jsonl")
+      File.write(log, "#{JSON.generate(cmd: '_meta', format_version: 999, recording: 'future')}\n")
+      expect { described_class.generate_workflow("future") }
+        .to raise_error(Browserctl::ProtocolMismatch) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::PROTOCOL_MISMATCH)
+          expect(e.message).to include("999")
+        end
+    end
+
+    it "raises ProtocolMismatch when the _meta header is missing format_version" do
+      log = File.join(@tmp_dir, "legacy.jsonl")
+      File.write(log, "#{JSON.generate(cmd: '_meta', log_format: 'v0.11', recording: 'legacy')}\n")
+      expect { described_class.generate_workflow("legacy") }
+        .to raise_error(Browserctl::ProtocolMismatch) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::PROTOCOL_MISMATCH)
+          expect(e.message).to include("missing format_version")
+        end
+    end
+
+    it "raises ProtocolMismatch when the log has no _meta header at all" do
+      log = File.join(@tmp_dir, "raw.jsonl")
+      File.write(log, "#{JSON.generate(cmd: 'click', name: 'main', selector: 'a')}\n")
+      expect { described_class.generate_workflow("raw") }
+        .to raise_error(Browserctl::ProtocolMismatch)
+    end
+  end
+
   describe "secure file permissions" do
     it "creates the JSONL file with mode 0600" do
       described_class.start("secure_test")


### PR DESCRIPTION
## Summary

PR #3 of v0.12 "Solid" milestone (WS-1, format-version convention).

- Stamps `format_version: 1` in the recording log `_meta` header via a new `RECORDING_FORMAT_VERSION` constant.
- Verifies `format_version` on load in `Recording.generate_workflow`. Missing or unsupported versions raise `Browserctl::ProtocolMismatch` with code `PROTOCOL_MISMATCH`.
- Mirrors the shape of `Browserctl::State::Bundle.verify_format_version!` for consistency. No auto-migration (lands in PR #5).
- Flips the recording row in `docs/reference/format-versions.md` from "reserved" to "live" with the source pointer to `lib/browserctl/recording.rb`.

## Test plan

- [x] `bundle exec rspec spec/unit/recording_spec.rb` — 48 examples, 0 failures
- [x] `bundle exec rspec` — 682 examples, 0 failures (54 pending; integration tests need Chrome)
- [x] `bundle exec rubocop lib/browserctl/recording.rb spec/unit/recording_spec.rb` — clean
- [x] Round-trip: fresh recording loads without raising
- [x] `format_version: 999` raises `ProtocolMismatch`
- [x] Missing `format_version` raises `ProtocolMismatch`
- [x] Log without any `_meta` header raises `ProtocolMismatch`