### PR TITLE
feat: benchmark harness + bundle_codec target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ examples/smoke/*.yml
 examples/smoke/*.json
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+bench/results/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,62 @@
+# bench/
+
+Tiny, dependency-free performance harness for browserctl. The goal is to
+catch order-of-magnitude regressions in code paths we care about — not to
+publish marketing throughput numbers.
+
+## Layout
+
+    bench/
+      README.md              ← this file
+      budgets.yml            ← per-target p95 budgets (the contract)
+      support/
+        target.rb            ← Target struct + ns-precision sampler
+        runner.rb            ← loads targets, writes JSON, prints rows
+      targets/
+        bundle_codec.rb      ← .bctl encode + decode round-trip
+      results/               ← gitignored; written on each run
+
+Each target file under `bench/targets/` assigns a `Browserctl::Bench::Target`
+to `Browserctl::Bench::CURRENT_TARGET`. The runner loads files one at a time,
+so targets do not interfere with each other.
+
+## Running
+
+    bundle exec rake bench:all                  # every target
+    bundle exec rake "bench:run[bundle_codec]"  # one target
+
+Each run writes `bench/results/<name>.json` with summary statistics:
+
+    {
+      "name": "bundle_codec",
+      "runs": 200,
+      "mean_ns": 38590,
+      "p50_ns": 29000,
+      "p95_ns": 52000,
+      "p99_ns": 254000,
+      "max_ns": 571000
+    }
+
+## How budgets are set
+
+We deliberately keep the math obvious. After adding a target:
+
+1. Run it five times back-to-back on a representative dev machine.
+2. Take the **worst observed `p95_ns`** across those runs.
+3. Multiply by `1.2` (a 20% headroom margin) and round up to a clean number.
+4. Record both `budget_ns` and `observed_ns` in `bench/budgets.yml` so the
+   next reviewer can see how much slack the budget has.
+
+Budgets are intentionally generous on first add. Tightening them is fine
+once the target has lived for a release or two and we know its variance.
+
+## Why no benchmark-ips?
+
+We measure with `Process.clock_gettime(:nanosecond)` directly, in roughly 30
+lines of Ruby. That keeps the gem's runtime/dev-dep surface small and means
+the numbers in `results/*.json` come from code that is read in one sitting.
+
+## Enforcement
+
+This harness writes results and budgets but does **not** yet fail the build
+on a budget overrun. That gate lands as a follow-up PR.

--- a/bench/budgets.yml
+++ b/bench/budgets.yml
@@ -1,0 +1,16 @@
+# Performance budgets for `bench:` targets.
+#
+# Each entry pins a single percentile metric to a budget in nanoseconds. The
+# `observed_ns` value is the worst sample seen across the runs that produced
+# this budget; `margin` is the multiplier applied to that observed value to
+# arrive at `budget_ns`. Bumping a budget should be deliberate — investigate
+# the regression first, only widen the budget if the new cost is justified.
+#
+# Enforcement (a CI task that fails the build when results exceed the budget)
+# lands in a follow-up PR. This file is the contract; the gate comes next.
+---
+bundle_codec:
+  metric: p95_ns
+  budget_ns: 150000
+  observed_ns: 119000
+  margin: 1.2

--- a/bench/support/runner.rb
+++ b/bench/support/runner.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require_relative "target"
+
+module Browserctl
+  module Bench
+    # Loads benchmark target files and runs them, writing JSON results to
+    # `bench/results/`. The runner is a plain Ruby module — there is no DSL,
+    # no auto-discovery surprise: each target file lives in `bench/targets/`
+    # and assigns a `Browserctl::Bench::Target` instance to
+    # `Browserctl::Bench::CURRENT_TARGET` when loaded.
+    module Runner
+      module_function
+
+      ROOT        = File.expand_path("../..", __dir__)
+      TARGETS_DIR = File.join(ROOT, "bench", "targets")
+      RESULTS_DIR = File.join(ROOT, "bench", "results")
+
+      # Returns sorted target names discovered in `bench/targets/`.
+      def all_targets
+        Dir.glob(File.join(TARGETS_DIR, "*.rb")).map { |p| File.basename(p, ".rb") }.sort
+      end
+
+      # Loads a target by either bare name (`bundle_codec`) or path
+      # (`bench/targets/bundle_codec.rb`). Returns the Target instance the
+      # file installed into `CURRENT_TARGET`.
+      def load_target(name_or_path)
+        path = if File.exist?(name_or_path)
+                 File.expand_path(name_or_path)
+               else
+                 File.join(TARGETS_DIR, "#{name_or_path}.rb")
+               end
+        raise ArgumentError, "no such target: #{name_or_path}" unless File.exist?(path)
+
+        Browserctl::Bench.send(:remove_const, :CURRENT_TARGET) if Browserctl::Bench.const_defined?(:CURRENT_TARGET)
+        load(path)
+        Browserctl::Bench::CURRENT_TARGET
+      end
+
+      # Runs the target, writes a JSON result file, and returns the result.
+      def run(target)
+        result = target.run
+        FileUtils.mkdir_p(RESULTS_DIR)
+        File.write(File.join(RESULTS_DIR, "#{target.name}.json"), "#{JSON.pretty_generate(result)}\n")
+        result
+      end
+
+      # One-line printable summary for a result hash.
+      def format_row(result)
+        format(
+          "%<name>-20s runs=%<runs>d mean=%<mean>s p50=%<p50>s p95=%<p95>s p99=%<p99>s max=%<max>s",
+          name: result[:name],
+          runs: result[:runs],
+          mean: fmt_ns(result[:mean_ns]),
+          p50: fmt_ns(result[:p50_ns]),
+          p95: fmt_ns(result[:p95_ns]),
+          p99: fmt_ns(result[:p99_ns]),
+          max: fmt_ns(result[:max_ns])
+        )
+      end
+
+      def fmt_ns(nanos)
+        if nanos >= 1_000_000
+          format("%<v>.2fms", v: nanos / 1_000_000.0)
+        elsif nanos >= 1_000
+          format("%<v>.2fµs", v: nanos / 1_000.0)
+        else
+          "#{nanos}ns"
+        end
+      end
+    end
+  end
+end

--- a/bench/support/target.rb
+++ b/bench/support/target.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Bench
+    # A single benchmark target.
+    #
+    # `setup` is invoked once before measurement to allocate fixtures or other
+    # state that must not be timed. It returns a context object that is then
+    # passed to each `measure` invocation.
+    #
+    # `measure` is called repeatedly. Only the body of `measure` is timed,
+    # using nanosecond-precision monotonic clock samples. We deliberately do
+    # not depend on benchmark-ips: the harness is intentionally tiny so it
+    # adds zero runtime dependencies and the math behind the numbers is
+    # obvious from this file alone.
+    BENCH_DEFAULT_ITERATIONS = 200
+    BENCH_DEFAULT_WARMUP     = 20
+
+    Target = Struct.new(:name, :setup, :measure, keyword_init: true) do
+      # Runs the target and returns a result hash with summary statistics.
+      #
+      # @param iterations [Integer] number of timed samples to collect
+      # @param warmup     [Integer] number of untimed samples run first
+      def run(iterations: BENCH_DEFAULT_ITERATIONS, warmup: BENCH_DEFAULT_WARMUP)
+        ctx = setup&.call
+
+        warmup.times { measure.call(ctx) }
+
+        samples = Array.new(iterations) do
+          t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+          measure.call(ctx)
+          Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0
+        end
+
+        summarize(samples)
+      end
+
+      private
+
+      def summarize(samples)
+        sorted = samples.sort
+        {
+          name: name,
+          runs: sorted.length,
+          mean_ns: (sorted.sum.to_f / sorted.length).round,
+          p50_ns: percentile(sorted, 0.50),
+          p95_ns: percentile(sorted, 0.95),
+          p99_ns: percentile(sorted, 0.99),
+          max_ns: sorted.last
+        }
+      end
+
+      def percentile(sorted, pct)
+        return 0 if sorted.empty?
+
+        # Nearest-rank percentile — simple and adequate for n in the hundreds.
+        rank = (pct * sorted.length).ceil.clamp(1, sorted.length)
+        sorted[rank - 1]
+      end
+    end
+  end
+end

--- a/bench/targets/bundle_codec.rb
+++ b/bench/targets/bundle_codec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "browserctl"
+require "browserctl/state/bundle"
+require_relative "../support/target"
+
+module Browserctl
+  module Bench
+    # Round-trip benchmark for the unencrypted .bctl codec: encode a realistic
+    # state payload (40 cookies + 20 localStorage entries + a manifest) and
+    # then decode it back. Encryption (AES-GCM + PBKDF2) is intentionally
+    # excluded — PBKDF2 dominates by orders of magnitude and would mask
+    # codec-shape regressions.
+    module BundleCodecFixtures
+      module_function
+
+      def build
+        { manifest: manifest, payload: { "cookies" => cookies, "local_storage" => local_storage } }
+      end
+
+      def manifest
+        { tool: "browserctl", created_at: "2026-05-10T00:00:00Z", profile: "default", host: "example.com" }
+      end
+
+      def cookies
+        Array.new(40) do |i|
+          {
+            "name" => "cookie_#{i}", "value" => SecureRandom.hex(32),
+            "domain" => "example.com", "path" => "/",
+            "expires" => 1_900_000_000 + i, "httpOnly" => true, "secure" => true
+          }
+        end
+      end
+
+      def local_storage
+        entries = Array.new(20).to_h { |_| ["k_#{SecureRandom.hex(4)}", SecureRandom.hex(48)] }
+        { "https://example.com" => entries }
+      end
+    end
+
+    CURRENT_TARGET = Target.new(
+      name: "bundle_codec",
+      setup: -> { BundleCodecFixtures.build },
+      measure: lambda do |ctx|
+        blob = Browserctl::State::Bundle.encode(manifest: ctx[:manifest], payload: ctx[:payload])
+        Browserctl::State::Bundle.decode(blob)
+      end
+    )
+  end
+end

--- a/rakelib/bench.rake
+++ b/rakelib/bench.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../bench/support/runner"
+
+namespace :bench do
+  desc "Run every benchmark target and write results to bench/results/"
+  task :all do
+    Browserctl::Bench::Runner.all_targets.each do |name|
+      target = Browserctl::Bench::Runner.load_target(name)
+      result = Browserctl::Bench::Runner.run(target)
+      puts Browserctl::Bench::Runner.format_row(result)
+    end
+  end
+
+  desc "Run a single benchmark target by name (e.g. bench:run[bundle_codec])"
+  task :run, [:name] do |_t, args|
+    name = args[:name] or raise ArgumentError, "usage: rake 'bench:run[<name>]'"
+    target = Browserctl::Bench::Runner.load_target(name)
+    result = Browserctl::Bench::Runner.run(target)
+    puts Browserctl::Bench::Runner.format_row(result)
+  end
+end


### PR DESCRIPTION
## Summary

Lands the WS-5 scaffold from `docs/plans/v0.12-solid.md`: a tiny dependency-free benchmark harness under `bench/`, plus the first target — `bundle_codec`, which round-trips a realistic 40-cookie / 20-localStorage state through `Browserctl::State::Bundle.encode` + `decode` (unencrypted path; encryption is excluded because PBKDF2 dominates and would mask codec-shape regressions). Results land in `bench/results/<name>.json` (gitignored). The initial p95 budget is captured in `bench/budgets.yml`.

No new gem dependencies. We measure with `Process.clock_gettime(:nanosecond)` directly — about 30 lines of Ruby — instead of pulling in benchmark-ips. Other WS-5 targets (snapshot, click, daemon idle RSS) are explicit follow-ups.

## Sample runs

Five back-to-back runs of `bundle exec rake "bench:run[bundle_codec]"` on the dev machine while shaping the budget:

```
bundle_codec         runs=200 mean=48.24µs p50=29.00µs p95=63.00µs  p99=382.00µs max=1.93ms
bundle_codec         runs=200 mean=61.39µs p50=31.00µs p95=91.00µs  p99=1.07ms   max=2.21ms
bundle_codec         runs=200 mean=54.15µs p50=30.00µs p95=59.00µs  p99=391.00µs max=2.79ms
bundle_codec         runs=200 mean=54.30µs p50=29.00µs p95=89.00µs  p99=407.00µs max=2.20ms
bundle_codec         runs=200 mean=75.10µs p50=32.00µs p95=119.00µs p99=917.00µs max=3.89ms
```

p95 across the five samples: 63µs, 91µs, 59µs, 89µs, 119µs.

## Budget

Worst observed `p95_ns` = 119_000ns. Apply the 1.2 margin → 142_800ns, round up to 150_000ns:

```yaml
bundle_codec:
  metric: p95_ns
  budget_ns: 150000
  observed_ns: 119000
  margin: 1.2
```

`bench/README.md` documents the recipe so the next target can repeat it.

## Enforcement

This PR only writes the budget file. The CI gate that fails the build when a result exceeds its budget is a deliberate follow-up (was tracked as #24). Treat `bench/budgets.yml` as the contract; the gate comes next.

## Test plan

- [ ] `bundle exec rake "bench:run[bundle_codec]"` prints a `format_row` line and writes `bench/results/bundle_codec.json`