### PR TITLE
feat: migration helpers

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -32,6 +32,7 @@ require "browserctl/commands/flow"
 require "browserctl/commands/dialog"
 require "browserctl/commands/ask"
 require "browserctl/commands/trace"
+require "browserctl/commands/migrate"
 
 def structured_stderr_payload(res, message)
   code    = (res[:code] || res["code"] || Browserctl::Error::Codes::GENERIC).to_s
@@ -146,6 +147,12 @@ def usage
     Trace:
       trace [<session>]  Pretty timeline of CLI + daemon log events.
 
+    Migrate:
+      migrate <path> [--to-version N] [--dry-run]
+        # Upgrades a persisted artifact (.bctl / .jsonl recording / workflow .rb)
+        # using registered migrations. Empty registry in v0.12 — first real
+        # migration ships post-1.0 when a format actually changes.
+
     Daemon:
       daemon start  [--headed] [--name NAME]
       daemon stop
@@ -191,6 +198,7 @@ begin
   when "init"     then Browserctl::Commands::Init.run(args)
   when "ask"      then Browserctl::Commands::Ask.run(args)
   when "trace"    then Browserctl::Commands::Trace.run(args)
+  when "migrate"  then Browserctl::Commands::Migrate.run(args)
 
   else
     client = Browserctl::Client.new(Browserctl.socket_path(daemon_name))

--- a/docs/reference/format-versions.md
+++ b/docs/reference/format-versions.md
@@ -92,6 +92,49 @@ incompatibility.
 Bundles, recordings, and (future) drift reports keep the strict
 `PROTOCOL_MISMATCH` behaviour described below.
 
+## Migration registry
+
+`Browserctl::Migrations` (`lib/browserctl/migrations.rb`) is the registry
+of upgraders that move an artifact written by an older browserctl up to
+the current build's format version. Operators trigger it with:
+
+```
+browserctl migrate <path> [--to-version N] [--dry-run]
+```
+
+- The CLI detects the format from the file extension (`.bctl` →
+  `:bundle`, `.jsonl` → `:recording`, `.rb` → `:workflow`), reads the
+  declared `format_version`, and chains registered migrations from the
+  current version up to `--to-version` (or the latest registered target).
+- `--dry-run` prints the plan and exits without rewriting the file.
+- On a current-version artifact the command is a no-op and exits 0:
+  `No migrations registered for <format> v<n>; nothing to do.`
+- Unknown format or no chain to the target exits with
+  `PROTOCOL_MISMATCH` (exit code 5).
+
+Registering a migration:
+
+```ruby
+Browserctl::Migrations.register(format: :bundle, from_version: 1, to_version: 2) do |path:, **|
+  # Read `path`, transform, write back at v2.
+end
+```
+
+The block is responsible for rewriting the file in place. The registry
+handles ordering and chains hops via BFS, so you only register one
+upgrader per adjacent version pair (`1 → 2`, `2 → 3`, …) — `migrate`
+walks the chain.
+
+`Browserctl::Migrations` is **separate** from
+`verify_format_version!` (in bundle/recording/workflow). The latter
+stays strict: a reader that encounters an unknown version raises
+`PROTOCOL_MISMATCH`. `migrate` is the only blessed path to mutate an
+old artifact in place.
+
+**The registry ships empty in v0.12.** The first real migration arrives
+only when a format actually changes post-1.0. The plumbing exists now
+so the operator invocation is stable the day a real migration lands.
+
 ## Unknown-version error
 
 A reader that encounters a version it does not recognise raises

