### PR TITLE
test: unit coverage gaps — snapshot/ref/fingerprint

### DIFF
--- a/spec/unit/snapshot/drift_scoring_spec.rb
+++ b/spec/unit/snapshot/drift_scoring_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/replay/snapshot_diff"
+
+# Gap-coverage specs for SnapshotDiff (drift scoring). The existing
+# `spec/unit/replay_snapshot_diff_spec.rb` covers digest stability and a
+# basic compare. These add: zero-drift identity, asymmetric add/remove
+# accounting, monotonicity (more changes → bigger diff), digest length /
+# format invariants, and degenerate empty inputs.
+#
+# Note: v0.11 SnapshotDiff is not a numeric drift score — it returns
+# {added:, removed:} sets and a hex digest. We treat "drift = size of
+# the symmetric difference" for monotonicity assertions, since that is
+# the contract callers (replay_telemetry) actually rely on.
+RSpec.describe Browserctl::Replay::SnapshotDiff do
+  let(:el_a) { { selector: "#a", role: "button", tag: "button" } }
+  let(:el_b) { { selector: "#b", role: "link",   tag: "a" } }
+  let(:el_c) { { selector: "#c", role: "img",    tag: "img" } }
+  let(:el_d) { { selector: "#d", role: "textbox", tag: "input" } }
+
+  def drift_size(diff)
+    diff[:added].size + diff[:removed].size
+  end
+
+  describe ".compare drift accounting" do
+    it "reports zero drift for identical snapshots" do
+      diff = described_class.compare([el_a, el_b], [el_a, el_b])
+      expect(drift_size(diff)).to eq(0)
+    end
+
+    it "reports zero drift even when element order differs" do
+      diff = described_class.compare([el_a, el_b], [el_b, el_a])
+      expect(drift_size(diff)).to eq(0)
+    end
+
+    it "reports a small non-zero drift for a single removed element" do
+      diff = described_class.compare([el_a, el_b], [el_a])
+      expect(diff[:added]).to be_empty
+      expect(diff[:removed]).to eq(["#b"])
+    end
+
+    it "reports asymmetric drift: addition vs removal of the same element" do
+      add_diff = described_class.compare([el_a], [el_a, el_b])
+      rem_diff = described_class.compare([el_a, el_b], [el_a])
+      expect(add_diff).to eq(added: ["#b"], removed: [])
+      expect(rem_diff).to eq(added: [], removed: ["#b"])
+    end
+
+    it "scales with number of changes (monotonicity)" do
+      one  = described_class.compare([el_a], [el_a, el_b])
+      two  = described_class.compare([el_a], [el_a, el_b, el_c])
+      many = described_class.compare([el_a], [el_a, el_b, el_c, el_d])
+      expect(drift_size(one)).to be < drift_size(two)
+      expect(drift_size(two)).to be < drift_size(many)
+    end
+
+    it "handles two empty snapshots without division-by-zero" do
+      expect { described_class.compare([], []) }
+        .not_to raise_error
+      expect(described_class.compare([], [])).to eq(added: [], removed: [])
+    end
+
+    it "handles nil snapshots as empty (no crash)" do
+      expect(described_class.compare(nil, [el_a])).to eq(added: ["#a"], removed: [])
+      expect(described_class.compare([el_a], nil)).to eq(added: [], removed: ["#a"])
+    end
+
+    it "returns sorted added/removed lists for deterministic output" do
+      diff = described_class.compare([el_a], [el_a, el_d, el_b, el_c])
+      expect(diff[:added]).to eq(diff[:added].sort)
+    end
+  end
+
+  describe ".digest format and stability" do
+    it "produces a 16-char lowercase hex digest" do
+      digest = described_class.digest([el_a, el_b])
+      expect(digest).to match(/\A[0-9a-f]{16}\z/)
+    end
+
+    it "is deterministic across repeated calls" do
+      first = described_class.digest([el_a, el_b])
+      5.times { expect(described_class.digest([el_a, el_b])).to eq(first) }
+    end
+
+    it "produces a non-nil digest for an empty snapshot (zero elements still hashes)" do
+      # Distinct from nil input; empty-array is a valid snapshot and digest is the hash of the empty join.
+      expect(described_class.digest([])).to match(/\A[0-9a-f]{16}\z/)
+    end
+
+    it "ignores entries missing a selector (treated as noise)" do
+      noisy = [el_a, { role: "button", tag: "button" }, el_b]
+      expect(described_class.digest(noisy)).to eq(described_class.digest([el_a, el_b]))
+    end
+  end
+end

