### PR TITLE
docs: error reference

### DIFF
--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -141,7 +141,7 @@ One of `selector` or `ref` is required for `fill` and `click`. Both cannot be om
 
 CLI command names and their flags map 1-to-1 to wire commands via the subcommand routers in `lib/browserctl/commands/`. There are no abbreviation aliases — CLI names match their wire counterparts exactly.
 
-CLI process exit codes are also part of this zone — see [exit-codes.md](exit-codes.md) for the full table.
+CLI process exit codes are also part of this zone — see [exit-codes.md](exit-codes.md) for the full table. Error `code` strings (the machine-readable contract on stderr and on the wire) are also Stable — see [errors.md](errors.md) for the full reference.
 
 ---
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,89 @@
+# browserctl Error Reference
+
+Every browserctl failure carries a stable, machine-readable **code**. The code — not the prose message — is the contract. The same code string surfaces in three places:
+
+- The `code:` field of a daemon JSON-RPC error response.
+- The `code` field of the JSON object the CLI prints to **stderr** on failure.
+- The lookup key for the process exit status (see [exit-codes.md](exit-codes.md)).
+
+Prose messages can change between releases for clarity. AI agents and shell scripts must branch on `code`, never on `error` / `message` text.
+
+## Structured payload
+
+Both the daemon wire format and the CLI's stderr line use the same shape:
+
+```json
+{
+  "error": "selector \"#submit\" not found",
+  "code": "SELECTOR_NOT_FOUND",
+  "context": { "selector": "#submit", "page": "checkout" },
+  "suggested_action": "Re-run snapshot to get fresh refs, then retry with a stable ref or selector."
+}
+```
+
+The shape is built by [`Browserctl::Error#to_payload`](../../lib/browserctl/errors.rb) and the daemon's [`ErrorPayload`](../../lib/browserctl/server/handlers/error_payload.rb) helper. `context` is free-form structured fields (selector, path, ref, ...). `suggested_action` is filled from [`SuggestedActions`](../../lib/browserctl/error/suggested_actions.rb) and is always present.
+
+## Code reference
+
+The canonical enum lives in [`lib/browserctl/error/codes.rb`](../../lib/browserctl/error/codes.rb). Every code below is a real `Browserctl::Error::Codes` constant; conversely, every constant in `Codes::ALL` appears in this table. The drift spec at `spec/docs/errors_md_spec.rb` enforces parity.
+
+| Code | Meaning | Typical trigger | Suggested action | Exit code | Source |
+| ---- | ------- | --------------- | ---------------- | --------- | ------ |
+| `AUTH_REQUIRED` | The page or state bundle requires re-authentication. | `auth-check` against a logged-out session; `state load` on an expired bundle. | Run the suggested flow to refresh credentials, then retry. | [`3`](exit-codes.md) | [codes.rb#L13](../../lib/browserctl/error/codes.rb#L13) |
+| `SELECTOR_NOT_FOUND` | A CSS selector or stable ref did not match anything on the page. | `click <page> "#missing"`; ref invalidated by a re-render. | Re-run snapshot to get fresh refs, then retry with a stable ref or selector. | [`6`](exit-codes.md) | [codes.rb#L14](../../lib/browserctl/error/codes.rb#L14) |
+| `STATE_EXPIRED` | A state bundle's TTL window has passed and it cannot be safely reused. | `state load` on a bundle past its `expires_at`. | Re-save the state bundle (state save) or rotate it (state rotate). | [`7`](exit-codes.md) | [codes.rb#L15](../../lib/browserctl/error/codes.rb#L15) |
+| `SECRET_RESOLUTION_FAILED` | A workflow tried to resolve a secret reference and the resolver failed (missing entry, transport error, malformed ref). | `secret://op/Vault/Item/field` where the item is gone. | Verify the secret resolver config and that the underlying secret exists. | [`1`](exit-codes.md) (falls through to `GENERIC`) | [codes.rb#L16](../../lib/browserctl/error/codes.rb#L16) |
+| `DAEMON_UNREACHABLE` | The CLI could not reach the daemon socket. | Daemon not started, wrong `--daemon` name, or socket file missing. | Start the daemon with 'browserctl daemon start', then retry. | [`4`](exit-codes.md) | [codes.rb#L17](../../lib/browserctl/error/codes.rb#L17) |
+| `PROTOCOL_MISMATCH` | A persisted artifact's `version:` header is unsupported by this build. | Loading a state bundle, recording, or workflow saved by a future browserctl. See [format-versions.md](format-versions.md). | Upgrade browserctl to a version that supports this artifact's format version. | [`5`](exit-codes.md) | [codes.rb#L18](../../lib/browserctl/error/codes.rb#L18) |
+| `DOMAIN_NOT_ALLOWED` | A navigation or action targeted a domain outside the policy allowlist. | `navigate` to a host not in `policy.yml` allowed domains. | Add the domain to your policy allowlist or use an allowed URL. | [`1`](exit-codes.md) (falls through to `GENERIC`) | [codes.rb#L19](../../lib/browserctl/error/codes.rb#L19) |
+| `KEY_NOT_FOUND` | A `fetch` request asked for a daemon-scoped key that was never `store`d in this session. | `fetch foo` before a corresponding `store foo …`. | Verify the key was stored in this daemon session before fetching. | [`1`](exit-codes.md) (falls through to `GENERIC`) | [codes.rb#L20](../../lib/browserctl/error/codes.rb#L20) |
+| `GENERIC` | Catch-all for any failure not (yet) assigned a dedicated code. The safe fallback. | Unmapped raise sites; future codes that haven't earned dedicated handling yet. | See docs/reference/errors.md for guidance. (default `SuggestedActions` fallback) | [`1`](exit-codes.md) | [codes.rb#L21](../../lib/browserctl/error/codes.rb#L21) |
+
+The "Exit code" column references [exit-codes.md](exit-codes.md). Codes whose row says "falls through to `GENERIC`" have no dedicated entry in [`ExitCodes::TABLE`](../../lib/browserctl/error/exit_codes.rb) and collapse to `1`. They may earn their own exit code in a future milestone.
+
+## Programmatic handling
+
+Branch on the `code` field, not on the prose `error`/`message`.
+
+**Shell:**
+
+```bash
+out=$(browserctl click checkout "#submit" 2>&1 1>/dev/null)
+case $(printf '%s' "$out" | jq -r '.code // "GENERIC"') in
+  SELECTOR_NOT_FOUND) browserctl snapshot checkout > /dev/null && retry ;;
+  AUTH_REQUIRED)      browserctl state rotate checkout ;;
+  *)                  echo "unhandled: $out" >&2; exit 1 ;;
+esac
+```
+
+The CLI's exit status is also stable — see [exit-codes.md](exit-codes.md). Many scripts can branch on `$?` alone and skip JSON parsing.
+
+**Ruby (against the daemon directly):**
+
+```ruby
+require "browserctl/client"
+
+client = Browserctl::Client.new
+begin
+  client.click(name: "checkout", selector: "#submit")
+rescue Browserctl::Error => e
+  case e.code
+  when Browserctl::Error::Codes::SELECTOR_NOT_FOUND
+    client.snapshot(name: "checkout") # refresh refs, then retry
+  when Browserctl::Error::Codes::AUTH_REQUIRED
+    # rotate the bound flow per e.context
+  else
+    warn "unhandled #{e.code}: #{e.message}"
+    raise
+  end
+end
+```
+
+The prose `e.message` is **not** stable across releases. Treat it as human-only.
+
+## Adding a new code
+
+1. Add a new constant to `Browserctl::Error::Codes` in `lib/browserctl/error/codes.rb`, and append it to `ALL`.
+2. Add a verb-first imperative entry to `SuggestedActions::TABLE` in `lib/browserctl/error/suggested_actions.rb`. Codes without an entry fall back to `DEFAULT`, which only points at this doc.
+3. Decide the exit-code mapping in `ExitCodes::TABLE` (`lib/browserctl/error/exit_codes.rb`). If the failure is operationally distinct enough to warrant its own integer, allocate one; otherwise it collapses to `GENERIC` (`1`). Update [exit-codes.md](exit-codes.md) if you allocate.
+4. Add a row to the table above. The `spec/docs/errors_md_spec.rb` drift spec will fail until you do.

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -4,6 +4,8 @@ The `browserctl` CLI exits with a small, stable set of integer status codes so A
 
 The mapping is implemented in [`lib/browserctl/error/exit_codes.rb`](../../lib/browserctl/error/exit_codes.rb) and lives in the **Stable** zone (see [api-stability.md](api-stability.md)) — codes will not be renumbered without a major version bump.
 
+For the meaning of each `Codes::*` string and its suggested-action template, see [errors.md](errors.md).
+
 ## Table
 
 | Exit code | Name                 | Meaning                                                                                  | Mapped `Codes::*`             | Example trigger                                                                  |

--- a/docs/reference/format-versions.md
+++ b/docs/reference/format-versions.md
@@ -102,4 +102,6 @@ This is deliberately a hard failure: silently doing something with data we
 don't understand is exactly the kind of bug `version: <int>` exists to
 prevent.
 
-[errors]: ./api-stability.md
+See [errors.md](errors.md) for the full code reference, including `PROTOCOL_MISMATCH`.
+
+[errors]: ./errors.md

--- a/spec/docs/errors_md_spec.rb
+++ b/spec/docs/errors_md_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/error/codes"
+
+# Drift guard: the table in docs/reference/errors.md must list exactly the codes
+# in Browserctl::Error::Codes::ALL. Any new code added to the enum (or removed
+# from it) without a matching doc edit will fail this spec.
+ERRORS_MD_PATH = File.expand_path("../../docs/reference/errors.md", __dir__)
+
+RSpec.describe "docs/reference/errors.md" do
+  def code_table_rows
+    contents = File.read(ERRORS_MD_PATH)
+    # Locate the "Code reference" section table.
+    section = contents[/## Code reference.*?(?=\n## |\z)/m]
+    raise "Code reference section not found in #{ERRORS_MD_PATH}" unless section
+
+    section.each_line.select { |line| line.start_with?("|") }
+  end
+
+  def codes_in_table
+    rows = code_table_rows
+    # Drop the header row and the alignment row (the two rows whose first cell
+    # is "Code" or contains only dashes/whitespace).
+    data_rows = rows.reject do |line|
+      cells = line.split("|").map(&:strip)
+      first = cells[1].to_s
+      first == "Code" || first.match?(/\A-+\z/)
+    end
+    data_rows.map do |line|
+      cell = line.split("|")[1].to_s.strip
+      cell.delete("`")
+    end
+  end
+
+  it "lists exactly the codes in Browserctl::Error::Codes::ALL" do
+    documented = codes_in_table.sort
+    canonical  = Browserctl::Error::Codes::ALL.sort
+    message = "errors.md table drifted from Codes::ALL.\n" \
+              "in doc only:  #{(documented - canonical).inspect}\n" \
+              "in code only: #{(canonical - documented).inspect}"
+    expect(documented).to eq(canonical), message
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `docs/reference/errors.md` — the canonical operator-facing reference for every `Browserctl::Error::Codes` constant. Each row lists meaning, typical trigger, suggested-action template (verbatim from `SuggestedActions`), exit-code mapping, and a source link to `lib/browserctl/error/codes.rb`.
- Adds a brief programmatic-handling recipe (Ruby + shell) emphasising that the `code` field is the stable contract — prose messages are not.
- Adds a 4-step "Adding a new code" checklist covering `Codes`, `SuggestedActions`, `ExitCodes::TABLE`, and this doc.
- Cross-links from `api-stability.md`, `exit-codes.md`, and `format-versions.md` back to the new errors page.
- Adds `spec/docs/errors_md_spec.rb` — parses the table out of the markdown and asserts the documented set equals `Codes::ALL`, guarding against drift.

## Sanity

Verified the table contains exactly the 9 codes in `Codes::ALL`: `AUTH_REQUIRED`, `SELECTOR_NOT_FOUND`, `STATE_EXPIRED`, `SECRET_RESOLUTION_FAILED`, `DAEMON_UNREACHABLE`, `PROTOCOL_MISMATCH`, `DOMAIN_NOT_ALLOWED`, `KEY_NOT_FOUND`, `GENERIC`. No mismatches between `Codes`, `SuggestedActions::TABLE`, and the doc — every `SuggestedActions` key is a real `Codes` constant, and vice versa.

No production code changed.

## Test plan

- [x] `bundle exec rspec spec/docs/errors_md_spec.rb` (1 example, 0 failures)
- [x] `bundle exec rubocop` (212 files, no offenses)
- [ ] Render `docs/reference/errors.md` on GitHub and verify table + cross-links resolve