### PR TITLE
feat: exit code map

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -52,7 +52,7 @@ def print_result(res)
   warn "Error: #{message}"
   warn payload
   puts res.to_json
-  exit(code == "AUTH_REQUIRED" ? 7 : 1)
+  exit Browserctl::Error::ExitCodes.for(code)
 end
 
 def usage
@@ -184,100 +184,112 @@ usage if cmd.nil? || %w[-h --help help].include?(cmd)
 
 runner = Browserctl::Runner.new
 
-case cmd
-when "workflow" then Browserctl::Commands::Workflow.run(runner, args)
-when "record"   then Browserctl::Commands::Record.run(args)
-when "init"     then Browserctl::Commands::Init.run(args)
-when "ask"      then Browserctl::Commands::Ask.run(args)
-when "trace"    then Browserctl::Commands::Trace.run(args)
-
-else
-  client = Browserctl::Client.new(Browserctl.socket_path(daemon_name))
-
+begin
   case cmd
-  when "flow"     then Browserctl::Commands::Flow.run(client, args)
-  when "page"     then Browserctl::Commands::Page.run(client, args)
-  when "cookie"   then Browserctl::Commands::Cookie.run(client, args)
-  when "storage"  then Browserctl::Commands::Storage.run(client, args)
-  when "session"  then Browserctl::Commands::Session.run(client, args)
-  when "state"    then Browserctl::Commands::State.run(client, args)
-  when "daemon"   then Browserctl::Commands::Daemon.run(client, args)
-  when "auth-check"
-    page_name = args.shift or abort "usage: browserctl auth-check <page> [--cookies] [--state NAME] [--flow NAME]"
-    include_cookies = args.delete("--cookies") ? true : false
-    state_idx = args.index("--state")
-    state_arg = if state_idx
-                  (args.delete_at(state_idx)
-                   args.delete_at(state_idx))
-                end
-    flow_idx  = args.index("--flow")
-    flow_arg  = if flow_idx
-                  (args.delete_at(flow_idx)
-                   args.delete_at(flow_idx))
-                end
-    print_result(client.auth_check(page_name, include_cookies: include_cookies,
-                                              state: state_arg, suggested_flow: flow_arg))
-  when "navigate" then print_result(client.navigate(args[0], args[1]))
-  when "fill"     then Browserctl::Commands::Fill.run(client, args)
-  when "click"    then Browserctl::Commands::Click.run(client, args)
-  when "snapshot" then Browserctl::Commands::Snapshot.run(client, args)
-  when "screenshot" then Browserctl::Commands::Screenshot.run(client, args)
-  when "evaluate" then print_result(client.evaluate(args[0], args[1]))
-  when "url"      then print_result(client.url(args[0]))
-  when "wait"
-    opts = Optimist.options(args) do
-      opt :timeout, "Seconds to wait (default: 30)", default: 30.0, short: "-t"
-    end
-    name = args.shift
-    selector = args.shift
-    abort "usage: browserctl wait <page> <selector> [--timeout N]" unless name && selector
-    print_result(client.wait(name, selector, timeout: opts[:timeout]))
-  when "pause"
-    opts = Optimist.options(args) do
-      opt :message, "Message shown to human", type: :string, short: "-m"
-    end
-    name = args.shift or abort "usage: browserctl pause <page> [--message MSG]"
-    res = client.pause(name, message: opts[:message])
-    if res[:error]
-      warn "Error: #{res[:error]}"
-      exit 1
-    end
-    puts "Page '#{name}' paused. Browser is live — interact freely."
-    puts "(#{opts[:message]})" if opts[:message]
-    puts "When done: browserctl resume #{name}"
-  when "resume" then Browserctl::Commands::Resume.run(client, args)
-  when "press"
-    name = args.shift or abort "usage: browserctl press <page> <key>"
-    key  = args.shift or abort "usage: browserctl press <page> <key>"
-    print_result(client.press(name, key))
-  when "hover"
-    name     = args.shift or abort "usage: browserctl hover <page> <selector>"
-    selector = args.shift or abort "usage: browserctl hover <page> <selector>"
-    print_result(client.hover(name, selector))
-  when "upload"
-    name     = args.shift or abort "usage: browserctl upload <page> <selector> <file>"
-    selector = args.shift or abort "usage: browserctl upload <page> <selector> <file>"
-    path     = args.shift or abort "usage: browserctl upload <page> <selector> <file>"
-    print_result(client.upload(name, selector, path))
-  when "select"
-    name     = args.shift or abort "usage: browserctl select <page> <selector> <value>"
-    selector = args.shift or abort "usage: browserctl select <page> <selector> <value>"
-    value    = args.shift or abort "usage: browserctl select <page> <selector> <value>"
-    print_result(client.select(name, selector, value))
-  when "dialog" then Browserctl::Commands::Dialog.run(client, args)
-  when "devtools"
-    name = args.shift or abort "usage: browserctl devtools <page>"
-    res = client.devtools(name)
-    if res[:error]
-      warn "Error: #{res[:error]}"
-      exit 1
-    end
-    url = res[:devtools_url]
-    puts "Opening DevTools for '#{name}':"
-    puts "  #{url}"
-    opener = RUBY_PLATFORM =~ /darwin/ ? "open" : "xdg-open"
-    system(opener, url)
+  when "workflow" then Browserctl::Commands::Workflow.run(runner, args)
+  when "record"   then Browserctl::Commands::Record.run(args)
+  when "init"     then Browserctl::Commands::Init.run(args)
+  when "ask"      then Browserctl::Commands::Ask.run(args)
+  when "trace"    then Browserctl::Commands::Trace.run(args)
+
   else
