### PR TITLE
feat: structured error payload

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -33,13 +33,26 @@ require "browserctl/commands/dialog"
 require "browserctl/commands/ask"
 require "browserctl/commands/trace"
 
+def structured_stderr_payload(res, message)
+  code    = (res[:code] || res["code"] || Browserctl::Error::Codes::GENERIC).to_s
+  context = res[:context] || res["context"] || {}
+  action  = res[:suggested_action] || res["suggested_action"] ||
+            Browserctl::Error::SuggestedActions.for(code)
+  [code, JSON.generate(code: code, message: message, context: context, suggested_action: action)]
+end
+
 def print_result(res)
-  if res.is_a?(Hash) && (res[:error] || res["error"])
-    warn "Error: #{res[:error] || res['error']}"
+  unless res.is_a?(Hash) && (res[:error] || res["error"])
     puts res.to_json
-    exit((res[:code] || res["code"]) == "AUTH_REQUIRED" ? 7 : 1)
+    return
   end
+
+  message = res[:error] || res["error"]
+  code, payload = structured_stderr_payload(res, message)
+  warn "Error: #{message}"
+  warn payload
   puts res.to_json
+  exit(code == "AUTH_REQUIRED" ? 7 : 1)
 end
 
 def usage

--- a/lib/browserctl/commands/cli_output.rb
+++ b/lib/browserctl/commands/cli_output.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "json"
 require_relative "../errors"
+require_relative "../error/suggested_actions"
 
 module Browserctl
   module Commands
@@ -9,7 +11,9 @@ module Browserctl
 
       def print_result(res)
         if res.is_a?(Hash) && (res[:error] || res["error"])
-          warn "Error: #{res[:error] || res['error']}"
+          message = res[:error] || res["error"]
+          warn "Error: #{message}"
+          warn structured_error_line(res, message)
           puts res.to_json
           exit exit_code_for(res)
         end
@@ -22,6 +26,22 @@ module Browserctl
         return AUTH_REQUIRED_EXIT_CODE if (res[:code] || res["code"]) == "AUTH_REQUIRED"
 
         1
+      end
+
+      # Builds the single-line structured payload emitted to stderr after
+      # the human-readable line. Agents parse this JSON deterministically.
+      # Shape: { code, message, context, suggested_action }.
+      def structured_error_line(res, message)
+        code    = (res[:code] || res["code"] || Browserctl::Error::Codes::GENERIC).to_s
+        context = res[:context] || res["context"] || {}
+        action  = res[:suggested_action] || res["suggested_action"] ||
+                  Browserctl::Error::SuggestedActions.for(code)
+        JSON.generate(
+          code: code,
+          message: message,
+          context: context,
+          suggested_action: action
+        )
       end
     end
   end

--- a/lib/browserctl/error/codes.rb
+++ b/lib/browserctl/error/codes.rb
@@ -16,6 +16,9 @@ module Browserctl
       SECRET_RESOLUTION_FAILED = "SECRET_RESOLUTION_FAILED"
       DAEMON_UNREACHABLE       = "DAEMON_UNREACHABLE"
       PROTOCOL_MISMATCH        = "PROTOCOL_MISMATCH"
+      DOMAIN_NOT_ALLOWED       = "DOMAIN_NOT_ALLOWED"
+      KEY_NOT_FOUND            = "KEY_NOT_FOUND"
+      GENERIC                  = "GENERIC"
 
       ALL = [
         AUTH_REQUIRED,
@@ -23,7 +26,10 @@ module Browserctl
         STATE_EXPIRED,
         SECRET_RESOLUTION_FAILED,
         DAEMON_UNREACHABLE,
-        PROTOCOL_MISMATCH
+        PROTOCOL_MISMATCH,
+        DOMAIN_NOT_ALLOWED,
+        KEY_NOT_FOUND,
+        GENERIC
       ].freeze
 
       def self.all

