### PR TITLE
feat: trace --redact

### DIFF
--- a/lib/browserctl/commands/trace.rb
+++ b/lib/browserctl/commands/trace.rb
@@ -3,20 +3,29 @@
 require "json"
 require "time"
 require_relative "../logger"
+require_relative "../redactor"
+require_relative "../secret_resolver_registry"
 
 module Browserctl
   module Commands
-    # `browserctl trace [<session>]` — pretty timeline of structured log events
-    # across cli.log + daemon.log. Defaults to most recent session.
+    # `browserctl trace [<session>] [--no-redact]` — pretty timeline of
+    # structured log events across cli.log + daemon.log. Defaults to most
+    # recent session.
     #
     # Loose categorisation by inspecting common keys (event/snapshot/request/
     # error). No schema is enforced — this command is tolerant of any JSONL
     # produced by Browserctl::JsonlFormatter.
     #
-    # TODO(PR#15): redact secrets via `--redact` flag. This PR prints raw
-    # log content as-is.
+    # Redaction: ON by default. Secret values are sourced from current ENV
+    # patterns (`*_TOKEN`, `*_KEY`, `*_SECRET`, `*_PASSWORD`) and any values
+    # captured by `SecretResolverRegistry` during this process. Pass
+    # `--no-redact` to disable (local debugging only). Note: when replaying
+    # historical traces from a previous process, registry-captured values are
+    # gone — only current ENV patterns apply.
     module Trace