-    abort "unknown command: #{cmd}\nRun 'browserctl --help' for usage."
+    client = Browserctl::Client.new(Browserctl.socket_path(daemon_name))
+
+    case cmd
+    when "flow"     then Browserctl::Commands::Flow.run(client, args)
+    when "page"     then Browserctl::Commands::Page.run(client, args)
+    when "cookie"   then Browserctl::Commands::Cookie.run(client, args)
+    when "storage"  then Browserctl::Commands::Storage.run(client, args)
+    when "session"  then Browserctl::Commands::Session.run(client, args)
+    when "state"    then Browserctl::Commands::State.run(client, args)
+    when "daemon"   then Browserctl::Commands::Daemon.run(client, args)
+    when "auth-check"
+      page_name = args.shift or abort "usage: browserctl auth-check <page> [--cookies] [--state NAME] [--flow NAME]"
+      include_cookies = args.delete("--cookies") ? true : false
+      state_idx = args.index("--state")
+      state_arg = if state_idx
+                    (args.delete_at(state_idx)
+                     args.delete_at(state_idx))
+                  end
+      flow_idx  = args.index("--flow")
+      flow_arg  = if flow_idx
+                    (args.delete_at(flow_idx)
+                     args.delete_at(flow_idx))
+                  end
+      print_result(client.auth_check(page_name, include_cookies: include_cookies,
+                                                state: state_arg, suggested_flow: flow_arg))
+    when "navigate" then print_result(client.navigate(args[0], args[1]))
+    when "fill"     then Browserctl::Commands::Fill.run(client, args)
+    when "click"    then Browserctl::Commands::Click.run(client, args)
+    when "snapshot" then Browserctl::Commands::Snapshot.run(client, args)
+    when "screenshot" then Browserctl::Commands::Screenshot.run(client, args)
+    when "evaluate" then print_result(client.evaluate(args[0], args[1]))
+    when "url"      then print_result(client.url(args[0]))
+    when "wait"
+      opts = Optimist.options(args) do
+        opt :timeout, "Seconds to wait (default: 30)", default: 30.0, short: "-t"
+      end
+      name = args.shift
+      selector = args.shift
+      abort "usage: browserctl wait <page> <selector> [--timeout N]" unless name && selector
+      print_result(client.wait(name, selector, timeout: opts[:timeout]))
+    when "pause"
+      opts = Optimist.options(args) do
+        opt :message, "Message shown to human", type: :string, short: "-m"
+      end
+      name = args.shift or abort "usage: browserctl pause <page> [--message MSG]"
+      res = client.pause(name, message: opts[:message])
+      if res[:error]
+        warn "Error: #{res[:error]}"
+        exit 1
+      end
+      puts "Page '#{name}' paused. Browser is live — interact freely."
+      puts "(#{opts[:message]})" if opts[:message]
+      puts "When done: browserctl resume #{name}"
+    when "resume" then Browserctl::Commands::Resume.run(client, args)
+    when "press"
+      name = args.shift or abort "usage: browserctl press <page> <key>"
+      key  = args.shift or abort "usage: browserctl press <page> <key>"
+      print_result(client.press(name, key))
+    when "hover"
+      name     = args.shift or abort "usage: browserctl hover <page> <selector>"
+      selector = args.shift or abort "usage: browserctl hover <page> <selector>"
+      print_result(client.hover(name, selector))
+    when "upload"
+      name     = args.shift or abort "usage: browserctl upload <page> <selector> <file>"
+      selector = args.shift or abort "usage: browserctl upload <page> <selector> <file>"
+      path     = args.shift or abort "usage: browserctl upload <page> <selector> <file>"
+      print_result(client.upload(name, selector, path))
+    when "select"
+      name     = args.shift or abort "usage: browserctl select <page> <selector> <value>"
+      selector = args.shift or abort "usage: browserctl select <page> <selector> <value>"
+      value    = args.shift or abort "usage: browserctl select <page> <selector> <value>"
+      print_result(client.select(name, selector, value))
+    when "dialog" then Browserctl::Commands::Dialog.run(client, args)
+    when "devtools"
+      name = args.shift or abort "usage: browserctl devtools <page>"
+      res = client.devtools(name)
+      if res[:error]
+        warn "Error: #{res[:error]}"
+        exit 1
+      end
+      url = res[:devtools_url]
+      puts "Opening DevTools for '#{name}':"
+      puts "  #{url}"
+      opener = RUBY_PLATFORM =~ /darwin/ ? "open" : "xdg-open"
+      system(opener, url)
+    else
+      abort "unknown command: #{cmd}\nRun 'browserctl --help' for usage."
+    end
   end