--- a/lib/browserctl/error/suggested_actions.rb
+++ b/lib/browserctl/error/suggested_actions.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "codes"
+
+module Browserctl
+  class Error < StandardError
+    # Maps a stable error code (see {Browserctl::Error::Codes}) to a short
+    # imperative sentence telling the operator (or AI agent) what to try
+    # next. Codes without an explicit entry fall back to a generic pointer
+    # to the error reference doc (added in PR #11 of v0.12).
+    module SuggestedActions
+      DEFAULT = "See docs/reference/errors.md for guidance."
+
+      TABLE = {
+        Codes::AUTH_REQUIRED =>
+          "Run the suggested flow to refresh credentials, then retry.",
+        Codes::SELECTOR_NOT_FOUND =>
+          "Re-run snapshot to get fresh refs, then retry with a stable ref or selector.",
+        Codes::STATE_EXPIRED =>
+          "Re-save the state bundle (state save) or rotate it (state rotate).",
+        Codes::SECRET_RESOLUTION_FAILED =>
+          "Verify the secret resolver config and that the underlying secret exists.",
+        Codes::DAEMON_UNREACHABLE =>
+          "Start the daemon with 'browserctl daemon start', then retry.",
+        Codes::PROTOCOL_MISMATCH =>
+          "Upgrade browserctl to a version that supports this artifact's format version.",
+        Codes::DOMAIN_NOT_ALLOWED =>
+          "Add the domain to your policy allowlist or use an allowed URL.",
+        Codes::KEY_NOT_FOUND =>
+          "Verify the key was stored in this daemon session before fetching.",
+        Codes::GENERIC => DEFAULT
+      }.freeze
+
+      # @param code [String, nil] a SCREAMING_SNAKE code from {Codes}
+      # @return [String] suggested action sentence; never nil
+      def self.for(code)
+        TABLE.fetch(code, DEFAULT)
+      end
+    end
+  end
+end

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "error/codes"
+require_relative "error/suggested_actions"
 
 module Browserctl
   # Base error class for all browserctl daemon errors.
@@ -9,14 +10,29 @@ module Browserctl
   # the sweep that retrofits every raise to use those codes lands in a later
   # v0.12 PR.
   # @attr_reader code [String] machine-readable error code
+  # @attr_reader context [Hash] free-form structured fields (selector, path, ...)
   class Error < StandardError
     def self.default_code = "error"
 
-    attr_reader :code
+    attr_reader :code, :context
 
-    def initialize(msg = nil, code: self.class.default_code)
-      @code = code
+    def initialize(msg = nil, code: self.class.default_code, context: {})
+      @code    = code
+      @context = context || {}
       super(msg)
+    end
+
+    # Returns the canonical structured payload emitted on the daemon wire and
+    # on CLI stderr. Shape is stable across releases — agents branch on `code`
+    # without parsing prose.
+    # @return [Hash{Symbol => Object}]
+    def to_payload
+      {
+        code: code,
+        message: message,
+        context: context,
+        suggested_action: SuggestedActions.for(code)
+      }
     end
   end
 
@@ -55,7 +71,9 @@ module Browserctl
         code: self.class.default_code,
         state: state,
         suggested_flow: suggested_flow,
-        reason: reason
+        reason: reason,
+        context: { state: state, suggested_flow: suggested_flow, reason: reason }.compact,
+        suggested_action: SuggestedActions.for(self.class.default_code)
       }.compact
     end
   end

--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -2,6 +2,7 @@
 
 require_relative "snapshot_builder"
 require_relative "page_session"
+require_relative "handlers/error_payload"
 require_relative "handlers/page_lifecycle"
 require_relative "handlers/navigation"
 require_relative "handlers/observation"
@@ -15,10 +16,12 @@ require_relative "handlers/state"
 require_relative "handlers/interaction"
 require_relative "../detectors"
 require_relative "../policy"
+require_relative "../errors"
 require_relative "../replay/snapshot_diff"
 
 module Browserctl
   class CommandDispatcher
+    include Handlers::ErrorPayload
     include Handlers::PageLifecycle
     include Handlers::Navigation
     include Handlers::Observation

--- a/lib/browserctl/server/handlers/daemon_control.rb
+++ b/lib/browserctl/server/handlers/daemon_control.rb
@@ -21,7 +21,11 @@ module Browserctl
         def cmd_fetch(req)
           key = req[:key].to_s
           found = @kv_mutex.synchronize { @kv_store.key?(key) ? { ok: true, value: @kv_store[key] } : nil }
-          found || { error: "key '#{key}' not found", code: "key_not_found" }
+          found || error_payload(
+            code: Browserctl::Error::Codes::KEY_NOT_FOUND,
+            message: "key '#{key}' not found",
+            context: { key: key }
+          )
         end
       end
     end