--- a/lib/browserctl/commands/migrate.rb
+++ b/lib/browserctl/commands/migrate.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative "../migrations"
+require_relative "../errors"
+require_relative "../error/codes"
+require_relative "../error/exit_codes"
+
+module Browserctl
+  module Commands
+    # `browserctl migrate <path> [--to-version N] [--dry-run]` — operator
+    # entry point for the {Browserctl::Migrations} registry. Detects the
+    # artifact's format and version, plans a chain of registered upgraders,
+    # and applies them in order (unless `--dry-run`).
+    #
+    # The registry ships empty in v0.12; this command exists so operators
+    # have a stable invocation the moment a real migration lands. On an
+    # already-current artifact the command is a no-op and exits 0.
+    module Migrate
+      USAGE = "Usage: browserctl migrate <path> [--to-version N] [--dry-run]"
+
+      def self.run(args, out: $stdout, err: $stderr)
+        abort USAGE if args.empty? || args.include?("-h") || args.include?("--help")
+        args = args.dup
+
+        dry_run    = !args.delete("--dry-run").nil?
+        target_idx = args.index("--to-version")
+        target = if target_idx
+                   args.delete_at(target_idx)
+                   Integer(args.delete_at(target_idx))
+                 end
+        path = args.shift
+        abort USAGE unless path
+
+        unless File.exist?(path)
+          err.puts "Error: file not found: #{path}"
+          exit Browserctl::Error::ExitCodes::GENERIC
+        end
+
+        execute(path, target_version: target, dry_run: dry_run, out: out, err: err)
+      rescue Browserctl::ProtocolMismatch => e
+        err.puts "Error: #{e.message}"
+        exit Browserctl::Error::ExitCodes.for(e.code)
+      end
+
+      def self.execute(path, target_version:, dry_run:, out:, err:)
+        format = Browserctl::Migrations.detect_format(path)
+        unless format
+          err.puts "Error: could not detect format for #{path} (expected .bctl, .jsonl, or .rb)"
+          exit Browserctl::Error::ExitCodes::PROTOCOL_MISMATCH
+        end
+
+        current = Browserctl::Migrations.detect_version(path, format)
+        out.puts "Detected: format=#{format} version=#{current.inspect} path=#{path}"
+
+        if dry_run
+          plan_dry_run(format, current, target_version, out)
+          return
+        end
+
+        result = Browserctl::Migrations.run(path, target_version: target_version)
+        if result.applied.empty?
+          out.puts "No migrations registered for #{format} v#{current}; nothing to do."
+        else
+          out.puts "Applied #{result.applied.size} migration(s): #{result.from} -> #{result.to}"
+          result.applied.each { |m| out.puts "  - #{format} v#{m.from_version} -> v#{m.to_version}" }
+        end
+      end
+
+      def self.plan_dry_run(format, current, target_version, out)
+        target = target_version || latest_target(format, current)
+        chain  = Browserctl::Migrations.find_path(format: format, from: current, to: target)
+
+        if chain.nil?
+          out.puts "No migration path #{format} v#{current} -> v#{target} (registered: " \
+                   "#{registered_for(format).inspect})"
+        elsif chain.empty?
+          out.puts "Already at v#{target}; no migrations would run."
+        else
+          out.puts "Plan (#{chain.size} step(s)):"
+          chain.each { |m| out.puts "  - #{format} v#{m.from_version} -> v#{m.to_version}" }
+        end
+      end
+
+      def self.latest_target(format, current)
+        targets = registered_for(format)
+        targets.empty? ? current : targets.max
+      end
+
+      def self.registered_for(format)
+        Browserctl::Migrations.all.select { |m| m.format == format }.map(&:to_version)
+      end
+    end
+  end
+end