+rescue Browserctl::Error => e
+  payload = {
+    code: e.code,
+    message: e.message,
+    context: e.respond_to?(:context) ? (e.context || {}) : {},
+    suggested_action: Browserctl::Error::SuggestedActions.for(e.code)
+  }
+  warn "Error: #{e.message}"
+  warn JSON.generate(payload)
+  exit Browserctl::Error::ExitCodes.for(e.code)
 end

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -141,6 +141,8 @@ One of `selector` or `ref` is required for `fill` and `click`. Both cannot be om
 
 CLI command names and their flags map 1-to-1 to wire commands via the subcommand routers in `lib/browserctl/commands/`. There are no abbreviation aliases — CLI names match their wire counterparts exactly.
 
+CLI process exit codes are also part of this zone — see [exit-codes.md](exit-codes.md) for the full table.
+
 ---
 
 ## Breaking changes log

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -1,0 +1,39 @@
+# browserctl Exit Codes
+
+The `browserctl` CLI exits with a small, stable set of integer status codes so AI agents and shell scripts can branch on `$?` without parsing stderr.
+
+The mapping is implemented in [`lib/browserctl/error/exit_codes.rb`](../../lib/browserctl/error/exit_codes.rb) and lives in the **Stable** zone (see [api-stability.md](api-stability.md)) — codes will not be renumbered without a major version bump.
+
+## Table
+
+| Exit code | Name                 | Meaning                                                                                  | Mapped `Codes::*`             | Example trigger                                                                  |
+| --------- | -------------------- | ---------------------------------------------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------------------- |
+| `0`       | `OK`                 | Success.                                                                                 | —                             | Any command returning a normal result.                                           |
+| `1`       | `GENERIC`            | Catch-all for errors not (yet) assigned a dedicated code. Always the safe fallback.      | `GENERIC`, plus any unmapped code (e.g. `DOMAIN_NOT_ALLOWED`, `KEY_NOT_FOUND`, `SECRET_RESOLUTION_FAILED`) | `state load <missing>`; allowlist denial.                                        |
+| `2`       | `DRIFT`              | **Reserved.** Allocated for an upcoming snapshot/selector drift signal in a later v0.12 PR. Currently unmapped — drift conditions surface as `GENERIC`. | _none yet_                    | _(reserved)_                                                                     |
+| `3`       | `AUTH_REQUIRED`      | The page or state bundle requires re-authentication. Rotate the bound flow and retry.   | `AUTH_REQUIRED`               | `auth-check` against a logged-out session; `state load` on an expired bundle whose flow re-runs. |
+| `4`       | `DAEMON_UNREACHABLE` | The CLI could not reach the daemon socket.                                              | `DAEMON_UNREACHABLE`          | Daemon not started, wrong `--daemon` name, or socket file missing.               |
+| `5`       | `PROTOCOL_MISMATCH`  | A persisted artifact's `version:` header is newer (or otherwise unsupported) than this build can read. | `PROTOCOL_MISMATCH`           | Loading a state bundle, recording, or workflow saved by a future browserctl.     |
+| `6`       | `SELECTOR_NOT_FOUND` | A CSS selector or stable ref did not match anything on the page.                        | `SELECTOR_NOT_FOUND`          | `click <page> "#missing"`; ref invalidated by a re-render.                       |
+| `7`       | `STATE_EXPIRED`      | A state bundle's TTL window has passed and it cannot be safely reused.                  | `STATE_EXPIRED`               | `state load` on a bundle past its `expires_at`.                                  |
+
+## Lookup contract
+
+`Browserctl::Error::ExitCodes.for(code)`:
+
+- Returns the integer above for any known `Codes::*` string.
+- Returns `1` (`GENERIC`) for `nil` or any code without an explicit entry.
+- Never raises.
+
+This is what the CLI's top-level rescue calls when a `Browserctl::Error` escapes:
+
+```ruby
+rescue Browserctl::Error => e
+  # ...emit human + JSON stderr...
+  exit Browserctl::Error::ExitCodes.for(e.code)
+end
+```
+
+## Compatibility note (v0.12)
+
+Prior to v0.12, the CLI exited `1` for everything except `AUTH_REQUIRED` (which already exited `7`). Scripts that hard-coded `exit 1 = error` continue to work — `1` is still the catch-all. Scripts that hard-coded `7 = AUTH_REQUIRED` must update: `AUTH_REQUIRED` is now `3`, and `7` is `STATE_EXPIRED`.

