### PR TITLE
feat: workflow format version

### DIFF
--- a/docs/reference/format-versions.md
+++ b/docs/reference/format-versions.md
@@ -37,7 +37,7 @@ source of truth for the convention:
 | -------------- | ----------------------------------- | --------------- | ------------------------------------ |
 | State bundle   | `*.bctl` manifest                   | `1` (live)      | `lib/browserctl/state/bundle.rb`     |
 | Recording log  | `recordings/<session>.jsonl`        | `1` (live)      | `lib/browserctl/recording.rb`        |
-| Workflow file  | `workflows/*.rb` (front-matter)     | `1` (reserved)  | `lib/browserctl/workflow.rb` (PR #4) |
+| Workflow file  | `workflows/*.rb` (front-matter)     | `1` (live)      | `lib/browserctl/workflow.rb`         |
 | Drift report   | `drift-*.json`                      | `1` (reserved)  | `lib/browserctl/replay/` (PR #3)     |
 | Daemon state   | `~/.browserctl/state.json`          | `1` (reserved)  | `lib/browserctl/state.rb` (PR #2)    |
 
@@ -64,6 +64,33 @@ When you bump a version:
 3. Register a forward migration with `Browserctl::Migrations` (lands in WS-1
    PR #5). `browserctl migrate <path>` runs registered upgraders.
 4. Update the table above and add a CHANGELOG entry under `### Breaking`.
+
+## Workflow files: warn, don't raise
+
+Workflow files (`*.rb` under `.browserctl/workflows/` or
+`~/.browserctl/workflows/`) are the one exception to the hard-failure
+rule. They declare their version in a top-of-file Ruby comment:
+
+```ruby
+# frozen_string_literal: true
+# format_version: 1
+
+Browserctl.workflow "login" do
+  ...
+end
+```
+
+The loader (`Browserctl::Runner#load_workflow_file`) calls
+`Browserctl.verify_workflow_format_version!` before `load`-ing the
+file. If the header is missing or declares an unsupported version, the
+loader emits a `[browserctl]` warning to stderr and proceeds to load
+the file anyway. This is deliberate: workflows are human-authored
+Ruby, and the cost of refusing to run a slightly-stale workflow is
+worse than the cost of loading it and letting Ruby raise on real
+incompatibility.
+
+Bundles, recordings, and (future) drift reports keep the strict
+`PROTOCOL_MISMATCH` behaviour described below.
 
 ## Unknown-version error
 

--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -172,6 +172,7 @@ module Browserctl
         header  = secret_header(secrets)
         <<~RUBY
           # frozen_string_literal: true
+          # format_version: #{Browserctl::WORKFLOW_FORMAT_VERSION}
           #{header}
           Browserctl.workflow #{name.inspect} do
             desc "Recorded on #{Date.today}"

--- a/lib/browserctl/runner.rb
+++ b/lib/browserctl/runner.rb
@@ -95,7 +95,10 @@ module Browserctl
       return if Browserctl.lookup_workflow(name.to_s)
 
       path = workflow_path(name)
-      load path if path
+      return unless path
+
+      Browserctl.verify_workflow_format_version!(path)
+      load path
     end
 
     def workflow_path(name)
@@ -111,7 +114,10 @@ module Browserctl
 
     def load_from_dir(dir)
       Dir.glob("#{dir}/*.rb").each do |f|
-        load f unless $LOADED_FEATURES.include?(f)
+        next if $LOADED_FEATURES.include?(f)
+
+        Browserctl.verify_workflow_format_version!(f)
+        load f
       end
     end
 

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -11,6 +11,61 @@ require_relative "secret_resolvers"
 require_relative "session"
 
 module Browserctl
+  # Workflow-file format version. Workflows are Ruby files; the schema gate
+  # is a top-of-file comment header:
+  #
+  #   # format_version: 1
+  #
+  # Unlike bundles and recordings, an unsupported or missing version on a
+  # workflow file is a *warning*, not a hard failure. Workflows are
+  # human-authored Ruby — the loader prefers to surface drift via stderr
+  # and let the file run, rather than block execution. See
+  # docs/reference/format-versions.md.
+  WORKFLOW_FORMAT_VERSION = 1
+  SUPPORTED_WORKFLOW_FORMAT_VERSIONS = [WORKFLOW_FORMAT_VERSION].freeze
+
+  # Matches a leading-line comment of the form `# format_version: <int>`.
+  # Tolerates leading whitespace inside the comment body and ignores the
+  # `# frozen_string_literal: true` magic comment that conventionally
+  # precedes it.
+  WORKFLOW_FORMAT_VERSION_HEADER = /^\s*#\s*format_version:\s*(\d+)\s*$/
+
+  # Parses the `# format_version: N` header from a workflow file's source.
+  # Scans only the contiguous leading comment block (and blank lines) so
+  # the header cannot be smuggled in mid-file. Returns the integer if
+  # present, or nil if the file has no version header.
+  def self.parse_workflow_format_version(source)
+    source.each_line do |line|
+      stripped = line.strip
+      next if stripped.empty?
+      break unless stripped.start_with?("#")
+
+      if (m = line.match(WORKFLOW_FORMAT_VERSION_HEADER))
+        return Integer(m[1])
+      end
+    end
+    nil
+  end
+
+  # Reads a workflow file and warns to stderr when the `format_version:`
+  # header is missing or declares an unsupported version. Always returns
+  # the parsed integer (or nil) — never raises. Callers should still
+  # `load` the file regardless.
+  def self.verify_workflow_format_version!(path)
+    source = File.read(path)
+    version = parse_workflow_format_version(source)
+
+    if version.nil?
+      warn "[browserctl] workflow #{path} is missing a `# format_version: N` header " \
+           "(expected #{WORKFLOW_FORMAT_VERSION}); proceeding anyway"
+    elsif !SUPPORTED_WORKFLOW_FORMAT_VERSIONS.include?(version)
+      warn "[browserctl] workflow #{path} format_version=#{version} is not supported " \
+           "(expected #{WORKFLOW_FORMAT_VERSION}); proceeding anyway"
+    end
+
+    version
+  end
+
   ParamDef = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
   StepResult = Struct.new(:name, :ok, :error, keyword_init: true)
   StepDef = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)

--- a/spec/unit/workflow_format_version_spec.rb
+++ b/spec/unit/workflow_format_version_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe "workflow format version" do
       end
     end
 
+    before do
+      # Isolate from doubles leaked by other specs into the global registry.
+      # We only care about the verifier's stderr side-effect here, not the returned list.
+      allow(Browserctl).to receive(:registry_snapshot).and_return({})
+    end
+
     def write_workflow(name, content)
       path = File.join(@workflows_dir, "#{name}.rb")
       File.write(path, content)

--- a/spec/unit/workflow_format_version_spec.rb
+++ b/spec/unit/workflow_format_version_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/workflow"
+require "browserctl/runner"
+require "tmpdir"
+
+RSpec.describe "workflow format version" do
+  describe "Browserctl::WORKFLOW_FORMAT_VERSION" do
+    it "is the integer 1 (current live version)" do
+      expect(Browserctl::WORKFLOW_FORMAT_VERSION).to eq(1)
+      expect(Browserctl::SUPPORTED_WORKFLOW_FORMAT_VERSIONS).to include(1)
+    end
+  end
+
+  describe ".parse_workflow_format_version" do
+    it "parses a `# format_version: N` header on the first line" do
+      src = "# format_version: 1\nBrowserctl.workflow 'x' do\nend\n"
+      expect(Browserctl.parse_workflow_format_version(src)).to eq(1)
+    end
+
+    it "parses the header after a `# frozen_string_literal: true` magic comment" do
+      src = "# frozen_string_literal: true\n# format_version: 2\n\nBrowserctl.workflow 'x' do\nend\n"
+      expect(Browserctl.parse_workflow_format_version(src)).to eq(2)
+    end
+
+    it "tolerates extra whitespace inside the comment body" do
+      src = "#   format_version:   3\n"
+      expect(Browserctl.parse_workflow_format_version(src)).to eq(3)
+    end
+
+    it "returns nil when no header is present in the leading comment block" do
+      src = "# frozen_string_literal: true\n\nBrowserctl.workflow 'x' do\nend\n"
+      expect(Browserctl.parse_workflow_format_version(src)).to be_nil
+    end
+
+    it "ignores a header that appears after code (must be in leading comment block)" do
+      src = "Browserctl.workflow 'x' do\n  # format_version: 1\nend\n"
+      expect(Browserctl.parse_workflow_format_version(src)).to be_nil
+    end
+  end
+
+  describe ".verify_workflow_format_version!" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        @tmp = dir
+        example.run
+      end
+    end
+
+    def write_workflow(content)
+      path = File.join(@tmp, "wf.rb")
+      File.write(path, content)
+      path
+    end
+
+    it "is silent when the header is present and supported" do
+      path = write_workflow("# frozen_string_literal: true\n# format_version: 1\n")
+      expect { Browserctl.verify_workflow_format_version!(path) }.not_to output.to_stderr
+    end
+
+    it "warns to stderr when the header is missing" do
+      path = write_workflow("# frozen_string_literal: true\n\nBrowserctl.workflow 'x' do\nend\n")
+      expect { Browserctl.verify_workflow_format_version!(path) }
+        .to output(/missing a `# format_version: N` header.*proceeding anyway/m).to_stderr
+    end
+
+    it "warns to stderr when the version is unsupported, including the value" do
+      path = write_workflow("# format_version: 99\n")
+      expect { Browserctl.verify_workflow_format_version!(path) }
+        .to output(/format_version=99 is not supported.*proceeding anyway/m).to_stderr
+    end
+
+    it "does not raise on unsupported versions (warn-only)" do
+      path = write_workflow("# format_version: 99\n")
+      expect { Browserctl.verify_workflow_format_version!(path) }.not_to raise_error
+    end
+
+    it "returns the parsed integer when present" do
+      path = write_workflow("# format_version: 1\n")
+      expect { Browserctl.verify_workflow_format_version!(path) }
+        .not_to output.to_stderr
+      expect(Browserctl.verify_workflow_format_version!(path)).to eq(1)
+    end
+  end
+
+  describe "Browserctl::Runner workflow loading" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        @tmp = dir
+        @workflows_dir = File.join(dir, ".browserctl", "workflows")
+        FileUtils.mkdir_p(@workflows_dir)
+        Dir.chdir(dir) { example.run }
+      end
+    end
+
+    def write_workflow(name, content)
+      path = File.join(@workflows_dir, "#{name}.rb")
+      File.write(path, content)
+      path
+    end
+
+    it "warns when loading a workflow file with a missing version header" do
+      write_workflow("wf_missing_#{rand(1_000_000)}", <<~RUBY)
+        # frozen_string_literal: true
+        Browserctl.workflow "wf_missing_header" do
+          desc "no header"
+        end
+      RUBY
+
+      expect { Browserctl::Runner.new.list_workflows }
+        .to output(/missing a `# format_version: N` header/).to_stderr
+    end
+
+    it "does not warn for a workflow file with the supported header" do
+      write_workflow("wf_ok_#{rand(1_000_000)}", <<~RUBY)
+        # frozen_string_literal: true
+        # format_version: 1
+        Browserctl.workflow "wf_ok_header" do
+          desc "good"
+        end
+      RUBY
+
+      expect { Browserctl::Runner.new.list_workflows }.not_to output.to_stderr
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Lands the workflow-file half of the WS-1 format-version convention (v0.12 Solid, PR #4 of WS-1).

Workflows are human-authored Ruby, so the schema gate is a top-of-file comment header:

```ruby
# frozen_string_literal: true
# format_version: 1

Browserctl.workflow "login" do
  ...
end
```

Unlike bundles (`lib/browserctl/state/bundle.rb`) and recordings (`lib/browserctl/recording.rb`), which raise `PROTOCOL_MISMATCH` on bad versions, the workflow loader **warns** to stderr and proceeds — refusing to run a slightly-stale workflow is worse than loading it and letting Ruby raise on real incompatibility. This carve-out is now documented in `docs/reference/format-versions.md`.

### Changes

- `Browserctl::WORKFLOW_FORMAT_VERSION = 1` + `SUPPORTED_WORKFLOW_FORMAT_VERSIONS`.
- `Browserctl.parse_workflow_format_version(source)` — scans only the leading comment block; returns `Integer` or `nil`.
- `Browserctl.verify_workflow_format_version!(path)` — warn-only; never raises.
- `Runner#load_workflow_file` and `#load_from_dir` invoke the verifier before `load`.
- `Recording.generate_workflow` stamps `# format_version: 1` into generated workflows.
- `docs/reference/format-versions.md`: workflow row flipped to "1 (live)"; new "Workflow files: warn, don't raise" section.

Sample warning text:

```
[browserctl] workflow ./.browserctl/workflows/login.rb format_version=99 is not supported (expected 1); proceeding anyway
[browserctl] workflow ./.browserctl/workflows/login.rb is missing a `# format_version: N` header (expected 1); proceeding anyway
```

### Notes / smallest-reasonable choices

- Header key is `format_version` (matches bundle/recording naming) rather than `browserctl_workflow_version`.
- Header must live in the **leading comment block** (after the optional `frozen_string_literal` magic comment, before any code) — prevents a smuggled header mid-file.
- No raise, no migrations, no touching of bundle/recording code paths.
- A pre-existing bug in `Runner#workflow_path` (returns `dir` instead of `candidate` from `find`) is left as-is — out of scope.

## Test plan

- [x] `bundle exec rspec` — 713 examples, 0 failures, 54 pending (Chrome integration).
- [x] `bundle exec rubocop` — clean on changed files.
- [x] New spec `spec/unit/workflow_format_version_spec.rb` — 13 examples covering: constant value, parser (header on first line, after magic comment, whitespace-tolerant, absent, mid-file ignored), verifier (silent on supported, warns on missing, warns on unsupported with value, never raises, returns parsed int), and runner integration via `list_workflows` (warns for missing header, silent for valid header).