-      USAGE = "Usage: browserctl trace [<session>]"
+      USAGE = "Usage: browserctl trace [<session>] [--no-redact]"
+      NO_REDACT_WARNING = "[browserctl] traces include unredacted secret values; " \
+                          "do not paste this output publicly."
 
       LEVEL_COLORS = {
         "DEBUG" => "\e[2;37m", # dim grey
@@ -35,9 +44,18 @@ module Browserctl
 
       OMIT_KEYS = %w[ts level component event msg].freeze
 
-      def self.run(args, log_dir: Browserctl.log_dir, out: $stdout)
+      def self.run(args, log_dir: Browserctl.log_dir, out: $stdout, err: $stderr)
         abort USAGE if args.include?("-h") || args.include?("--help")
+        args = args.dup
+        redact = !args.delete("--no-redact")
         session_filter = args.shift
+
+        if redact
+          redactor = build_redactor
+        else
+          redactor = nil
+          warn_no_redact(err)
+        end
 
         records = load_records(log_dir)
         if records.empty?
@@ -51,7 +69,22 @@ module Browserctl
           return
         end
 
-        render(records, out: out)
+        render(records, out: out, redactor: redactor)
+      end
+
+      def self.build_redactor
+        extra = if defined?(Browserctl::SecretResolverRegistry)
+                  Browserctl::SecretResolverRegistry.resolved_values
+                else
+                  []
+                end
+        Browserctl::Redactor.from_env(extra: extra)
+      rescue StandardError
+        Browserctl::Redactor.new(secrets: [])
+      end
+
+      def self.warn_no_redact(err)
+        err&.puts NO_REDACT_WARNING
       end
 
       def self.load_records(log_dir)
@@ -89,12 +122,12 @@ module Browserctl
         end
       end
 
-      def self.render(records, out:)
+      def self.render(records, out:, redactor: nil)
         tty = out.respond_to?(:tty?) && out.tty?
-        records.each { |r| out.puts(format_line(r, tty: tty)) }
+        records.each { |r| out.puts(format_line(r, tty: tty, redactor: redactor)) }
       end
 
-      def self.format_line(record, tty:)
+      def self.format_line(record, tty:, redactor: nil)
         level = (record["level"] || "INFO").to_s
         line  = format("%-12<ts>s %<icon>s %-5<level>s %-7<comp>s %-22<label>s %<ctx>s",
                        ts: format_ts(record["ts"]),
@@ -104,6 +137,7 @@ module Browserctl
                        label: event_label(record),
                        ctx: context_snippet(record)).rstrip
 
+        line = redactor.redact(line) if redactor
         tty ? colourise(line, level) : line
       end
 

--- a/lib/browserctl/redactor.rb
+++ b/lib/browserctl/redactor.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Browserctl
+  # Redacts known secret values from arbitrary strings.
+  #
+  # Used by `browserctl trace` to ensure traces are safe to attach to issues
+  # by default. Secret values are sourced from two places:
+  #   1. ENV variables whose names match well-known secret patterns
+  #      (`*_TOKEN`, `*_KEY`, `*_SECRET`, `*_PASSWORD`).
+  #   2. Values captured at runtime by `SecretResolverRegistry` (in-memory
+  #      only — never persisted).
+  #
+  # Replacement marker is the literal `[REDACTED]`. We considered including
+  # a sha256 prefix to distinguish values, but that doubles the surface area
+  # for accidental leakage (a determined attacker could brute-force short
+  # secrets from the prefix), and the timeline is more scannable with a
+  # uniform marker.
+  class Redactor
+    MARKER = "[REDACTED]"
+    MIN_LENGTH = 4
+    ENV_PATTERNS = [/_TOKEN\z/, /_KEY\z/, /_SECRET\z/, /_PASSWORD\z/].freeze
+
+    # @param secrets [Array<String>] secret values to redact.
+    def initialize(secrets: [])
+      # Filter empty / too-short values; longest-first to avoid partial
+      # overlaps (e.g. redacting "abcd" before "abcdef" would leave "ef").
+      @secrets = secrets
+                 .compact
+                 .map(&:to_s)
+                 .reject { |s| s.length < MIN_LENGTH }
+                 .uniq
+                 .sort_by { |s| -s.length }
+    end
+
+    # @param string [String, nil]
+    # @return [String, nil]
+    def redact(string)
+      return string if string.nil?
+
+      result = string.to_s
+      @secrets.each { |secret| result = result.gsub(secret, MARKER) }
+      result
+    end
+
+    def empty?
+      @secrets.empty?
+    end
+
+    # Build a Redactor from the current ENV using well-known patterns.
+    # Optionally merges in additional values (e.g. from runtime instrumentation).
+    def self.from_env(env: ENV, extra: [])
+      values = env.each_with_object([]) do |(name, value), acc|
+        acc << value if ENV_PATTERNS.any? { |re| name =~ re }
+      end
+      new(secrets: values + Array(extra))
+    end
+  end
+end

--- a/lib/browserctl/secret_resolver_registry.rb
+++ b/lib/browserctl/secret_resolver_registry.rb
@@ -4,8 +4,9 @@ require_relative "errors"
 
 module Browserctl
   class SecretResolverRegistry
-    @mutex    = Mutex.new
-    @registry = {}
+    @mutex          = Mutex.new
+    @registry       = {}
+    @resolved_values = []
 
     def self.register(resolver_class)
       instance = resolver_class.new
@@ -25,7 +26,9 @@ module Browserctl
         raise SecretResolverError, msg
       end
 
-      resolver.resolve(reference)
+      value = resolver.resolve(reference)
+      record_resolved_value(value)
+      value
     rescue SecretResolverError
       raise
     rescue StandardError => e
@@ -36,8 +39,24 @@ module Browserctl
       @mutex.synchronize { @registry.key?(scheme) }
     end
 
+    # In-memory record of values resolved during this process. Used by the
+    # Redactor so trace output never leaks values that flowed through the
+    # registry. Never persisted.
+    def self.resolved_values
+      @mutex.synchronize { @resolved_values.dup }
+    end
+
+    def self.record_resolved_value(value)
+      return unless value.is_a?(String) && !value.empty?
+
+      @mutex.synchronize { @resolved_values << value unless @resolved_values.include?(value) }
+    end
+
     def self.reset!
-      @mutex.synchronize { @registry.clear }
+      @mutex.synchronize do
+        @registry.clear
+        @resolved_values.clear
+      end
     end
   end
 end

--- a/spec/unit/redactor_spec.rb
+++ b/spec/unit/redactor_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/redactor"
+
+RSpec.describe Browserctl::Redactor do
+  describe "#redact" do
+    it "replaces a known secret value with [REDACTED]" do
+      redactor = described_class.new(secrets: ["sk-supersecret"])
+      expect(redactor.redact("token=sk-supersecret bar")).to eq("token=[REDACTED] bar")
+    end
+
+    it "redacts longer matches before shorter ones" do
+      redactor = described_class.new(secrets: %w[abcd abcdef])
+      # If "abcd" was applied first, "ef" would be left dangling. Longest-first
+      # ensures the full "abcdef" is replaced as one unit.
+      expect(redactor.redact("xx abcdef yy")).to eq("xx [REDACTED] yy")
+    end
+
+    it "skips empty and short secret values" do
+      redactor = described_class.new(secrets: ["", nil, "abc", "longenough"])
+      expect(redactor.redact("abc longenough")).to eq("abc [REDACTED]")
+    end
+
+    it "is case-sensitive" do
+      redactor = described_class.new(secrets: ["SecretValue"])
+      expect(redactor.redact("secretvalue SecretValue")).to eq("secretvalue [REDACTED]")
+    end
+
+    it "returns nil unchanged" do
+      expect(described_class.new(secrets: ["abcd"]).redact(nil)).to be_nil
+    end
+
+    it "returns the original string when no secrets are configured" do
+      expect(described_class.new(secrets: []).redact("hello")).to eq("hello")
+    end
+
+    it "redacts repeated occurrences" do
+      redactor = described_class.new(secrets: ["mysecret"])
+      expect(redactor.redact("mysecret and mysecret again"))
+        .to eq("[REDACTED] and [REDACTED] again")
+    end
+  end
+
+  describe ".from_env" do
+    it "picks up values from variables matching well-known patterns" do
+      env = {
+        "GITHUB_TOKEN" => "ghp_abcdef123456",
+        "API_KEY" => "key_abcd",
+        "DB_PASSWORD" => "hunter22",
+        "OAUTH_SECRET" => "shhh1234",
+        "PATH" => "/usr/bin",
+        "HOME" => "/home/me"
+      }
+      redactor = described_class.from_env(env: env)
+      out = redactor.redact("ghp_abcdef123456 key_abcd hunter22 shhh1234 /usr/bin")
+      expect(out).to eq("[REDACTED] [REDACTED] [REDACTED] [REDACTED] /usr/bin")
+    end
+
+    it "merges in extra runtime-captured values" do
+      env = { "PATH" => "/usr/bin" }
+      redactor = described_class.from_env(env: env, extra: ["runtime-secret"])
+      expect(redactor.redact("hi runtime-secret")).to eq("hi [REDACTED]")
+    end
+  end
+end

--- a/spec/unit/trace_spec.rb
+++ b/spec/unit/trace_spec.rb
@@ -9,6 +9,7 @@ require "tmpdir"
 RSpec.describe Browserctl::Commands::Trace do
   let(:tmp_dir) { Dir.mktmpdir("browserctl-trace") }
   let(:out)     { StringIO.new }
+  let(:err)     { StringIO.new }
 
   after { FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir) }
 