--- a/lib/browserctl/error/exit_codes.rb
+++ b/lib/browserctl/error/exit_codes.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative "codes"
+
+module Browserctl
+  class Error < StandardError
+    # Stable mapping from a canonical {Browserctl::Error::Codes} string to a
+    # process exit status. The CLI's top-level rescue uses this so AI agents
+    # and shell scripts can branch on `$?` deterministically without parsing
+    # stderr.
+    #
+    # Stability contract:
+    # - Exit code integers are part of the v0.12 stable surface and will not
+    #   be renumbered without a major version bump.
+    # - Unknown / unmapped codes intentionally fall through to {GENERIC} (1)
+    #   so an unfamiliar code never silently surfaces as a non-error (0).
+    #
+    # See docs/reference/exit-codes.md for the operator-facing table.
+    module ExitCodes
+      OK                 = 0
+      GENERIC            = 1
+      DRIFT              = 2
+      AUTH_REQUIRED      = 3
+      DAEMON_UNREACHABLE = 4
+      PROTOCOL_MISMATCH  = 5
+      SELECTOR_NOT_FOUND = 6
+      STATE_EXPIRED      = 7
+
+      # Canonical Codes string → exit status integer. Codes without an entry
+      # (e.g. DOMAIN_NOT_ALLOWED, KEY_NOT_FOUND, SECRET_RESOLUTION_FAILED,
+      # GENERIC) collapse to {GENERIC} for now; they may earn dedicated exit
+      # codes in a future milestone.
+      #
+      # DRIFT (2) is reserved for a future Codes::DRIFT and currently has no
+      # entry in this table — drift-related raises fall through to GENERIC
+      # until that code is introduced.
+      TABLE = {
+        Codes::AUTH_REQUIRED => AUTH_REQUIRED,
+        Codes::DAEMON_UNREACHABLE => DAEMON_UNREACHABLE,
+        Codes::PROTOCOL_MISMATCH => PROTOCOL_MISMATCH,
+        Codes::SELECTOR_NOT_FOUND => SELECTOR_NOT_FOUND,
+        Codes::STATE_EXPIRED => STATE_EXPIRED
+      }.freeze
+
+      # @param code [String, nil] a canonical code from {Browserctl::Error::Codes}
+      # @return [Integer] mapped exit status; {GENERIC} for nil or unknown codes
+      def self.for(code)
+        return GENERIC if code.nil?
+
+        TABLE.fetch(code, GENERIC)
+      end
+    end
+  end
+end