--- a/lib/browserctl/migrations.rb
+++ b/lib/browserctl/migrations.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "errors"
+require_relative "error/codes"
+
+module Browserctl
+  # Migration registry for browserctl persisted formats. Operators run
+  # `browserctl migrate <path>` to upgrade an artifact written by an older
+  # browserctl to the current build's format version.
+  #
+  # Distinct from `verify_format_version!` (in bundle/recording/workflow):
+  # those gates stay strict — a reader that encounters an unknown version
+  # raises {Browserctl::ProtocolMismatch}. This module is the only blessed
+  # path to mutate an old artifact in place.
+  #
+  # The registry ships **empty** in v0.12. The first real migration arrives
+  # only when a format actually changes post-1.0. See
+  # `docs/reference/format-versions.md` ("Migration registry").
+  module Migrations
+    # Single registered upgrader. `upgrade` is a Proc invoked with the
+    # absolute path of the file being migrated; it is responsible for
+    # rewriting that file in place, advancing it from `from_version` to
+    # `to_version`.
+    Migration = Struct.new(:format, :from_version, :to_version, :upgrade, keyword_init: true)
+
+    # Result of {.run}. `applied` is the ordered list of {Migration} steps
+    # that ran. When the artifact was already at target, `applied` is empty.
+    Result = Struct.new(:format, :from, :to, :applied, keyword_init: true)
+
+    FORMAT_EXTENSIONS = {
+      ".bctl" => :bundle,
+      ".jsonl" => :recording,
+      ".rb" => :workflow
+    }.freeze
+
+    @registry = []
+    @mutex = Mutex.new
+
+    class << self
+      # Registers an upgrader for one hop in `format`'s version chain. The
+      # block receives the file path as a keyword argument and must rewrite
+      # the file in place to the new version.
+      def register(format:, from_version:, to_version:, &upgrade)
+        raise ArgumentError, "upgrade block required" unless upgrade
+
+        @mutex.synchronize do
+          @registry << Migration.new(format: format, from_version: from_version,
+                                     to_version: to_version, upgrade: upgrade)
+        end
+      end
+
+      # All registered migrations, in registration order.
+      def all
+        @mutex.synchronize { @registry.dup }
+      end
+
+      # Test-only hook — clears the registry. Not part of the public API.
+      def reset!
+        @mutex.synchronize { @registry.clear }
+      end
+
+      # Breadth-first search through registered migrations to chain a path
+      # for `format` from `from` to `to`. Returns the ordered list of
+      # {Migration} hops, or `nil` if no path is reachable. When `from == to`
+      # returns an empty array (already at target — no work to do).
+      def find_path(format:, from:, to:)
+        return [] if from == to
+
+        all_for_format = all.select { |m| m.format == format }
+        queue = [[from, []]]
+        seen  = { from => true }
+
+        until queue.empty?
+          current, path = queue.shift
+          all_for_format.each do |m|
+            next unless m.from_version == current
+            next if seen[m.to_version]
+
+            new_path = path + [m]
+            return new_path if m.to_version == to
+
+            seen[m.to_version] = true
+            queue << [m.to_version, new_path]
+          end
+        end
+        nil
+      end
+
+      # Inspects an artifact path and returns a format symbol — `:bundle`,
+      # `:recording`, or `:workflow` — or `nil` when the format cannot be
+      # identified. Detection is extension-driven: keep new formats listed
+      # in {FORMAT_EXTENSIONS} so this stays a one-line lookup.
+      def detect_format(path)
+        FORMAT_EXTENSIONS[File.extname(path.to_s).downcase]
+      end
+
+      # Reads `path` and returns the integer format_version it declares, or
+      # `nil` when no version header is present. Format-specific because
+      # each format stores the header differently — the bundle in its
+      # binary manifest, the recording in a `_meta` JSONL line, the
+      # workflow in a Ruby comment.
+      def detect_version(path, format)
+        case format
+        when :bundle    then peek_bundle_version(path)
+        when :recording then peek_recording_version(path)
+        when :workflow  then peek_workflow_version(path)
+        end
+      end
+
+      # End-to-end migration. Detects format and current version, finds a
+      # chain of registered upgraders to `target_version` (or the latest
+      # `to_version` seen for this format if `target_version` is nil), and
+      # invokes each in order. Each upgrader rewrites the file in place.
+      #
+      # Returns a {Result}. When no migrations are needed (or the registry
+      # has no entries for this format), `applied` is empty.
+      #
+      # Raises {Browserctl::ProtocolMismatch} when format detection fails,
+      # the version cannot be read, or no chain reaches the target.
+      def run(path, target_version: nil)
+        format  = detect_format(path) or raise_protocol("could not detect format for #{path}")
+        current = detect_version(path, format) or raise_protocol("could not read format_version from #{path}")
+        target  = target_version || latest_known_target(format, current)
+
+        if current == target
+          # If we'd be a no-op but the artifact's declared version is one this
+          # build's reader does not support, surface that as PROTOCOL_MISMATCH —
+          # there is no migration registered to bring it into range.
+          unless format_version_supported?(format, current)
+            raise_protocol("#{format} at #{path} declares unsupported format_version=#{current}; " \
+                           "no migration registered")
+          end
+          return Result.new(format: format, from: current, to: current, applied: [])
+        end
+
+        chain = find_path(format: format, from: current, to: target)
+        raise_protocol("no migration path from #{format} v#{current} to v#{target}") if chain.nil?
+
+        chain.each { |m| m.upgrade.call(path: path, from_version: m.from_version, to_version: m.to_version) }
+        Result.new(format: format, from: current, to: target, applied: chain)
+      end
+
+      private
+
+      # Reflects whether each format's reader currently accepts a given
+      # version. Mirrors the SUPPORTED_FORMAT_VERSIONS constant on the
+      # corresponding class — kept here so adding a new format is one
+      # branch, not a new public API.
+      def format_version_supported?(format, version)
+        case format
+        when :bundle
+          require_relative "state/bundle"
+          Browserctl::State::Bundle::SUPPORTED_FORMAT_VERSIONS.include?(version)
+        when :recording
+          require_relative "recording"
+          Browserctl::Recording::SUPPORTED_FORMAT_VERSIONS.include?(version)
+        when :workflow
+          require_relative "workflow"
+          Browserctl::SUPPORTED_WORKFLOW_FORMAT_VERSIONS.include?(version)
+        else
+          false
+        end
+      end
+
+      def latest_known_target(format, current)
+        targets = all.select { |m| m.format == format }.map(&:to_version)
+        targets.empty? ? current : targets.max
+      end
+
+      def peek_bundle_version(path)
+        require_relative "state/bundle"
+        manifest = Browserctl::State::Bundle.peek_manifest(File.binread(path))
+        manifest[:format_version] || manifest["format_version"]
+      rescue Browserctl::ProtocolMismatch
+        # `peek_manifest` raises on unknown versions, but we want to *return*
+        # the version so a migration can target it. Re-parse the manifest
+        # bytes directly when the strict gate refuses.
+        peek_bundle_version_loosely(path)
+      end
+
+      def peek_bundle_version_loosely(path)
+        blob = File.binread(path)
+        # Manifest length is at byte offset 8 (5 magic + 3 header). Parse
+        # the JSON without invoking Bundle's strict version check.
+        manifest_len = blob.byteslice(8, 4).unpack1("N")
+        manifest_bytes = blob.byteslice(12, manifest_len)
+        manifest = JSON.parse(manifest_bytes)
+        manifest["format_version"]
+      rescue StandardError
+        nil
+      end
+
+      def peek_recording_version(path)
+        first_line = File.foreach(path).first
+        return nil unless first_line
+
+        meta = JSON.parse(first_line, symbolize_names: true)
+        return nil unless meta[:cmd] == "_meta"
+
+        meta[:format_version]
+      rescue JSON::ParserError
+        nil
+      end
+
+      def peek_workflow_version(path)
+        require_relative "workflow"
+        Browserctl.parse_workflow_format_version(File.read(path))
+      end
+
+      def raise_protocol(msg)
+        raise Browserctl::ProtocolMismatch.new(msg, code: Browserctl::Error::Codes::PROTOCOL_MISMATCH)
+      end
+    end
+  end
+end