@@ -86,6 +87,44 @@ RSpec.describe Browserctl::Commands::Trace do
 
       described_class.run([], log_dir: tmp_dir, out: out)
       expect(out.string).not_to include("\e[")
+    end
+  end
+
+  describe "redaction" do
+    around do |example|
+      original = ENV.fetch("FAKE_API_TOKEN", nil)
+      ENV["FAKE_API_TOKEN"] = "tk_fakesecretvalue123"
+      example.run
+    ensure
+      if original.nil?
+        ENV.delete("FAKE_API_TOKEN")
+      else
+        ENV["FAKE_API_TOKEN"] = original
+      end
+    end
+
+    it "redacts ENV-pattern secret values from output by default" do
+      write_log("cli.log", [
+                  { ts: "2026-05-10T06:00:00.000Z", level: "INFO", component: "cli",
+                    event: "auth", header: "Bearer tk_fakesecretvalue123" }
+                ])
+
+      described_class.run([], log_dir: tmp_dir, out: out, err: err)
+      expect(out.string).not_to include("tk_fakesecretvalue123")
+      expect(out.string).to include("[REDACTED]")
+      expect(err.string).to be_empty
+    end
+
+    it "passes secrets through with --no-redact and warns on stderr" do
+      write_log("cli.log", [
+                  { ts: "2026-05-10T06:00:00.000Z", level: "INFO", component: "cli",
+                    event: "auth", header: "Bearer tk_fakesecretvalue123" }
+                ])
+
+      described_class.run(["--no-redact"], log_dir: tmp_dir, out: out, err: err)
+      expect(out.string).to include("tk_fakesecretvalue123")
+      expect(out.string).not_to include("[REDACTED]")
+      expect(err.string).to include("unredacted secret values")
     end
   end
 end


### PR DESCRIPTION
## Summary

`browserctl trace` now redacts known secret values from output **by default** so traces can be safely attached to issues.

- New `Browserctl::Redactor` (substring replacement, longest-first, case-sensitive, skips values < 4 chars).
- `SecretResolverRegistry` records resolved values in-memory (per process, never persisted) so values that flowed through `env://` / `keychain://` / `op://` are also redacted.
- `Browserctl::Commands::Trace` builds a redactor from current ENV (`*_TOKEN`, `*_KEY`, `*_SECRET`, `*_PASSWORD`) plus the registry's captured set, and applies it to every rendered line.
- New `--no-redact` opt-out for local debugging; emits a stderr warning.

Marker is the literal `[REDACTED]`. A sha256-prefix variant was considered but rejected — uniform marker keeps the timeline scannable and avoids leaking discriminators for short secrets.

## Sample output

Given a log line containing `Bearer ghp_abcdef1234567890` while `GITHUB_TOKEN=ghp_abcdef1234567890` is set:

Default (redaction on):
```
06:00:00.000 . INFO  cli     auth                   header=Bearer [REDACTED]
```

With `--no-redact`:
```
[browserctl] traces include unredacted secret values; do not paste this output publicly.
06:00:00.000 . INFO  cli     auth                   header=Bearer ghp_abcdef1234567890
```

## Historical-trace caveat

When trace replays JSONL written by a previous process, the registry's in-memory set is empty. Only current-ENV pattern matches apply. Documented in the module docstring.

## Follow-up: crash reports?

`crash_report.rb` was deliberately left out of this PR (out of scope per WS-3). Crash reports also serialise stack frames and context that may include secret values, and they are written to disk — so they're arguably more sensitive than trace output. Recommend a follow-up PR to thread `Redactor` through `CrashReport` before write.

## Test plan

- [x] `bundle exec rspec` — 711 examples, 0 failures
- [x] `bundle exec rubocop` clean on changed files
- [x] Manual: confirmed default redaction + `--no-redact` passthrough + stderr warning