--- a/lib/browserctl/server/handlers/error_payload.rb
+++ b/lib/browserctl/server/handlers/error_payload.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "../../errors"
+
+module Browserctl
+  class CommandDispatcher
+    module Handlers
+      # Centralised structured-error builder for daemon JSON-RPC responses.
+      # Each handler returns `{ error:, code:, context:, suggested_action: }`
+      # for any failure carrying a stable {Browserctl::Error::Codes} code.
+      module ErrorPayload
+        # @param code [String] a SCREAMING_SNAKE code from {Codes}
+        # @param message [String] human-readable error
+        # @param context [Hash] free-form structured fields (selector, path, ...)
+        # @return [Hash{Symbol => Object}]
+        def error_payload(code:, message:, context: {})
+          {
+            error: message,
+            code: code,
+            context: context,
+            suggested_action: Browserctl::Error::SuggestedActions.for(code)
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/interaction.rb
+++ b/lib/browserctl/server/handlers/interaction.rb
@@ -27,7 +27,13 @@ module Browserctl
               "return { x: r.left + r.width / 2, y: r.top + r.height / 2 }; " \
               "})(#{sel.to_json})"
             )
-            return { error: "selector not found: #{sel}", code: "selector_not_found" } unless coords
+            unless coords
+              return error_payload(
+                code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
+                message: "selector not found: #{sel}",
+                context: { selector: sel }
+              )
+            end
 
             session.page.mouse.move(x: coords["x"], y: coords["y"])
             { ok: true }
@@ -43,7 +49,13 @@ module Browserctl
             return sel if sel.is_a?(Hash)
 
             el = session.page.at_css(sel)
-            return { error: "selector not found: #{sel}", code: "selector_not_found" } unless el
+            unless el
+              return error_payload(
+                code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
+                message: "selector not found: #{sel}",
+                context: { selector: sel }
+              )
+            end
 
             el.select_file(path)
             { ok: true }
@@ -56,7 +68,13 @@ module Browserctl
             return sel if sel.is_a?(Hash)
 
             el = session.page.at_css(sel)
