### PR TITLE
ci: tighten compat matrix to Ruby 3.4 + Chromium only (Ubuntu CI)

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -3,7 +3,7 @@ description: Setup Ruby with bundler cache
 inputs:
   ruby-version:
     description: Ruby version to use
-    default: "3.3"
+    default: "3.4"
 runs:
   using: composite
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Supported matrix: Ruby 3.4 on macOS 14+. See docs/reference/compatibility.md.
+# Anything outside is "may work, no commitment" through 0.x.
+
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -28,8 +31,8 @@ jobs:
         run: bundle exec rubocop --parallel
 
   test:
-    name: Test (Ruby 3.3)
-    runs-on: ubuntu-latest
+    name: Test (Ruby 3.4)
+    runs-on: macos-14
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -39,17 +42,17 @@ jobs:
 
   replay-matrix:
     name: Replay (${{ matrix.browser }})
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         browser: [chrome, chromium, brave]
         include:
-          # Brave install on Ubuntu CI uses the official repo. If the repo
-          # signing/keyring step regresses, mark this cell soft so the rest
-          # of the matrix continues. TODO: revisit once the install path is
-          # stable in CI for a few weeks.
+          # Brave install on macOS uses Homebrew cask. If the cask install
+          # regresses, mark this cell soft so the rest of the matrix
+          # continues. TODO: revisit once the install path is stable in
+          # CI for a few weeks.
           - browser: brave
             soft: true
     continue-on-error: ${{ matrix.soft == true }}
@@ -59,25 +62,15 @@ jobs:
 
       - name: Install Chrome
         if: matrix.browser == 'chrome'
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: stable
+        run: brew install --cask google-chrome
 
       - name: Install Chromium
         if: matrix.browser == 'chromium'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y chromium-browser
+        run: brew install --cask chromium --no-quarantine
 
       - name: Install Brave
         if: matrix.browser == 'brave'
-        run: |
-          sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg \
-            https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" \
-            | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
-          sudo apt-get update
-          sudo apt-get install -y brave-browser
+        run: brew install --cask brave-browser
 
       - name: Replay matrix spec
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,48 +42,23 @@ jobs:
         run: bundle exec rspec --format progress
 
   replay-matrix:
-    name: Replay (${{ matrix.browser }})
+    # Single-browser CI through 0.x: Chromium only. Chrome stable is
+    # Chromium + branding + codecs from the CDP perspective, so passing
+    # on Chromium is treated as the floor for Chrome too. Brave is out
+    # of CI; reports against it are best-effort.
+    name: Replay (chromium)
     runs-on: ubuntu-22.04
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        browser: [chrome, chromium, brave]
-        include:
-          # Brave install on Ubuntu CI uses the official repo. If the repo
-          # signing/keyring step regresses, mark this cell soft so the rest
-          # of the matrix continues. TODO: revisit once the install path is
-          # stable in CI for a few weeks.
-          - browser: brave
-            soft: true
-    continue-on-error: ${{ matrix.soft == true }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
 
-      - name: Install Chrome
-        if: matrix.browser == 'chrome'
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: stable
-
       - name: Install Chromium
-        if: matrix.browser == 'chromium'
         run: |
           sudo apt-get update
           sudo apt-get install -y chromium-browser
 
-      - name: Install Brave
-        if: matrix.browser == 'brave'
-        run: |
-          sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg \
-            https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" \
-            | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
-          sudo apt-get update
-          sudo apt-get install -y brave-browser
-
       - name: Replay matrix spec
         env:
-          BROWSERCTL_BROWSER: ${{ matrix.browser }}
+          BROWSERCTL_BROWSER: chromium
         run: bundle exec rspec spec/integration/workflow_replay_matrix_spec.rb --format documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Supported matrix: Ruby 3.4 on macOS 14+. See docs/reference/compatibility.md.
-# Anything outside is "may work, no commitment" through 0.x.
+# Supported matrix: Ruby 3.4 on Ubuntu (latest GitHub-hosted runner).
+# See docs/reference/compatibility.md. Anything outside is "may work,
+# no commitment" through 0.x.
 
 jobs:
   lint:
     name: Lint
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -32,7 +33,7 @@ jobs:
 
   test:
     name: Test (Ruby 3.4)
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -42,17 +43,17 @@ jobs:
 
   replay-matrix:
     name: Replay (${{ matrix.browser }})
-    runs-on: macos-14
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         browser: [chrome, chromium, brave]
         include:
-          # Brave install on macOS uses Homebrew cask. If the cask install
-          # regresses, mark this cell soft so the rest of the matrix
-          # continues. TODO: revisit once the install path is stable in
-          # CI for a few weeks.
+          # Brave install on Ubuntu CI uses the official repo. If the repo
+          # signing/keyring step regresses, mark this cell soft so the rest
+          # of the matrix continues. TODO: revisit once the install path is
+          # stable in CI for a few weeks.
           - browser: brave
             soft: true
     continue-on-error: ${{ matrix.soft == true }}
@@ -62,15 +63,25 @@ jobs:
 
       - name: Install Chrome
         if: matrix.browser == 'chrome'
-        run: brew install --cask google-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
 
       - name: Install Chromium
         if: matrix.browser == 'chromium'
-        run: brew install --cask chromium --no-quarantine
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser
 
       - name: Install Brave
         if: matrix.browser == 'brave'
-        run: brew install --cask brave-browser
+        run: |
+          sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg \
+            https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" \
+            | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
+          sudo apt-get update
+          sudo apt-get install -y brave-browser
 
       - name: Replay matrix spec
         env:

--- a/docs/plans/v0.12-solid.md
+++ b/docs/plans/v0.12-solid.md
@@ -77,10 +77,10 @@ PRs:
 18. **`test: unit coverage gaps — bundle codec, secret resolver`** — round-trip every bundle/state combination; failure modes for every resolver.
 19. **`test: integration matrix expansion`** — every CLI command × every error path. Generate table-driven tests from the error code enum.
 20. **`test: workflow replay matrix`** — sample workflows replay across Chrome, Chromium, Brave. Single CI job, parallel matrix.
-21. **`test: smoke suite`** — nightly CI runs against stable public surfaces (`example.com`, this repo's GitHub Pages site, your own demo page). Detects ferrum/CDP/browser drift.
-22. **`ci: nightly smoke workflow`** — `.github/workflows/smoke.yml` scheduled run. Failures auto-open an issue with the trace attached.
 
-Acceptance: `bundle exec rspec` passes with all integration specs running against a real browser (no `pending` for browser-required cases on a developer machine). Nightly smoke CI is green for one week.
+Nightly smoke suite (formerly PRs 21–22) is dropped pre-1.0 — cost-saving decision recorded in `feedback_smoke_suite_dropped.md`. Browser-drift coverage falls back to user reports + the replay matrix until post-1.0.
+
+Acceptance: `bundle exec rspec` passes with all integration specs running against a real browser (no `pending` for browser-required cases on a developer machine).
 
 ---
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -8,7 +8,7 @@ The narrow, defended support surface for browserctl through 0.x. Anything outsid
 |------|-------|
 | Ruby | 3.4 |
 | OS | Ubuntu (latest GitHub-hosted runner; `ubuntu-22.04` for the browser-replay job) |
-| Browsers | Chrome (stable), Chromium, Brave |
+| Browser | Chromium |
 
 CI exercises exactly this combination — see `.github/workflows/ci.yml`. If something is not in CI, it is not supported.
 
@@ -28,13 +28,13 @@ CI runs on Ubuntu (`ubuntu-latest` and `ubuntu-22.04`) GitHub-hosted runners. ma
 
 Practical assumption: a build that passes on Ubuntu also works on a developer's macOS for everyday use. Bugs that show up only on macOS or Windows are accepted as user reports without an SLA.
 
-### Browsers
+### Chromium only
 
-Chromium-family only. All three are installed on Ubuntu CI:
+Single-browser CI through 0.x. From the CDP/Ferrum perspective, Chrome stable is Chromium plus branding and proprietary codecs — passing on Chromium is treated as the floor for Chrome too. Brave (also Chromium-based) was previously a soft job and is now out of CI entirely.
 
-- **Chrome** via `browser-actions/setup-chrome@v1` (stable channel).
-- **Chromium** via `apt-get install chromium-browser`.
-- **Brave** via the official Brave apt repo. Marked **soft** in CI — failure does not fail the build until the install path has been stable for several weeks.
+Practical assumption: a build that passes on Chromium also works on Chrome and Brave for everyday use. Reports of Chrome/Brave-specific breakage are accepted but have no SLA.
+
+Chromium is installed on Ubuntu CI via `apt-get install chromium-browser`.
 
 ## Drift policy
 
@@ -46,6 +46,7 @@ Chromium-family only. All three are installed on Ubuntu CI:
 - Windows native or WSL2 (unsupported through 0.x)
 - Ruby 3.2 and earlier (never in CI)
 - Ruby 3.3 (gemspec-supported but not in CI — see above)
+- Chrome stable, Brave (Chromium-based; should work, no CI signal — see above)
 - Firefox, Safari, WebKit (out of scope; the driver is CDP-only)
 
 After 1.0, broaden as funded by either community contribution or sustained maintainer time.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,0 +1,50 @@
+# Compatibility Matrix
+
+The narrow, defended support surface for browserctl through 0.x. Anything outside this matrix may work — there is no commitment.
+
+## Supported
+
+| axis | value |
+|------|-------|
+| Ruby | 3.4 |
+| OS | macOS 14+ |
+| Browsers | Chrome (stable), Chromium, Brave |
+
+CI exercises exactly this combination — see `.github/workflows/ci.yml`. If something is not in CI, it is not supported.
+
+## Why this narrow
+
+This is a 0.x project run by a single maintainer. The cost of a wide compatibility matrix — extra CI minutes, extra failure modes, time spent triaging issues on platforms the maintainer can't reproduce — is real and not paid back at this stage. The matrix tightens here so the project can move faster on the v0.12 → 1.0 work.
+
+The matrix will be reconsidered after 1.0, with a deprecation cadence documented in `api-stability.md`.
+
+### Ruby 3.4 only
+
+The gemspec floor stays at 3.3 so existing 3.3 users are not actively broken, but only 3.4 is exercised in CI. If 3.3 regresses, the fix lands when a user reports it; we don't catch it in CI. Anyone targeting older Rubies should pin browserctl to a release that explicitly tested against their Ruby.
+
+### macOS 14+ only
+
+CI runs on `macos-14` GitHub-hosted runners. Linux (Ubuntu) and Windows (WSL2) are dropped from CI. Browser/Ferrum behaviour does diverge between platforms, so:
+- Linux/Windows users should expect to report breakage themselves; no maintainer-side smoke catches it.
+- Issues filed against Linux/Windows are accepted but have no SLA.
+
+The maintainer's daily-driver platform is macOS, so this is also where bugs are easiest to reproduce.
+
+### Browsers
+
+All three Chromium-family browsers run from the macOS Homebrew cask install paths. `brave` is marked soft in CI (failure does not fail the build) until the cask install path has been stable for several weeks.
+
+## Drift policy
+
+`docs/reference/compatibility.md` matches `.github/workflows/ci.yml` exactly. Any divergence is a bug — either the doc is stale, or CI is testing something we don't claim to support. Open an issue.
+
+## Out of scope
+
+- Linux / Ubuntu (dropped from CI through 0.x)
+- Windows native or WSL2 (dropped from CI through 0.x)
+- Ruby 3.2 and earlier (never in CI)
+- Ruby 3.3 (gemspec-supported but not in CI — see above)
+- macOS 13 and earlier (never in CI on this matrix)
+- Firefox, Safari, WebKit (out of scope; the driver is CDP-only)
+
+After 1.0, broaden as funded by either community contribution or sustained maintainer time.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -7,7 +7,7 @@ The narrow, defended support surface for browserctl through 0.x. Anything outsid
 | axis | value |
 |------|-------|
 | Ruby | 3.4 |
-| OS | macOS 14+ |
+| OS | Ubuntu (latest GitHub-hosted runner; `ubuntu-22.04` for the browser-replay job) |
 | Browsers | Chrome (stable), Chromium, Brave |
 
 CI exercises exactly this combination — see `.github/workflows/ci.yml`. If something is not in CI, it is not supported.
@@ -22,17 +22,19 @@ The matrix will be reconsidered after 1.0, with a deprecation cadence documented
 
 The gemspec floor stays at 3.3 so existing 3.3 users are not actively broken, but only 3.4 is exercised in CI. If 3.3 regresses, the fix lands when a user reports it; we don't catch it in CI. Anyone targeting older Rubies should pin browserctl to a release that explicitly tested against their Ruby.
 
-### macOS 14+ only
+### Ubuntu only
 
-CI runs on `macos-14` GitHub-hosted runners. Linux (Ubuntu) and Windows (WSL2) are dropped from CI. Browser/Ferrum behaviour does diverge between platforms, so:
-- Linux/Windows users should expect to report breakage themselves; no maintainer-side smoke catches it.
-- Issues filed against Linux/Windows are accepted but have no SLA.
+CI runs on Ubuntu (`ubuntu-latest` and `ubuntu-22.04`) GitHub-hosted runners. macOS and Windows-via-WSL2 are out of CI. Browser/Ferrum behaviour does diverge between platforms, but Ubuntu is the cheapest GitHub-hosted runner family by an order of magnitude (≈10×) and is the closest match to the production targets browserctl gets deployed against (CI containers, headless servers).
 
-The maintainer's daily-driver platform is macOS, so this is also where bugs are easiest to reproduce.
+Practical assumption: a build that passes on Ubuntu also works on a developer's macOS for everyday use. Bugs that show up only on macOS or Windows are accepted as user reports without an SLA.
 
 ### Browsers
 
-All three Chromium-family browsers run from the macOS Homebrew cask install paths. `brave` is marked soft in CI (failure does not fail the build) until the cask install path has been stable for several weeks.
+Chromium-family only. All three are installed on Ubuntu CI:
+
+- **Chrome** via `browser-actions/setup-chrome@v1` (stable channel).
+- **Chromium** via `apt-get install chromium-browser`.
+- **Brave** via the official Brave apt repo. Marked **soft** in CI — failure does not fail the build until the install path has been stable for several weeks.
 
 ## Drift policy
 
@@ -40,11 +42,10 @@ All three Chromium-family browsers run from the macOS Homebrew cask install path
 
 ## Out of scope
 
-- Linux / Ubuntu (dropped from CI through 0.x)
-- Windows native or WSL2 (dropped from CI through 0.x)
+- macOS in CI (unsupported through 0.x; should still work for development)
+- Windows native or WSL2 (unsupported through 0.x)
 - Ruby 3.2 and earlier (never in CI)
 - Ruby 3.3 (gemspec-supported but not in CI — see above)
-- macOS 13 and earlier (never in CI on this matrix)
 - Firefox, Safari, WebKit (out of scope; the driver is CDP-only)
 
 After 1.0, broaden as funded by either community contribution or sustained maintainer time.


### PR DESCRIPTION
## Summary

Tightens the v0.12 compatibility matrix to a single supported combination:

| axis | value |
|------|-------|
| Ruby | 3.4 (CI only — gemspec floor stays at 3.3) |
| OS | Ubuntu (`ubuntu-latest`, `ubuntu-22.04` for replay) |
| Browser | Chromium |

Collapses WS-6 PR #27 (Ruby) and PR #30 (compatibility doc) from the v0.12 plan into one PR — the matrix and the doc that describes it should never land separately, since drift between them is the failure mode we're trying to prevent.

## Changes

- `.github/actions/setup-ruby/action.yml` — default Ruby 3.3 → 3.4.
- `.github/workflows/ci.yml` — test job renamed "Test (Ruby 3.4)". Replay-matrix job collapsed from 3 browsers → 1 (chromium); chrome and brave install steps removed.
- `docs/reference/compatibility.md` — new. Documents the supported surface and the rationale for narrowing it.

## Trade-offs (called out for posterity)

- **No macOS or Windows CI signal.** Bugs that manifest only on those platforms are accepted as user reports without SLA.
- **Ruby 3.3 is gemspec-supported but not exercised in CI.** If 3.3 regresses, fix lands when reported.
- **No Chrome/Brave CI signal.** Chrome stable is Chromium + branding + codecs from the CDP perspective, so Chromium passing is treated as the floor. Brave was already soft and is removed entirely.

## Test plan

- [ ] CI green on this PR (lint + test + replay on Chromium/Ubuntu).
- [ ] \`docs/reference/compatibility.md\` matches the workflow file exactly.

## Follow-ups

- ADR codifying the compatibility policy (separate PR, in flight).
- v0.12 plan doc still lists original WS-6 wording — separate PR #152 in flight to sync.