--- a/spec/unit/commands_migrate_spec.rb
+++ b/spec/unit/commands_migrate_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "json"
+require "stringio"
+require "browserctl/commands/migrate"
+require "browserctl/state/bundle"
+
+RSpec.describe Browserctl::Commands::Migrate do
+  let(:tmp_dir) { Dir.mktmpdir("browserctl-migrate-cli") }
+  let(:out)     { StringIO.new }
+  let(:err)     { StringIO.new }
+
+  before { Browserctl::Migrations.reset! }
+  after  do
+    Browserctl::Migrations.reset!
+    FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir)
+  end
+
+  it "prints a 'nothing to do' notice on a current-version artifact" do
+    path = File.join(tmp_dir, "rec.jsonl")
+    File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 1, recording: 'x')}\n")
+
+    described_class.run([path], out: out, err: err)
+    expect(out.string).to include("Detected: format=recording version=1")
+    expect(out.string).to include("nothing to do")
+  end
+
+  it "exits with PROTOCOL_MISMATCH on a recording with an unsupported format_version" do
+    path = File.join(tmp_dir, "rec.jsonl")
+    File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 99, recording: 'x')}\n")
+
+    expect do
+      described_class.run([path], out: out, err: err)
+    end.to raise_error(SystemExit) { |e| expect(e.status).to eq(Browserctl::Error::ExitCodes::PROTOCOL_MISMATCH) }
+    expect(err.string).to include("unsupported format_version=99")
+  end
+
+  it "exits with PROTOCOL_MISMATCH on an unknown extension" do
+    path = File.join(tmp_dir, "mystery.xyz")
+    File.write(path, "data")
+
+    expect do
+      described_class.run([path], out: out, err: err)
+    end.to raise_error(SystemExit) { |e| expect(e.status).to eq(Browserctl::Error::ExitCodes::PROTOCOL_MISMATCH) }
+    expect(err.string).to include("could not detect format")
+  end
+
+  it "exits with PROTOCOL_MISMATCH when no path reaches --to-version" do
+    path = File.join(tmp_dir, "rec.jsonl")
+    File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 1, recording: 'x')}\n")
+
+    expect do
+      described_class.run([path, "--to-version", "99"], out: out, err: err)
+    end.to raise_error(SystemExit) { |e| expect(e.status).to eq(Browserctl::Error::ExitCodes::PROTOCOL_MISMATCH) }
+    expect(err.string).to include("no migration path")
+  end
+
+  it "prints a plan and skips writes under --dry-run" do
+    path = File.join(tmp_dir, "rec.jsonl")
+    original = "#{JSON.generate(cmd: '_meta', format_version: 1, recording: 'x')}\n"
+    File.write(path, original)
+
+    Browserctl::Migrations.register(format: :recording, from_version: 1, to_version: 2) do |path:, **|
+      File.write(path, "TOUCHED")
+    end
+
+    described_class.run([path, "--dry-run"], out: out, err: err)
+    expect(out.string).to include("Plan (1 step(s))")
+    expect(out.string).to include("recording v1 -> v2")
+    expect(File.read(path)).to eq(original)
+  end
+
+  it "applies a registered migration end-to-end" do
+    path = File.join(tmp_dir, "rec.jsonl")
+    File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 1, recording: 'x')}\n")
+
+    Browserctl::Migrations.register(format: :recording, from_version: 1, to_version: 2) do |path:, **|
+      File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 2, recording: 'x')}\n")
+    end
+
+    described_class.run([path], out: out, err: err)
+    expect(out.string).to include("Applied 1 migration(s): 1 -> 2")
+    expect(JSON.parse(File.read(path).lines.first)["format_version"]).to eq(2)
+  end
+
+  it "exits with GENERIC when the file does not exist" do
+    expect do
+      described_class.run([File.join(tmp_dir, "nope.bctl")], out: out, err: err)
+    end.to raise_error(SystemExit) { |e| expect(e.status).to eq(Browserctl::Error::ExitCodes::GENERIC) }
+  end
+end