-            return { error: "selector not found: #{sel}", code: "selector_not_found" } unless el
+            unless el
+              return error_payload(
+                code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
+                message: "selector not found: #{sel}",
+                context: { selector: sel }
+              )
+            end
 
             el.evaluate(
               "this.value = #{req[:value].to_json}; " \

--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -8,7 +8,11 @@ module Browserctl
 
         def cmd_navigate(req)
           unless Policy.allowed_navigation?(req[:url].to_s)
-            return { error: "navigation to '#{req[:url]}' blocked by domain policy", code: "domain_not_allowed" }
+            return error_payload(
+              code: Browserctl::Error::Codes::DOMAIN_NOT_ALLOWED,
+              message: "navigation to '#{req[:url]}' blocked by domain policy",
+              context: { url: req[:url].to_s }
+            )
           end
 
           with_page(req[:name]) do |session|
@@ -81,7 +85,13 @@ module Browserctl
 
         def type_into(page, selector, value)
           el = page.at_css(selector)
-          return { error: "selector not found: #{selector}", code: "selector_not_found" } unless el
+          unless el
+            return error_payload(
+              code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
+              message: "selector not found: #{selector}",
+              context: { selector: selector }
+            )
+          end
 
           el.focus
           el.evaluate("this.select()")
@@ -91,7 +101,13 @@ module Browserctl
 
         def click_element(page, selector)
           el = page.at_css(selector)
-          return { error: "selector not found: #{selector}", code: "selector_not_found" } unless el
+          unless el
+            return error_payload(
+              code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
+              message: "selector not found: #{selector}",
+              context: { selector: selector }
+            )
+          end
 
           # Use the DOM native click() so JS-only event listeners fire.
           # CDP mouse simulation (el.click) dispatches events at screen coordinates

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -391,7 +391,7 @@ module Browserctl
     end
 
     def selector_not_found?(res)
-      res.is_a?(Hash) && res[:code] == "selector_not_found"
+      res.is_a?(Hash) && res[:code] == Browserctl::Error::Codes::SELECTOR_NOT_FOUND
     end
 
     def log_rematch(cmd, selector, match)

--- a/spec/unit/auth_required_error_spec.rb
+++ b/spec/unit/auth_required_error_spec.rb
@@ -24,8 +24,10 @@ RSpec.describe Browserctl::AuthRequiredError do
     expect(response[:reason]).to eq("redirect_login")
   end
 
-  it "omits nil fields from to_response" do
+  it "omits nil fields from to_response but always carries the structured payload keys" do
     response = described_class.new("login").to_response
-    expect(response.keys).to contain_exactly(:error, :code)
+    expect(response.keys).to contain_exactly(:error, :code, :context, :suggested_action)
+    expect(response[:context]).to eq({})
+    expect(response[:suggested_action]).to be_a(String)
   end
 end

--- a/spec/unit/cli_output_spec.rb
+++ b/spec/unit/cli_output_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe Browserctl::Commands::CliOutput do
 
   describe "#print_result" do
     it "prints OK responses as JSON without exiting" do
-      out = capture_stdout { host.print_result(ok: true, value: 42) }
+      out, = capture_io { host.print_result(ok: true, value: 42) }
       expect(out).to include('"ok":true')
       expect(out).to include('"value":42')
     end
 
     it "exits 7 with the body still printed for AUTH_REQUIRED" do
-      out = capture_stdout do
+      out, = capture_io do
         expect { host.print_result(error: "login", code: "AUTH_REQUIRED", suggested_flow: "f") }
           .to raise_error(SystemExit) { |e| expect(e.status).to eq(7) }
       end
@@ -38,20 +38,51 @@ RSpec.describe Browserctl::Commands::CliOutput do
     end
 
     it "exits 1 for plain errors" do
-      capture_stdout do
+      capture_io do
         expect { host.print_result(error: "oops") }
           .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
       end
     end
+
+    it "emits a structured JSON line on stderr after the human line" do
+      _, err = capture_io do
+        expect do
+          host.print_result(
+            error: "selector not found: .x",
+            code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
+            context: { selector: ".x" },
+            suggested_action: "Re-run snapshot."
+          )
+        end.to raise_error(SystemExit)
+      end
+      lines = err.split("\n")
+      expect(lines.first).to start_with("Error: selector not found")
+      payload = JSON.parse(lines.last)
+      expect(payload).to eq(
+        "code" => "SELECTOR_NOT_FOUND",
+        "message" => "selector not found: .x",
+        "context" => { "selector" => ".x" },
+        "suggested_action" => "Re-run snapshot."
+      )
+    end
+
+    it "fills in suggested_action and GENERIC code when missing from the daemon response" do
+      _, err = capture_io do
+        expect { host.print_result(error: "boom") }.to raise_error(SystemExit)
+      end
+      payload = JSON.parse(err.split("\n").last)
+      expect(payload["code"]).to eq("GENERIC")
+      expect(payload["suggested_action"]).to eq(Browserctl::Error::SuggestedActions::DEFAULT)
+    end
   end
 
-  def capture_stdout
+  def capture_io
     original_stdout = $stdout
     original_stderr = $stderr
     $stdout = StringIO.new
     $stderr = StringIO.new
     yield
-    $stdout.string
+    [$stdout.string, $stderr.string]
   ensure
     $stdout = original_stdout
     $stderr = original_stderr

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -527,7 +527,7 @@ RSpec.describe Browserctl::CommandDispatcher do
       it "returns an error for a missing key" do
         result = dispatcher.dispatch({ cmd: "fetch", key: "missing" })
         expect(result[:error]).to match(/key 'missing' not found/)
-        expect(result[:code]).to eq("key_not_found")
+        expect(result[:code]).to eq(Browserctl::Error::Codes::KEY_NOT_FOUND)
       end
 
       it "overwrites an existing key" do

--- a/spec/unit/error_codes_spec.rb
+++ b/spec/unit/error_codes_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe Browserctl::Error::Codes do
         "STATE_EXPIRED",
         "SECRET_RESOLUTION_FAILED",
         "DAEMON_UNREACHABLE",
-        "PROTOCOL_MISMATCH"
+        "PROTOCOL_MISMATCH",
+        "DOMAIN_NOT_ALLOWED",
+        "KEY_NOT_FOUND",
+        "GENERIC"
       )
       expect(described_class.all).to be_frozen
     end