--- a/spec/unit/snapshot/fingerprint_matcher_spec.rb
+++ b/spec/unit/snapshot/fingerprint_matcher_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/replay/fingerprint_matcher"
+
+# Gap-coverage specs for FingerprintMatcher. The pre-existing
+# `spec/unit/fingerprint_matcher_spec.rb` covers happy-path #best and one
+# #score case. These focus on algorithmic edge cases: weight bounds,
+# determinism, monotonicity, and graceful handling of degenerate input.
+RSpec.describe Browserctl::Replay::FingerprintMatcher do
+  subject(:matcher) { described_class.new }
+
+  let(:base_fp) do
+    { text: "Sign in", role: "button",
+      neighbors: %w[input: a:Forgot], position: { index: 3, depth: 4 } }
+  end
+
+  describe "#score bounds and determinism" do
+    it "is bounded in [0.0, 1.0] for any plausible input" do
+      a = base_fp
+      b = { text: "Sign in", role: "button", neighbors: %w[input: a:Forgot],
+            position: { index: 3, depth: 4 } }
+      expect(matcher.score(a, b)).to be_between(0.0, 1.0).inclusive
+    end
+
+    it "returns exactly 1.0 for an exact fingerprint match" do
+      expect(matcher.score(base_fp, base_fp.dup)).to be_within(1e-9).of(1.0)
+    end
+
+    it "is deterministic across repeated calls (no rand, no time leak)" do
+      first = matcher.score(base_fp, base_fp.dup)
+      10.times { expect(matcher.score(base_fp, base_fp.dup)).to eq(first) }
+    end
+
+    it "is symmetric: score(a, b) == score(b, a)" do
+      a = base_fp
+      b = { text: "Sign In", role: "button", neighbors: %w[input:],
+            position: { index: 5, depth: 4 } }
+      expect(matcher.score(a, b)).to be_within(1e-9).of(matcher.score(b, a))
+    end
+  end
+
+  describe "#score graceful degeneracy" do
+    it "returns 0.0 when target is nil" do
+      expect(matcher.score(nil, base_fp)).to eq(0.0)
+    end
+
+    it "returns 0.0 when candidate is nil" do
+      expect(matcher.score(base_fp, nil)).to eq(0.0)
+    end
+
+    it "does not crash when text is missing entirely" do
+      a = { role: "button", neighbors: [], position: { index: 0, depth: 0 } }
+      b = { role: "button", neighbors: [], position: { index: 0, depth: 0 } }
+      # text=0.0, role=1.0, neighbors=1.0 (both empty), position=1.0 → 0.6
+      expect(matcher.score(a, b)).to be_within(1e-9).of(0.6)
+    end
+
+    it "treats two empty neighbor arrays as a perfect Jaccard (1.0)" do
+      a = base_fp.merge(neighbors: [])
+      b = base_fp.merge(neighbors: [])
+      # all four components match → 1.0
+      expect(matcher.score(a, b)).to be_within(1e-9).of(1.0)
+    end
+
+    it "treats one empty + one non-empty neighbor list as Jaccard 0.0" do
+      a = base_fp.merge(neighbors: [])
+      b = base_fp.merge(neighbors: ["input:"])
+      # text+role+position all match (0.40+0.20+0.15=0.75), neighbors=0
+      expect(matcher.score(a, b)).to be_within(1e-9).of(0.75)
+    end
+  end
+
+  describe "#score monotonicity" do
+    it "decreases monotonically as position drifts further" do
+      near = base_fp.merge(position: { index: 4, depth: 4 })
+      mid  = base_fp.merge(position: { index: 6, depth: 4 })
+      far  = base_fp.merge(position: { index: 9, depth: 9 })
+      s_near = matcher.score(base_fp, near)
+      s_mid  = matcher.score(base_fp, mid)
+      s_far  = matcher.score(base_fp, far)
+      expect(s_near).to be > s_mid
+      expect(s_mid).to be >= s_far
+    end
+
+    it "scores text mismatch lower than neighbor-only mismatch" do
+      text_diff = base_fp.merge(text: "Cancel")
+      nbr_diff  = base_fp.merge(neighbors: ["nope:"])
+      expect(matcher.score(base_fp, text_diff)).to be < matcher.score(base_fp, nbr_diff)
+    end
+  end
+
+  describe "#best edge cases" do
+    it "picks the higher-scoring candidate when several clear threshold" do
+      target = base_fp
+      cands = [
+        { ref: "lo", fingerprint: base_fp.merge(neighbors: ["input:"]) },
+        { ref: "hi", fingerprint: base_fp.dup }
+      ]
+      expect(matcher.best(target, cands).candidate[:ref]).to eq("hi")
+    end
+
+    it "returns a Match struct exposing candidate and score" do
+      target = base_fp
+      cands  = [{ ref: "x", fingerprint: base_fp.dup }]
+      m = matcher.best(target, cands)
+      expect(m).to respond_to(:candidate, :score)
+      expect(m.candidate[:ref]).to eq("x")
+    end
+  end
+end