--- a/lib/browserctl/errors.rb
+++ b/lib/browserctl/errors.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "error/codes"
+require_relative "error/exit_codes"
 require_relative "error/suggested_actions"
 
 module Browserctl

--- a/spec/unit/exit_codes_spec.rb
+++ b/spec/unit/exit_codes_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "English"
+require "spec_helper"
+require "browserctl/errors"
+
+RSpec.describe Browserctl::Error::ExitCodes do
+  describe "stable integer constants" do
+    it "pins each named status to its v0.12 wire-stable integer" do
+      {
+        OK: 0,
+        GENERIC: 1,
+        DRIFT: 2,
+        AUTH_REQUIRED: 3,
+        DAEMON_UNREACHABLE: 4,
+        PROTOCOL_MISMATCH: 5,
+        SELECTOR_NOT_FOUND: 6,
+        STATE_EXPIRED: 7
+      }.each do |const, value|
+        expect(described_class.const_get(const)).to eq(value)
+      end
+    end
+  end
+
+  describe ".for" do
+    it "maps each canonical Codes::* with a dedicated exit code" do
+      {
+        Browserctl::Error::Codes::AUTH_REQUIRED => 3,
+        Browserctl::Error::Codes::DAEMON_UNREACHABLE => 4,
+        Browserctl::Error::Codes::PROTOCOL_MISMATCH => 5,
+        Browserctl::Error::Codes::SELECTOR_NOT_FOUND => 6,
+        Browserctl::Error::Codes::STATE_EXPIRED => 7
+      }.each do |code, expected|
+        expect(described_class.for(code)).to eq(expected)
+      end
+    end
+
+    it "returns GENERIC (1) for nil" do
+      expect(described_class.for(nil)).to eq(1)
+    end
+
+    it "returns GENERIC (1) for an unknown string" do
+      expect(described_class.for("UNKNOWN")).to eq(1)
+      expect(described_class.for("not_a_code")).to eq(1)
+      expect(described_class.for("")).to eq(1)
+    end
+
+    it "returns GENERIC (1) for codes that exist in the enum but have no dedicated exit slot" do
+      expect(described_class.for(Browserctl::Error::Codes::GENERIC)).to eq(1)
+      expect(described_class.for(Browserctl::Error::Codes::DOMAIN_NOT_ALLOWED)).to eq(1)
+      expect(described_class.for(Browserctl::Error::Codes::KEY_NOT_FOUND)).to eq(1)
+      expect(described_class.for(Browserctl::Error::Codes::SECRET_RESOLUTION_FAILED)).to eq(1)
+    end
+
+    it "DRIFT (2) is reserved — no canonical Codes::* maps to it yet" do
+      mapped = Browserctl::Error::Codes.all.map { |c| described_class.for(c) }
+      expect(mapped).not_to include(described_class::DRIFT)
+    end
+
+    it "never raises for arbitrary input" do
+      [nil, "", "x", :sym, 123].each do |bad|
+        expect { described_class.for(bad) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "CLI top-level rescue integration" do
+    let(:bin) { File.expand_path("../../bin/browserctl", __dir__) }
+
+    # Drives the CLI binary against a non-existent daemon socket. The
+    # client raises Browserctl::DaemonUnavailableError (code:
+    # DAEMON_UNREACHABLE), which the new top-level rescue must map to
+    # exit status 4 — the strongest end-to-end assertion that the map is
+    # wired into the binary's escape path.
+    it "maps a typed DAEMON_UNREACHABLE error to exit code 4" do
+      Dir.mktmpdir do |home|
+        out = `BROWSERCTL_HOME=#{home} HOME=#{home} #{bin} state load any-name 2>&1`
+        status = $CHILD_STATUS.exitstatus
+        expect(status).to eq(4), "expected exit 4, got #{status}; output:\n#{out}"
+        expect(out).to include("DAEMON_UNREACHABLE")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

WS-2 / PR #10 of the v0.12 "Solid" milestone. Codifies CLI process exit codes via a new `Browserctl::Error::ExitCodes` module so AI agents and shell scripts can branch on `$?` deterministically without parsing stderr.

| Exit | Name                 | Mapped `Codes::*`                                                                                |
| ---: | -------------------- | ------------------------------------------------------------------------------------------------ |
|  `0` | `OK`                 | —                                                                                                |
|  `1` | `GENERIC`            | `GENERIC` + any unmapped code (e.g. `DOMAIN_NOT_ALLOWED`, `KEY_NOT_FOUND`, `SECRET_RESOLUTION_FAILED`) |
|  `2` | `DRIFT`              | _reserved_ — no current `Codes::*` maps here; falls through to `GENERIC` until a future PR adds `Codes::DRIFT` |
|  `3` | `AUTH_REQUIRED`      | `AUTH_REQUIRED`                                                                                  |
|  `4` | `DAEMON_UNREACHABLE` | `DAEMON_UNREACHABLE`                                                                             |
|  `5` | `PROTOCOL_MISMATCH`  | `PROTOCOL_MISMATCH`                                                                              |
|  `6` | `SELECTOR_NOT_FOUND` | `SELECTOR_NOT_FOUND`                                                                             |
|  `7` | `STATE_EXPIRED`      | `STATE_EXPIRED`                                                                                  |

- `lib/browserctl/error/exit_codes.rb` — module + `ExitCodes.for(code)` (nil/unknown → `GENERIC`, never raises).
- `bin/browserctl` — added a top-level `rescue Browserctl::Error` that emits the existing human + JSON stderr lines and exits `ExitCodes.for(e.code)`. `print_result` now uses the same map (drops the hard-coded `AUTH_REQUIRED == 7` shortcut).
- `docs/reference/exit-codes.md` — operator-facing table; linked from `api-stability.md`.
- Specs: unit coverage of every mapping (incl. `nil`, unknown strings, and codes-without-a-slot), plus an integration spec that drives the binary against a missing daemon and asserts exit `4` + `DAEMON_UNREACHABLE` on stderr.

## Breaking change

Scripts that hard-coded `exit 7 == AUTH_REQUIRED` must update — `AUTH_REQUIRED` is now `3`, and `7` is `STATE_EXPIRED`. Scripts that hard-coded the previous "exit `1` for everything" behavior also need to widen their checks: typed errors now surface their dedicated codes (`3`–`7`) rather than collapsing to `1`. Treating any non-zero exit as failure remains safe.

## Out of scope

- Adding `Codes::DRIFT` (the constant slot is reserved; mapping arrives with the code itself in a later PR).
- Authoring `docs/reference/errors.md` (PR #11).

## Test plan

- [x] `bundle exec rspec` — 708 examples, 0 failures, 54 pending (Chrome-gated integration tests)
- [x] `bundle exec rubocop` — 208 files, 0 offenses
- [x] New `spec/unit/exit_codes_spec.rb` — 8 examples, including end-to-end binary invocation
- [ ] Manual: run `browserctl state load missing-bundle` against no daemon and confirm `echo $?` is `4`