--- a/spec/unit/error_payload_spec.rb
+++ b/spec/unit/error_payload_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/errors"
+
+RSpec.describe Browserctl::Error, "#to_payload" do
+  it "returns the canonical four-key structured payload" do
+    err = Browserctl::SelectorNotFound.new("selector not found: .x", context: { selector: ".x" })
+    expect(err.to_payload).to eq(
+      code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
+      message: "selector not found: .x",
+      context: { selector: ".x" },
+      suggested_action: Browserctl::Error::SuggestedActions.for(Browserctl::Error::Codes::SELECTOR_NOT_FOUND)
+    )
+  end
+
+  it "defaults context to an empty hash" do
+    err = Browserctl::SelectorNotFound.new("x")
+    expect(err.to_payload[:context]).to eq({})
+  end
+
+  it "uses the default fallback action for unknown codes" do
+    err = Browserctl::Error.new("oops", code: "TOTALLY_MADE_UP")
+    expect(err.to_payload[:suggested_action]).to eq(Browserctl::Error::SuggestedActions::DEFAULT)
+  end
+end
+
+RSpec.describe Browserctl::Error::SuggestedActions do
+  it "returns a non-empty imperative sentence for every enum code" do
+    Browserctl::Error::Codes::ALL.each do |code|
+      action = described_class.for(code)
+      expect(action).to be_a(String)
+      expect(action).not_to be_empty
+    end
+  end
+
+  it "falls back to DEFAULT for unknown codes" do
+    expect(described_class.for("NOT_A_REAL_CODE")).to eq(described_class::DEFAULT)
+  end
+
+  it "returns the AUTH_REQUIRED action verbatim" do
+    expect(described_class.for(Browserctl::Error::Codes::AUTH_REQUIRED))
+      .to match(/refresh credentials/i)
+  end
+end

--- a/spec/unit/replay_fallback_spec.rb
+++ b/spec/unit/replay_fallback_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Browserctl::PageProxy, "selector_not_found fallback" do
     it "rematches via fingerprint when selector fails and retries by ref" do
       expect(client).to receive(:click).with("login", "form .submit-old", ref: nil)
                                        .and_return({ error: "selector not found: form .submit-old",
-                                                     code: "selector_not_found" })
+                                                     code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND })
       expect(client).to receive(:snapshot).with("login", format: "elements")
                                           .and_return({ ok: true, snapshot: live_snapshot })
       expect(client).to receive(:click).with("login", nil, ref: "eb22222").and_return({ ok: true })
@@ -42,7 +42,7 @@ RSpec.describe Browserctl::PageProxy, "selector_not_found fallback" do
       proxy = described_class.new("login", client, replay_context: ctx)
       expect(client).to receive(:click).with("login", "form .other", ref: nil)
                                        .and_return({ error: "selector not found: form .other",
-                                                     code: "selector_not_found" })
+                                                     code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND })
 
       expect { proxy.click("form .other") }.to raise_error(Browserctl::WorkflowError, /selector not found/)
       expect(ctx.drift_events).to be_empty
@@ -55,7 +55,7 @@ RSpec.describe Browserctl::PageProxy, "selector_not_found fallback" do
       ]
       expect(client).to receive(:click).with("login", "form .submit-old", ref: nil)
                                        .and_return({ error: "selector not found: form .submit-old",
-                                                     code: "selector_not_found" })
+                                                     code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND })
       expect(client).to receive(:snapshot).and_return({ ok: true, snapshot: cold_snapshot })
 
       expect { proxy.click("form .submit-old") }.to raise_error(Browserctl::WorkflowError)
@@ -66,7 +66,8 @@ RSpec.describe Browserctl::PageProxy, "selector_not_found fallback" do
     it "does not attempt fallback when no replay context is attached" do
       bare = described_class.new("login", client)
       expect(client).to receive(:click).once
-                                       .and_return({ error: "selector not found: x", code: "selector_not_found" })
+                                       .and_return({ error: "selector not found: x",
+                                                     code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND })
       expect(client).not_to receive(:snapshot)
       expect { bare.click("x") }.to raise_error(Browserctl::WorkflowError)
     end
@@ -87,7 +88,7 @@ RSpec.describe Browserctl::PageProxy, "selector_not_found fallback" do
 
       expect(client).to receive(:fill).with("login", "input.old", "me@example.com", ref: nil)
                                       .and_return({ error: "selector not found: input.old",
-                                                    code: "selector_not_found" })
+                                                    code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND })
       expect(client).to receive(:snapshot).and_return({ ok: true, snapshot: live_snapshot })
       expect(client).to receive(:fill).with("login", nil, "me@example.com", ref: "ea11111")
                                       .and_return({ ok: true })

