### PR TITLE
test: workflow replay matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,50 @@ jobs:
       - uses: ./.github/actions/setup-ruby
       - name: Test
         run: bundle exec rspec --format progress
+
+  replay-matrix:
+    name: Replay (${{ matrix.browser }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, chromium, brave]
+        include:
+          # Brave install on Ubuntu CI uses the official repo. If the repo
+          # signing/keyring step regresses, mark this cell soft so the rest
+          # of the matrix continues. TODO: revisit once the install path is
+          # stable in CI for a few weeks.
+          - browser: brave
+            soft: true
+    continue-on-error: ${{ matrix.soft == true }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-ruby
+
+      - name: Install Chrome
+        if: matrix.browser == 'chrome'
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Install Chromium
+        if: matrix.browser == 'chromium'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser
+
+      - name: Install Brave
+        if: matrix.browser == 'brave'
+        run: |
+          sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg \
+            https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" \
+            | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
+          sudo apt-get update
+          sudo apt-get install -y brave-browser
+
+      - name: Replay matrix spec
+        env:
+          BROWSERCTL_BROWSER: ${{ matrix.browser }}
+        run: bundle exec rspec spec/integration/workflow_replay_matrix_spec.rb --format documentation

--- a/spec/integration/workflow_replay_matrix_spec.rb
+++ b/spec/integration/workflow_replay_matrix_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/driver"
+
+# Cross-browser replay matrix.
+#
+# Picks the browser indicated by BROWSERCTL_BROWSER (chrome|chromium|brave),
+# starts a daemon backed by that binary, and replays a couple of representative
+# workflow shapes (form-fill + JS evaluate) end-to-end against data: URLs.
+#
+# Skips cleanly when the requested browser is not installed locally — never
+# fails the dev's local `rspec` run. CI provides each binary in its own matrix
+# cell.
+module ReplayMatrixHelpers
+  BINS = {
+    "chrome" => %w[google-chrome chrome],
+    "chromium" => %w[chromium-browser chromium],
+    "brave" => %w[brave-browser brave]
+  }.freeze
+
+  ENV_OVERRIDES = { "chromium" => "CHROMIUM_PATH", "brave" => "BRAVE_PATH" }.freeze
+
+  module_function
+
+  def selected_browser
+    ENV.fetch("BROWSERCTL_BROWSER", "chrome")
+  end
+
+  def browser_available?(name)
+    if (env = ENV_OVERRIDES[name])
+      override = ENV.fetch(env, nil)
+      return true if override && File.executable?(override)
+    end
+    return true if BINS.fetch(name, []).any? { |b| system("which #{b}", out: File::NULL, err: File::NULL) }
+    return Browserctl::Driver::CDP::BRAVE_PATHS.values.flatten.any? { |p| File.executable?(p) } \
+      if name == "brave"
+
+    false
+  end
+end
+
+RSpec.describe "workflow replay matrix", :integration do
+  def self.selected_browser
+    ReplayMatrixHelpers.selected_browser
+  end
+
+  def browser_available?(name)
+    ReplayMatrixHelpers.browser_available?(name)
+  end
+
+  before(:all) do
+    browser = self.class.selected_browser
+    skip "#{browser} not installed (set BROWSERCTL_BROWSER or install the binary)" \
+      unless browser_available?(browser)
+
+    @client = start_daemon(browser: browser)
+  end
+
+  after(:all) { stop_daemon if @daemon_pid }
+
+  it "replays a form-fill + click workflow on #{selected_browser}" do
+    html = <<~HTML
+      <html><body>
+        <input id="email" type="text">
+        <input id="password" type="password">
+        <button id="go" onclick="document.body.dataset.signed='1'">Sign in</button>
+      </body></html>
+    HTML
+    encoded = "data:text/html;base64,#{[html].pack('m0')}"
+
+    @client.page_open("login")
+    @client.navigate("login", encoded)
+    expect(@client.fill("login", "input#email", "alice@example.com")[:ok]).to be(true)
+    expect(@client.fill("login", "input#password", "hunter2")[:ok]).to be(true)
+    expect(@client.click("login", "button#go")[:ok]).to be(true)
+    expect(@client.evaluate("login", "document.body.dataset.signed")[:result]).to eq("1")
+  ensure
+    begin
+      @client.page_close("login")
+    rescue StandardError
+      nil
+    end
+  end
+
+  it "replays a JS-evaluate + snapshot workflow on #{selected_browser}" do
+    html = "<html><body><a href='/'>Home</a><button id='b'>Click</button></body></html>"
+    encoded = "data:text/html;base64,#{[html].pack('m0')}"
+
+    @client.page_open("eval")
+    @client.navigate("eval", encoded)
+    expect(@client.evaluate("eval", "1 + 2")[:result]).to eq(3)
+    snap = @client.snapshot("eval", format: "elements")
+    expect(snap[:ok]).to be(true)
+    expect(snap[:snapshot]).to be_an(Array)
+    expect(snap[:snapshot].map { |e| e[:tag] }).to include("a", "button")
+  ensure
+    begin
+      @client.page_close("eval")
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ module BrowserctlHelpers
     old.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
   end
 
-  def start_daemon(headed: false, name: nil)
+  def start_daemon(headed: false, name: nil, browser: ENV.fetch("BROWSERCTL_BROWSER", "chrome"))
     socket = Browserctl.socket_path(name)
     pid_f  = Browserctl.pid_path(name)
 
@@ -24,6 +24,7 @@ module BrowserctlHelpers
       $stderr.reopen(File::NULL)
       Browserctl::Server.new(
         headless: !headed,
+        browser: browser,
         socket_path: socket,
         pid_path: pid_f
       ).run
@@ -64,9 +65,18 @@ RSpec.configure do |config|
   config.include BrowserctlHelpers
 
   config.before(:each, :integration) do
-    chrome_bins = %w[chromium-browser google-chrome chromium chrome]
-    available = chrome_bins.any? { |b| system("which #{b}", out: File::NULL, err: File::NULL) }
-    skip "Chrome not available — install chromium or google-chrome to run integration tests" unless available
+    requested = ENV.fetch("BROWSERCTL_BROWSER", "chrome")
+    bins = case requested
+           when "chromium" then %w[chromium-browser chromium]
+           when "brave"    then %w[brave-browser brave]
+           else                 %w[google-chrome chrome chromium-browser chromium]
+           end
+    available = bins.any? { |b| system("which #{b}", out: File::NULL, err: File::NULL) }
+    brave_path = ENV.fetch("BRAVE_PATH", nil)
+    chromium_path = ENV.fetch("CHROMIUM_PATH", nil)
+    available ||= requested == "brave" && brave_path && File.executable?(brave_path)
+    available ||= requested == "chromium" && chromium_path && File.executable?(chromium_path)
+    skip "#{requested} not available — install it or set BROWSERCTL_BROWSER" unless available
   end
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
## Summary
- New `spec/integration/workflow_replay_matrix_spec.rb` drives a real daemon end-to-end (open page, fill, click, evaluate, snapshot) on the browser selected by `BROWSERCTL_BROWSER` (chrome|chromium|brave). Skips cleanly when the binary is missing.
- New `replay-matrix` job in `.github/workflows/ci.yml` — single job, `fail-fast: false`, parallel matrix `{chrome, chromium, brave}` on `ubuntu-22.04`. Each cell installs its browser, exports `BROWSERCTL_BROWSER`, runs only the matrix spec. Brave is soft (`continue-on-error`) so apt regressions don't block PRs.
- `spec_helper.rb`: `start_daemon` now accepts `browser:`; the `:integration` before-hook recognises chromium/brave in addition to chrome.

WS-4, PR #20 in the v0.12 Solid plan.

## Test plan
- [x] `bundle exec rspec` green locally (853 examples, 0 failures, integration specs skip without local browsers)
- [x] `bundle exec rubocop --parallel` clean
- [x] Matrix spec skips cleanly when `BROWSERCTL_BROWSER=brave` and Brave is not installed
- [ ] CI: chrome cell green, chromium cell green, brave cell green (or soft-fails without blocking)