### PR TITLE
test: smoke suite + nightly CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,92 @@
+name: Smoke
+
+on:
+  schedule:
+    # Daily at 06:17 UTC — random offset to avoid the top-of-hour stampede.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Smoke (nightly public surfaces)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    env:
+      SMOKE_LABEL: smoke-failure
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-ruby
+
+      - uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Run smoke specs
+        id: smoke
+        run: bundle exec rspec --tag smoke --format progress
+
+      - name: Upload smoke trace
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-trace
+          path: |
+            tmp/smoke-trace.log
+            tmp/crash-*
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Open or comment on smoke-failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the label exists (idempotent).
+          if ! gh label list --limit 200 | awk '{print $1}' | grep -qx "$SMOKE_LABEL"; then
+            gh label create "$SMOKE_LABEL" \
+              --color B60205 \
+              --description "Nightly smoke suite failure — auto-managed" || true
+          fi
+
+          DATE="$(date -u +%Y-%m-%d)"
+          BODY="Nightly smoke run failed on \`main\`.
+
+          - Run: ${RUN_URL}
+          - Workflow: \`${{ github.workflow }}\`
+          - Commit: \`${{ github.sha }}\`
+          - Trace artifact: \`smoke-trace\` on the run above
+
+          This issue is auto-managed by \`.github/workflows/smoke.yml\`.
+          Close it once the underlying drift is fixed; the workflow will
+          open a new one on the next failure."
+
+          # Duplicate protection: if any open issue carries the smoke label,
+          # comment on the most recent one rather than opening a new issue.
+          EXISTING="$(gh issue list \
+            --state open \
+            --label "$SMOKE_LABEL" \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number' || true)"
+
+          if [ -n "${EXISTING:-}" ] && [ "$EXISTING" != "null" ]; then
+            echo "Existing open smoke-failure issue #$EXISTING — commenting."
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            echo "No open smoke-failure issue — creating one."
+            gh issue create \
+              --title "smoke: ${DATE} failure on main" \
+              --label "$SMOKE_LABEL" \
+              --body "$BODY"
+          fi

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --format progress
+--tag ~smoke

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -145,3 +145,17 @@ Before you click submit, check that you have:
 - [ ] **OS + Ruby version** (the crash report carries these; otherwise mention them).
 
 A short, redacted trace plus a reviewed crash report covers most bug reports without a back-and-forth.
+
+## Smoke tests
+
+A nightly GitHub Actions workflow (`.github/workflows/smoke.yml`) runs the suite under `spec/smoke/` against stable public surfaces (`example.com`, the project's GitHub repo page) using a real Chrome. This catches drift in Chrome, ferrum, or our CDP wrappers before users hit it.
+
+Smoke specs are tagged `:smoke` and excluded from the default `bundle exec rspec` run via `.rspec` (`--tag ~smoke`). Run them locally with:
+
+```sh
+bundle exec rspec --tag smoke
+```
+
+Specs skip cleanly when no Chrome or no internet is available, so the local default suite stays hermetic.
+
+When the nightly run fails, the workflow uploads `tmp/smoke-trace.log` as an artifact and opens (or comments on) an issue tagged `smoke-failure`. Only one open `smoke-failure` issue exists at a time — subsequent failures append comments to it, so the issue list stays quiet.

--- a/spec/smoke/smoke_spec.rb
+++ b/spec/smoke/smoke_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+# Smoke specs — exercise stable public surfaces with a real Chrome.
+#
+# Excluded from the default suite via `.rspec` (`--tag ~smoke`). Run with:
+#
+#     bundle exec rspec --tag smoke
+#
+# Each spec:
+#   * Loads a real public URL through a real Chrome/Chromium browser.
+#   * Has a 30s wall-clock timeout (Timeout.timeout).
+#   * On failure, dumps a minimal trace to tmp/smoke-trace.log + stderr.
+#   * Skips cleanly (rather than failing) when Chrome is unavailable or the
+#     network is offline — the nightly CI provides both, so a real failure
+#     means real drift.
+#
+# Note: there is no browserctl GitHub Pages site at the time of writing
+# (no docs/_config.yml, no gh-pages branch). The third stable surface here
+# is github.com/patrick204nqh/browserctl, which is unlikely to drift in a
+# way that breaks page-load + DOM access.
+
+require "spec_helper"
+require "fileutils"
+require "timeout"
+require "socket"
+
+SMOKE_TRACE_PATH = File.expand_path("../../tmp/smoke-trace.log", __dir__)
+SMOKE_TIMEOUT = 30
+
+RSpec.describe "smoke", :smoke do
+  def chrome_available?
+    %w[chromium-browser google-chrome chromium chrome].any? do |b|
+      system("which #{b}", out: File::NULL, err: File::NULL)
+    end
+  end
+
+  def network_available?
+    Socket.tcp("example.com", 80, connect_timeout: 3) { true }
+  rescue StandardError
+    false
+  end
+
+  def write_trace(label, error)
+    FileUtils.mkdir_p(File.dirname(SMOKE_TRACE_PATH))
+    File.open(SMOKE_TRACE_PATH, "a") do |f|
+      f.puts "=== #{Time.now.utc.iso8601} #{label} ==="
+      f.puts "#{error.class}: #{error.message}"
+      f.puts(error.backtrace&.first(20))
+      f.puts
+    end
+    warn "[smoke] failure trace -> #{SMOKE_TRACE_PATH}"
+    warn "[smoke] #{error.class}: #{error.message}"
+  end
+
+  def visit_and_snapshot(url)
+    @client.page_open("smoke", url: url)
+    deadline = Time.now + SMOKE_TIMEOUT
+    snap = nil
+    loop do
+      snap = @client.snapshot("smoke", format: "html")
+      break if snap[:ok] && snap[:html]
+      raise "snapshot timed out for #{url}" if Time.now > deadline
+
+      sleep 0.2
+    end
+    snap
+  ensure
+    begin
+      @client.page_close("smoke")
+    rescue StandardError
+      nil
+    end
+  end
+
+  before(:all) do
+    skip "Chrome not available — install chromium or google-chrome" unless chrome_available?
+    skip "no network — smoke needs internet" unless network_available?
+
+    @client = start_daemon
+  end
+
+  after(:all) do
+    stop_daemon if @daemon_pid
+  end
+
+  around(:each) do |example|
+    Timeout.timeout(SMOKE_TIMEOUT) { example.run }
+  rescue StandardError => e
+    write_trace(example.full_description, e)
+    raise
+  end
+
+  it "loads example.com and renders the canonical title" do
+    snap = visit_and_snapshot("https://example.com/")
+    expect(snap[:html]).to include("Example")
+    title = @client.evaluate("smoke", "document.title")
+    expect(title[:result].to_s).to match(/Example/i)
+  end
+
+  it "loads the browserctl GitHub repo page" do
+    snap = visit_and_snapshot("https://github.com/patrick204nqh/browserctl")
+    expect(snap[:html]).to include("browserctl")
+  end
+
+  # Third stable surface: a known browserctl-adjacent URL we control or
+  # trust to be long-lived. Skipped because no GitHub Pages site exists yet
+  # for this repo. Re-enable once docs/ ships as Pages.
+  it "loads the browserctl docs site (skipped: no GH Pages site yet)" do
+    skip "no GitHub Pages site configured for this repo"
+  end
+end


### PR DESCRIPTION
Implements WS-4 (PR #21 + #22) of the v0.12 Solid milestone — bundled because the smoke suite and the workflow that runs it are paired.

## Summary

- **`spec/smoke/smoke_spec.rb`** — RSpec suite exercising stable public surfaces (`example.com`, `github.com/patrick204nqh/browserctl`) with a real Chrome via the daemon. Tagged `:smoke`, 30s timeout per spec, dumps `tmp/smoke-trace.log` + stderr on failure, skips cleanly when Chrome or the network is absent.
- **`.rspec`** — adds `--tag ~smoke` so `bundle exec rspec` excludes smoke by default. Local + CI default suites stay hermetic.
- **`.github/workflows/smoke.yml`** — daily `17 6 * * *` schedule plus `workflow_dispatch`. Single Ubuntu 22.04 job installs Chrome via `browser-actions/setup-chrome@v1` and runs `bundle exec rspec --tag smoke`. On failure it uploads `tmp/smoke-trace.log` (and any `tmp/crash-*`) as the `smoke-trace` artifact, then opens or comments on an issue.
- **`docs/guides/debugging.md`** — adds a "Smoke tests" subsection covering the loop.

## Duplicate-issue protection

Per the v0.12 plan's open question (default option):

1. Workflow ensures the `smoke-failure` label exists (`gh label create`, idempotent).
2. Queries `gh issue list --state open --label smoke-failure --limit 1`.
3. If an open issue exists, **comments on it** with the run URL + commit SHA.
4. Otherwise creates a new issue titled `smoke: <date> failure on main` and applies the `smoke-failure` label.

Net effect: at most one open `smoke-failure` issue at any time. Close it once the underlying drift is fixed.

## Notes / smallest-reasonable choices

- **Third surface skipped.** The plan called for "this repo's GitHub Pages site". No `docs/_config.yml` or `gh-pages` branch exists yet — the third spec is a `skip` placeholder. Re-enable when Pages ships.
- **No new gem deps.** Uses stdlib `Timeout`, `Socket`, `FileUtils`.
- **Chrome action choice.** `browser-actions/setup-chrome@v1` over apt — faster, version-pinnable, used widely.

## Test plan

- [x] `bundle exec rspec` (default) — 851 examples, 0 failures, 54 pending (no chrome locally). Smoke specs excluded.
- [x] `bundle exec rspec --tag smoke` — 3 examples, 0 failures, 3 pending (skip cleanly without chrome).
- [x] `bundle exec rubocop --parallel` — clean.
- [ ] First nightly run (or a manual `workflow_dispatch`) to confirm the install + execute path.
- [ ] Force a failure (e.g. assert on a string that isn't there) once, on a throwaway branch, to confirm the issue-create + label + dedupe path end-to-end.