--- a/spec/unit/snapshot/ref_hashing_spec.rb
+++ b/spec/unit/snapshot/ref_hashing_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nokogiri"
+require "browserctl/snapshot/ref"
+
+# Gap-coverage specs for the ref hashing algorithm. The existing
+# `spec/unit/snapshot_ref_spec.rb` covers basic determinism and a few
+# signal-sensitivity cases. These add: format invariants, cross-process
+# stability proxy, non-ASCII / very long inputs, and disambiguation
+# pathologies.
+RSpec.describe Browserctl::Snapshot::RefDeriver do
+  subject(:deriver) { described_class.new }
+
+  def first_node(html, css)
+    Nokogiri::HTML(html).at_css(css)
+  end
+
+  describe "ref format invariants" do
+    it "always starts with 'e' and has exactly HASH_LEN hex chars after" do
+      node = first_node("<html><body><button>Go</button></body></html>", "button")
+      ref = deriver.derive(node)
+      expect(ref).to match(/\Ae[0-9a-f]{#{described_class::HASH_LEN}}\z/)
+    end
+
+    it "produces a fixed total length of HASH_LEN + 1" do
+      nodes = [
+        first_node("<html><body><button>A</button></body></html>", "button"),
+        first_node("<html><body><a>Bxxxxxxxxxxxxxxxxxxxxxx</a></body></html>", "a"),
+        first_node("<html><body><input placeholder='you@example.com'></body></html>", "input")
+      ]
+      nodes.each do |n|
+        expect(deriver.derive(n).length).to eq(described_class::HASH_LEN + 1)
+      end
+    end
+
+    it "uses lowercase hex only (no uppercase, no non-hex)" do
+      20.times do |i|
+        node = first_node("<html><body><button>Btn#{i}</button></body></html>", "button")
+        suffix = deriver.derive(node)[1..]
+        expect(suffix).to match(/\A[0-9a-f]+\z/)
+      end
+    end
+  end
+
+  describe "stability across signal-irrelevant noise" do
+    it "is unaffected by leading/trailing whitespace in accessible name" do
+      a = first_node("<html><body><button>  Save  </button></body></html>", "button")
+      b = first_node("<html><body><button>Save</button></body></html>", "button")
+      expect(deriver.derive(a)).to eq(deriver.derive(b))
+    end
+
+    it "is a pure function of node signal (no hidden process state)" do
+      # Proxy for cross-process stability: derive once, GC-churn, derive again.
+      node = first_node("<html><body><a href='/x'>Hello</a></body></html>", "a")
+      first = deriver.derive(node)
+      GC.start
+      second = described_class.new.derive(node)
+      expect(second).to eq(first)
+    end
+  end
+
+  describe "edge case inputs" do
+    it "handles empty accessible name without raising" do
+      node = first_node("<html><body><div></div></body></html>", "div")
+      expect { deriver.derive(node) }.not_to raise_error
+      expect(deriver.derive(node)).to match(/\Ae[0-9a-f]{7}\z/)
+    end
+
+    it "handles non-ASCII text" do
+      a = first_node("<html><body><button>你好</button></body></html>", "button")
+      b = first_node("<html><body><button>Hello</button></body></html>", "button")
+      expect(deriver.derive(a)).not_to eq(deriver.derive(b))
+      expect(deriver.derive(a)).to match(/\Ae[0-9a-f]{7}\z/)
+    end
+
+    it "handles very long accessible name (truncates internally)" do
+      long_text = "x" * 5000
+      node = first_node("<html><body><button>#{long_text}</button></body></html>", "button")
+      expect { deriver.derive(node) }.not_to raise_error
+      expect(deriver.derive(node)).to match(/\Ae[0-9a-f]{7}\z/)
+    end
+  end
+
+  describe "#disambiguate edge cases" do
+    it "returns ref unchanged when taken is empty" do
+      expect(deriver.disambiguate("eabc1234", {})).to eq("eabc1234")
+    end
+
+    it "skips over a sparse taken set and finds the next free slot" do
+      taken = { "eabc1234" => true, "eabc1234-2" => true, "eabc1234-3" => true }
+      expect(deriver.disambiguate("eabc1234", taken)).to eq("eabc1234-4")
+    end
+
+    it "is idempotent for a ref already disambiguated and not in taken" do
+      expect(deriver.disambiguate("eabc1234-2", {})).to eq("eabc1234-2")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

WS-4 PR #17 of the v0.12 "Solid" milestone. Fills v0.11 unit coverage gaps for the three replayable subsystems:

- **Fingerprint matcher** (`Browserctl::Replay::FingerprintMatcher`) — 13 examples covering score bounds [0.0, 1.0], determinism, symmetry, monotonicity vs position drift, and graceful nil / missing-field handling.
- **Ref hashing** (`Browserctl::Snapshot::RefDeriver`) — 12 examples covering ref format invariants (`e` + `HASH_LEN` lowercase hex), signal purity (cross-process stability proxy), non-ASCII / 5KB inputs, and `#disambiguate` edge cases.
- **Drift scoring** (`Browserctl::Replay::SnapshotDiff`) — 11 examples covering zero-drift identity, asymmetric add vs remove, monotonicity with change count, digest format/length, and degenerate nil/empty snapshots.

No production code changes. Each new spec file is one unit, 11–13 examples, no `pending`/`skip`. New specs live under `spec/unit/snapshot/` to mirror `lib/browserctl/snapshot/`.

Note: "drift scoring" in v0.11 is not a numeric score — `SnapshotDiff` returns `{added:, removed:}` sets plus a hex digest. Specs assert the contract callers (replay telemetry) actually rely on, using `added.size + removed.size` as the drift quantity for monotonicity.

## Test plan

- [x] `bundle exec rspec spec/unit/snapshot/` — 36 examples, 0 failures
- [x] `bundle exec rspec spec/unit/` — 730 examples, 0 failures (was 694)
- [x] `bundle exec rubocop spec/unit/snapshot/` — clean