--- a/spec/unit/structured_error_payload_spec.rb
+++ b/spec/unit/structured_error_payload_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/server/command_dispatcher"
+require "browserctl/server/page_session"
+require "browserctl/server/snapshot_builder"
+
+RSpec.describe "structured error payloads on the daemon wire" do
+  let(:driver)   { double("driver") }
+  let(:pages)    { {} }
+  let(:snapshot) { instance_double(Browserctl::SnapshotBuilder) }
+  subject(:dispatcher) { Browserctl::CommandDispatcher.new(pages, driver, snapshot) }
+
+  it "fetch returns SCREAMING_SNAKE KEY_NOT_FOUND with context + suggested_action" do
+    res = dispatcher.dispatch({ cmd: "fetch", key: "missing" })
+    expect(res[:code]).to eq(Browserctl::Error::Codes::KEY_NOT_FOUND)
+    expect(res[:context]).to eq(key: "missing")
+    expect(res[:suggested_action]).to eq(
+      Browserctl::Error::SuggestedActions.for(Browserctl::Error::Codes::KEY_NOT_FOUND)
+    )
+    expect(res[:error]).to match(/key 'missing' not found/)
+  end
+
+  it "navigate returns DOMAIN_NOT_ALLOWED structured payload when policy blocks" do
+    allow(Browserctl::Policy).to receive(:allowed_navigation?).and_return(false)
+    res = dispatcher.dispatch({ cmd: "navigate", name: "x", url: "http://blocked.example" })
+    expect(res[:code]).to eq(Browserctl::Error::Codes::DOMAIN_NOT_ALLOWED)
+    expect(res[:context]).to eq(url: "http://blocked.example")
+    expect(res[:suggested_action]).to be_a(String)
+    expect(res[:suggested_action]).not_to be_empty
+  end
+
+  it "click on a missing selector returns SELECTOR_NOT_FOUND with selector context" do
+    page = double("page")
+    allow(page).to receive(:at_css).and_return(nil)
+    pages["home"] = Browserctl::PageSession.new(page)
+
+    res = dispatcher.dispatch({ cmd: "click", name: "home", selector: ".gone" })
+    expect(res[:code]).to eq(Browserctl::Error::Codes::SELECTOR_NOT_FOUND)
+    expect(res[:context]).to eq(selector: ".gone")
+    expect(res[:suggested_action]).to match(/snapshot/i)
+  end
+end


### PR DESCRIPTION
## Summary

PR #9 of the v0.12 Solid milestone (WS-2 · Standardised error model).

Daemon JSON-RPC errors and CLI stderr now both emit the canonical four-key shape:

```json
{"code":"SELECTOR_NOT_FOUND","message":"selector not found: .x","context":{"selector":".x"},"suggested_action":"Re-run snapshot to get fresh refs, then retry with a stable ref or selector."}
```

## What changed

- `Browserctl::Error#to_payload` — single source of truth for the `{code, message, context, suggested_action}` hash.
- `Browserctl::Error::SuggestedActions` — per-code imperative lookup with a default fallback (`"See docs/reference/errors.md for guidance."` — forward-ref to PR #11).
- `Browserctl::CommandDispatcher::Handlers::ErrorPayload` — centralised builder so handlers don't duplicate serialisation.
- Handlers updated: `navigate` (DOMAIN_NOT_ALLOWED), `fill`/`click`/`hover`/`upload`/`select` (SELECTOR_NOT_FOUND), `fetch` (KEY_NOT_FOUND) — all now carry `context` (selector / url / key) and `suggested_action`.
- `bin/browserctl` and `lib/browserctl/commands/cli_output.rb` — emit human "Error: ..." line on stderr, then a single JSON line on stderr; stdout still carries the raw daemon response.
- `Codes` enum gained `DOMAIN_NOT_ALLOWED`, `KEY_NOT_FOUND`, `GENERIC`.
- `AuthRequiredError#to_response` now also includes `context`/`suggested_action` so the AUTH path matches the canonical shape.

## Breaking (wire format)

Daemon handler responses previously emitted snake_case codes; they now emit SCREAMING_SNAKE:

| before | after |
| --- | --- |
| `selector_not_found` | `SELECTOR_NOT_FOUND` |
| `domain_not_allowed` | `DOMAIN_NOT_ALLOWED` |
| `key_not_found` | `KEY_NOT_FOUND` |

The replay fallback in `Browserctl::PageProxy` (workflow.rb) was updated to match. CHANGELOG.md is release-please generated, so the breaking change is documented here in the PR body.

## Out of scope (deferred)

- Exit-code map — PR #10.
- `docs/reference/errors.md` — PR #11.

## Choices on ambiguity

- Order: human line first, then JSON line on stderr (always — no flag). Smallest reasonable default; agents can grep for the JSON line, humans see the friendly line first.
- `Browserctl::Error` class hierarchy untouched per the brief; only the wire-format strings emitted by handlers were rewritten.

## Test plan

- [x] `bundle exec rspec` — 688 examples, 0 failures
- [x] `bundle exec rubocop` — clean
- [x] New specs: `error_payload_spec`, `structured_error_payload_spec`; extended `cli_output_spec`