--- a/spec/unit/migrations_spec.rb
+++ b/spec/unit/migrations_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "json"
+require "browserctl/migrations"
+require "browserctl/state/bundle"
+
+RSpec.describe Browserctl::Migrations do
+  let(:tmp_dir) { Dir.mktmpdir("browserctl-migrations") }
+
+  before { described_class.reset! }
+  after  do
+    described_class.reset!
+    FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir)
+  end
+
+  describe "default state" do
+    it "ships with an empty registry" do
+      expect(described_class.all).to eq([])
+    end
+  end
+
+  describe ".register" do
+    it "appends a Migration entry" do
+      described_class.register(format: :bundle, from_version: 1, to_version: 2) { |**| nil }
+      expect(described_class.all.size).to eq(1)
+      expect(described_class.all.first).to have_attributes(format: :bundle, from_version: 1, to_version: 2)
+    end
+
+    it "rejects registration without an upgrade block" do
+      expect { described_class.register(format: :bundle, from_version: 1, to_version: 2) }
+        .to raise_error(ArgumentError, /upgrade block required/)
+    end
+  end
+
+  describe ".find_path" do
+    it "returns an empty array when from == to" do
+      expect(described_class.find_path(format: :bundle, from: 1, to: 1)).to eq([])
+    end
+
+    it "chains two hops" do
+      described_class.register(format: :bundle, from_version: 1, to_version: 2) { |**| nil }
+      described_class.register(format: :bundle, from_version: 2, to_version: 3) { |**| nil }
+
+      chain = described_class.find_path(format: :bundle, from: 1, to: 3)
+      expect(chain.map(&:to_version)).to eq([2, 3])
+    end
+
+    it "returns nil when no path exists" do
+      described_class.register(format: :bundle, from_version: 1, to_version: 2) { |**| nil }
+      expect(described_class.find_path(format: :bundle, from: 1, to: 5)).to be_nil
+    end
+
+    it "ignores migrations from other formats" do
+      described_class.register(format: :recording, from_version: 1, to_version: 2) { |**| nil }
+      expect(described_class.find_path(format: :bundle, from: 1, to: 2)).to be_nil
+    end
+  end
+
+  describe ".detect_format" do
+    it "maps known extensions" do
+      expect(described_class.detect_format("foo.bctl")).to eq(:bundle)
+      expect(described_class.detect_format("bar.jsonl")).to eq(:recording)
+      expect(described_class.detect_format("baz.rb")).to eq(:workflow)
+    end
+
+    it "returns nil for unknown extensions" do
+      expect(described_class.detect_format("unknown.txt")).to be_nil
+    end
+  end
+
+  describe ".detect_version" do
+    it "reads the version from a recording log" do
+      path = File.join(tmp_dir, "rec.jsonl")
+      File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 1, recording: 'x')}\n")
+      expect(described_class.detect_version(path, :recording)).to eq(1)
+    end
+
+    it "reads the version from a bundle manifest" do
+      path = File.join(tmp_dir, "state.bctl")
+      blob = Browserctl::State::Bundle.encode(manifest: { origins: ["x"] }, payload: { "k" => "v" })
+      File.binwrite(path, blob)
+      expect(described_class.detect_version(path, :bundle)).to eq(1)
+    end
+
+    it "reads the version from a workflow comment" do
+      path = File.join(tmp_dir, "wf.rb")
+      File.write(path, "# frozen_string_literal: true\n# format_version: 1\n")
+      expect(described_class.detect_version(path, :workflow)).to eq(1)
+    end
+  end
+
+  describe ".run" do
+    it "applies upgraders in order on a tmpfile" do
+      path = File.join(tmp_dir, "rec.jsonl")
+      File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 1, recording: 'x')}\n")
+
+      calls = []
+      described_class.register(format: :recording, from_version: 1, to_version: 2) do |path:, **|
+        calls << [1, 2, path]
+        File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 2, recording: 'x')}\n")
+      end
+      described_class.register(format: :recording, from_version: 2, to_version: 3) do |path:, **|
+        calls << [2, 3, path]
+        File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 3, recording: 'x')}\n")
+      end
+
+      result = described_class.run(path)
+      expect(result.format).to eq(:recording)
+      expect(result.from).to eq(1)
+      expect(result.to).to eq(3)
+      expect(result.applied.map { |m| [m.from_version, m.to_version] }).to eq([[1, 2], [2, 3]])
+      expect(calls.map { |c| c[0..1] }).to eq([[1, 2], [2, 3]])
+      expect(JSON.parse(File.read(path).lines.first)["format_version"]).to eq(3)
+    end
+
+    it "is a no-op when no migrations are registered" do
+      path = File.join(tmp_dir, "rec.jsonl")
+      File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 1, recording: 'x')}\n")
+
+      result = described_class.run(path)
+      expect(result.applied).to eq([])
+      expect(result.from).to eq(1)
+      expect(result.to).to eq(1)
+    end
+
+    it "raises ProtocolMismatch when no path reaches the target" do
+      path = File.join(tmp_dir, "rec.jsonl")
+      File.write(path, "#{JSON.generate(cmd: '_meta', format_version: 1, recording: 'x')}\n")
+
+      expect { described_class.run(path, target_version: 99) }
+        .to raise_error(Browserctl::ProtocolMismatch, /no migration path/)
+    end
+
+    it "raises ProtocolMismatch when format cannot be detected" do
+      path = File.join(tmp_dir, "mystery.xyz")
+      File.write(path, "data")
+      expect { described_class.run(path) }
+        .to raise_error(Browserctl::ProtocolMismatch, /could not detect format/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

WS-1 PR #5 of v0.12 Solid: migration helpers plumbing.

- New `Browserctl::Migrations` registry (`register` / `all` / `find_path` BFS / `detect_format` / `detect_version` / `run`).
- New `browserctl migrate <path> [--to-version N] [--dry-run]` command. Detects format by extension (`.bctl` / `.jsonl` / `.rb`), plans a chain of registered upgraders, applies in order. Each upgrader rewrites the file in place.
- Registry ships **empty**. First real migration arrives only when a format changes post-1.0 — the plumbing exists now so the operator invocation is stable the day that lands.
- `verify_format_version!` strictness in bundle/recording/workflow is untouched. Migrate is the separate operator-driven channel.
- New docs section in `docs/reference/format-versions.md` ("Migration registry").

Exit-code behaviour:
- Current-version artifact → exit 0, prints `No migrations registered for <format> v<n>; nothing to do.`
- Unknown extension → exit 5 (PROTOCOL_MISMATCH).
- Declared version unsupported by reader and no migration registered → exit 5.
- File missing → exit 1.

## Test plan

- [x] `bundle exec rspec spec/unit` — 694 examples, 0 failures (23 new).
- [x] `bundle exec rubocop` — 215 files, 0 offenses.
- [x] Manual smoke: current-version recording prints "nothing to do" (exit 0); v99 recording exits 5 with `unsupported format_version=99`.
- [ ] Reviewer to confirm doc copy in `docs/reference/format-versions.md` reads cleanly alongside the existing version table.