### PR TITLE
feat!: noun-verb CLI consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Every browser automation tool restarts the browser when your script ends. That m
 ```bash
 browserd &                                               # start the daemon (headless)
 browserctl page open main --url https://example.com/login
-browserctl snapshot main                                 # AI-friendly JSON snapshot with ref IDs
+browserctl page snapshot main                                 # AI-friendly JSON snapshot with ref IDs
 browserctl fill main --ref e1 --value me@example.com    # interact by ref, no selectors needed
 browserctl click main --ref e2
 browserctl daemon stop
@@ -42,7 +42,7 @@ browserd &
 browserctl page open main --url https://moatazeldebsy.github.io/test-automation-practices/#/auth
 
 # 4. Snapshot — returns JSON with a ref ID per interactable element
-browserctl snapshot main
+browserctl page snapshot main
 # → [{"ref":"e1","tag":"input","attrs":{"data-test":"username-input"}}, {"ref":"e2",...}, {"ref":"e3","tag":"button","text":"Login",...}]
 
 # 5. Interact using the ref IDs from the snapshot
@@ -52,7 +52,7 @@ browserctl click main --ref e3
 
 # 6. Observe
 browserctl url main
-browserctl snapshot main --diff   # only what changed
+browserctl page snapshot main --diff       # only what changed
 
 # Session persistence: save now, pick up later
 browserctl session save my-session

--- a/bin/browserctl
+++ b/bin/browserctl
@@ -18,7 +18,7 @@ require "browserctl/commands/fill"
 require "browserctl/commands/click"
 require "browserctl/commands/snapshot"
 require "browserctl/commands/screenshot"
-require "browserctl/commands/record"
+require "browserctl/commands/recording"
 require "browserctl/commands/resume"
 require "browserctl/commands/init"
 require "browserctl/commands/page"
@@ -64,10 +64,12 @@ def usage
       init
 
     Page:
-      page open <name> [--url URL]
-      page close <name>
+      page open       <name> [--url URL]
+      page close      <name>
       page list
-      page focus <name>
+      page focus      <name>
+      page snapshot   <name> [--format elements|html] [--diff]
+      page screenshot <name> [--out PATH] [--full]
 
     Interaction (page is always first arg after verb):
       navigate <page> <url>
@@ -75,8 +77,6 @@ def usage
                <page> --ref <ref> --value <value>
       click    <page> <selector>
                <page> --ref <ref>
-      snapshot <page> [--format elements|html] [--diff]
-      screenshot <page> [--out PATH] [--full]
       evaluate <page> <expression>
       url      <page>
       wait     <page> <selector> [--timeout N]
@@ -128,9 +128,9 @@ def usage
       state import <source> [--name NAME]
 
     Recording:
-      record start <name>
-      record stop  [--out PATH]
-      record status
+      recording start <name>
+      recording stop  [--out PATH]
+      recording status
 
     Workflow:
       workflow run      <name|file> [--check] [--params file] [--key value ...]
@@ -193,9 +193,9 @@ runner = Browserctl::Runner.new
 
 begin
   case cmd
-  when "workflow" then Browserctl::Commands::Workflow.run(runner, args)
-  when "record"   then Browserctl::Commands::Record.run(args)
-  when "init"     then Browserctl::Commands::Init.run(args)
+  when "workflow"  then Browserctl::Commands::Workflow.run(runner, args)
+  when "recording" then Browserctl::Commands::Recording.run(args)
+  when "init"      then Browserctl::Commands::Init.run(args)
   when "ask"      then Browserctl::Commands::Ask.run(args)
   when "trace"    then Browserctl::Commands::Trace.run(args)
   when "migrate"  then Browserctl::Commands::Migrate.run(args)
@@ -229,8 +229,6 @@ begin
     when "navigate" then print_result(client.navigate(args[0], args[1]))
     when "fill"     then Browserctl::Commands::Fill.run(client, args)
     when "click"    then Browserctl::Commands::Click.run(client, args)
-    when "snapshot" then Browserctl::Commands::Snapshot.run(client, args)
-    when "screenshot" then Browserctl::Commands::Screenshot.run(client, args)
     when "evaluate" then print_result(client.evaluate(args[0], args[1]))
     when "url"      then print_result(client.url(args[0]))
     when "wait"

--- a/docs/architecture/decisions/0018-promotion-gates.md
+++ b/docs/architecture/decisions/0018-promotion-gates.md
@@ -10,7 +10,7 @@
 v0.11's pipeline turns recordings into promoted, replayable artefacts:
 
 ```
-record start → record stop → workflow generate → workflow run --check (× N) → workflow promote
+recording start → recording stop → workflow generate → workflow run --check (× N) → workflow promote
 ```
 
 The generator emits a workflow file from a single recording. That file may pass `--check` once and break the next time — a single clean run is not enough evidence that the workflow is durable. We need a gate that promotes only workflows whose `--check` history shows reliable behaviour.

--- a/docs/concepts/hitl.md
+++ b/docs/concepts/hitl.md
@@ -38,7 +38,7 @@ res[:challenge]   # => true when Cloudflare interstitial is detected
 ```
 
 ```bash
-browserctl snapshot main   # JSON includes "challenge": true when blocked
+browserctl page snapshot main   # JSON includes "challenge": true when blocked
 ```
 
 When `challenge` is true, the workflow decides what to do: pause and wait, retry the navigation, or abort.

--- a/docs/concepts/sessions-and-pages.md
+++ b/docs/concepts/sessions-and-pages.md
@@ -32,7 +32,7 @@ Inside the daemon, each browser tab is a **named page**. You give it a name when
 ```bash
 browserctl page open login --url https://app.example.com/login
 browserctl fill login "input[name=email]" me@example.com
-browserctl snapshot login
+browserctl page snapshot login
 browserctl page close login
 ```
 

--- a/docs/concepts/snapshots-and-refs.md
+++ b/docs/concepts/snapshots-and-refs.md
@@ -14,10 +14,10 @@ browserctl uses a different model: **refs** — and as of v0.11, refs are stable
 
 ## The snapshot
 
-`browserctl snapshot <page>` inspects the live page and returns a compact JSON array of every interactable element — inputs, buttons, links, selects, textareas. Static elements that cannot be acted on are omitted.
+`browserctl page snapshot <name>` inspects the live page and returns a compact JSON array of every interactable element — inputs, buttons, links, selects, textareas. Static elements that cannot be acted on are omitted.
 
 ```bash
-browserctl snapshot login
+browserctl page snapshot login
 ```
 
 ```json
@@ -142,7 +142,7 @@ The replay layer scores candidate elements in the new DOM against this fingerpri
 After the first snapshot, subsequent snapshots can return only the elements that changed since the last one:
 
 ```bash
-browserctl snapshot login --diff
+browserctl page snapshot login --diff
 ```
 
 This is useful in two situations:
@@ -155,7 +155,7 @@ This is useful in two situations:
 
 ## Refs and recording
 
-When you record a session with `browserctl record start <name>`, each command is captured and later replayed as a workflow. Selector-based interactions replay directly. Ref-based interactions now replay through two layers:
+When you record a session with `browserctl recording start <name>`, each command is captured and later replayed as a workflow. Selector-based interactions replay directly. Ref-based interactions now replay through two layers:
 
 1. The recorded ref is looked up against the current snapshot. Because refs are stable, this works whenever the page is semantically unchanged.
 2. If the ref no longer resolves (e.g. the page was redesigned and the parent path shifted), the recorded **fingerprint** is matched against the new DOM. If a match scores above the threshold, replay continues silently and the rematch is logged.
@@ -169,7 +169,7 @@ Workflow generation (v0.11) prefers stable selectors, with the fingerprint shipp
 When a model needs to understand page structure rather than interact with specific elements, pass `--format html`:
 
 ```bash
-browserctl snapshot login --format html
+browserctl page snapshot login --format html
 ```
 
 This returns the full page HTML. Useful for reading content, understanding layout, or extracting information. For interaction, use the default JSON format.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ The name (`main`) is what you'll use to address this tab in every subsequent com
 Snapshot the page to see what's on it:
 
 ```bash
-browserctl snapshot main
+browserctl page snapshot main
 ```
 
 You'll get a compact JSON array of every interactable element on the page, each with a short ref ID:
@@ -140,13 +140,13 @@ browserctl url main
 Take a screenshot:
 
 ```bash
-browserctl screenshot main --out /tmp/after-login.png --full
+browserctl page screenshot main --out /tmp/after-login.png --full
 ```
 
 Snapshot again to see what changed — use `--diff` to get only the elements that are different from the last snapshot:
 
 ```bash
-browserctl snapshot main --diff
+browserctl page snapshot main --diff
 ```
 
 ---

--- a/docs/guides/agent-integration.md
+++ b/docs/guides/agent-integration.md
@@ -10,7 +10,7 @@ Start the daemon once, then issue commands from your agent's tool calls:
 
 ```bash
 browserd &                         # start once; keeps the browser alive
-browserctl snapshot main           # → JSON array your agent reads
+browserctl page snapshot main      # → JSON array your agent reads
 browserctl click main --ref e3     # act on ref IDs from the snapshot
 browserctl daemon stop             # clean up when done
 ```
@@ -118,12 +118,12 @@ For shell-based agent loops, pipe snapshot output through `jq`:
 
 ```bash
 # Get the ref for the login button
-LOGIN_REF=$(browserctl snapshot main | jq -r '.[] | select(.text == "Login") | .ref')
+LOGIN_REF=$(browserctl page snapshot main | jq -r '.[] | select(.text == "Login") | .ref')
 
 browserctl click main --ref "$LOGIN_REF"
 
 # Poll until a target element appears
-until browserctl snapshot main | jq -e '.[] | select(.attrs["data-test"] == "dashboard")' > /dev/null; do
+until browserctl page snapshot main | jq -e '.[] | select(.attrs["data-test"] == "dashboard")' > /dev/null; do
   sleep 1
 done
 ```

--- a/docs/guides/ai-authoring.md
+++ b/docs/guides/ai-authoring.md
@@ -7,8 +7,8 @@ This guide walks an AI agent (or a human moving fast) from a one-off browser exp
 The pipeline is four CLI commands:
 
 ```bash
-browserctl record start <name>          # explore interactively
-browserctl record stop                  # save the recording
+browserctl recording start <name>          # explore interactively
+browserctl recording stop                  # save the recording
 browserctl workflow generate <name>     # → .browserctl/workflows/<name>.rb
 browserctl workflow run <name> --check  # × N (default 3 clean runs)
 browserctl workflow promote <name> [--as-flow]
@@ -18,19 +18,19 @@ No manual editing is required for the happy path.
 
 ---
 
-## 1. Explore — `record start` / `record stop`
+## 1. Explore — `recording start` / `recording stop`
 
 Start a recording session, then drive the browser as you normally would. Every `click`, `fill`, `navigate`, etc. is logged to `~/.browserctl/recordings/<name>.jsonl` along with the snapshot ref, the resolved CSS selector, the element's fingerprint, and a postcondition hint (URL, snapshot digest).
 
 ```bash
 browserd &
 browserctl page open main --url "https://example.com/login"
-browserctl record start gh_issues
+browserctl recording start gh_issues
 browserctl fill main "input[name=username]" alice
 browserctl fill main "input[name=password]" hunter2
 browserctl click main "button[type=submit]"
 browserctl navigate main "https://example.com/issues"
-browserctl record stop
+browserctl recording stop
 ```
 
 The recording captures *what was tried*, not just what worked. Failed clicks and selector retries also appear in the log so the generator can ignore them.
@@ -145,9 +145,9 @@ Once promoted as a flow, it shows up in `browserctl flow list` and is invocable 
 ```bash
 # 1. Explore
 browserd &
-browserctl record start scrape_issues
+browserctl recording start scrape_issues
 # … drive the browser …
-browserctl record stop
+browserctl recording stop
 
 # 2. Generate
 browserctl workflow generate scrape_issues

--- a/docs/product.md
+++ b/docs/product.md
@@ -40,13 +40,13 @@ This is not a workaround. It is the intended workflow.
 
 ### 2. Reproduce anything. Share it as code.
 
-The `record` command captures a live browser session as a replayable Ruby workflow. Reproduce a bug once, record the steps, hand the script to a colleague.
+The `recording` command captures a live browser session as a replayable Ruby workflow. Reproduce a bug once, record the steps, hand the script to a colleague.
 
 ```bash
 # Record the session
-browserctl record start my-bug
+browserctl recording start my-bug
 # ... interact in the browser ...
-browserctl record stop
+browserctl recording stop
 
 # Later: replay it against any environment
 browserctl workflow run my-bug --url https://staging.example.com

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -20,6 +20,8 @@ All commands require `browserd` to be running unless noted.
 | `page close <name>` | Close a named tab |
 | `page list` | List all open named pages and their current URLs |
 | `page focus <name>` | Bring a tab to front (headed mode only) |
+| `page snapshot <name> [--format elements\|html] [--diff]` | Snapshot DOM; `--diff` returns only changed elements |
+| `page screenshot <name> [--out PATH] [--full]` | Take a screenshot |
 
 ---
 
@@ -34,8 +36,6 @@ Page is always the first argument after the verb.
 | `fill <page> --ref <id> --value <v>` | Fill an input field by snapshot ref |
 | `click <page> <selector>` | Click an element by CSS selector |
 | `click <page> --ref <id>` | Click an element by snapshot ref |
-| `snapshot <page> [--format elements\|html] [--diff]` | Snapshot DOM; `--diff` returns only changed elements |
-| `screenshot <page> [--out PATH] [--full]` | Take a screenshot |
 | `evaluate <page> <expression>` | Evaluate a JavaScript expression |
 | `url <page>` | Print the current URL |
 | `wait <page> <selector> [--timeout N]` | Wait until selector appears (default: 30s) |
@@ -50,7 +50,7 @@ Page is always the first argument after the verb.
 | `dialog dismiss <page>` | Pre-register a one-shot handler to dismiss the next JS dialog |
 | `ask <prompt>` | Pause and prompt the human for a value via stdin (orchestration-level — takes no `<page>` argument; reads from operator stdin) |
 
-`navigate` and `snapshot` responses include `"challenge": true` when a Cloudflare interstitial is detected. See [Handling Challenges](../guides/handling-challenges.md).
+`navigate` and `page snapshot` responses include `"challenge": true` when a Cloudflare interstitial is detected. See [Handling Challenges](../guides/handling-challenges.md).
 
 > `navigate` steers an already-open page. Use `page open --url` to create a new tab and navigate in one step.
 
@@ -159,9 +159,9 @@ A session bundles everything needed to resume a browser state: all open pages (n
 
 | Command | Description |
 |---|---|
-| `record start <name>` | Begin recording commands as a replayable workflow |
-| `record stop [--out PATH]` | End recording; saves to `.browserctl/workflows/` or custom path |
-| `record status` | Show whether a recording is active |
+| `recording start <name>` | Begin recording commands as a replayable workflow |
+| `recording stop [--out PATH]` | End recording; saves to `.browserctl/workflows/` or custom path |
+| `recording status` | Show whether a recording is active |
 
 ---
 
@@ -244,7 +244,7 @@ If `--daemon` is omitted, `browserctl` connects to the default socket (`browserd
 
 ## Snapshot format
 
-`browserctl snapshot <page>` returns a JSON array of interactable elements:
+`browserctl page snapshot <name>` returns a JSON array of interactable elements:
 
 ```json
 [

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -50,7 +50,7 @@ Branch on the `code` field, not on the prose `error`/`message`.
 ```bash
 out=$(browserctl click checkout "#submit" 2>&1 1>/dev/null)
 case $(printf '%s' "$out" | jq -r '.code // "GENERIC"') in
-  SELECTOR_NOT_FOUND) browserctl snapshot checkout > /dev/null && retry ;;
+  SELECTOR_NOT_FOUND) browserctl page snapshot checkout > /dev/null && retry ;;
   AUTH_REQUIRED)      browserctl state rotate checkout ;;
   *)                  echo "unhandled: $out" >&2; exit 1 ;;
 esac

--- a/lib/browserctl/commands/page.rb
+++ b/lib/browserctl/commands/page.rb
@@ -2,21 +2,25 @@
 
 require "optimist"
 require_relative "cli_output"
+require_relative "snapshot"
+require_relative "screenshot"
 
 module Browserctl
   module Commands
     module Page
       extend CliOutput
 
-      USAGE = "Usage: browserctl page <open|close|list|focus> [args]"
+      USAGE = "Usage: browserctl page <open|close|list|focus|snapshot|screenshot> [args]"
 
       def self.run(client, args)
         sub = args.shift or abort USAGE
         case sub
-        when "open"  then run_open(client, args)
-        when "close" then run_close(client, args)
-        when "list"  then run_list(client)
-        when "focus" then run_focus(client, args)
+        when "open"       then run_open(client, args)
+        when "close"      then run_close(client, args)
+        when "list"       then run_list(client)
+        when "focus"      then run_focus(client, args)
+        when "snapshot"   then Browserctl::Commands::Snapshot.run(client, args)
+        when "screenshot" then Browserctl::Commands::Screenshot.run(client, args)
         else abort "unknown page subcommand '#{sub}'\n#{USAGE}"
         end
       end

--- a/lib/browserctl/commands/recording.rb
+++ b/lib/browserctl/commands/recording.rb
@@ -7,8 +7,8 @@ require "browserctl/recording"
 
 module Browserctl
   module Commands
-    class Record
-      USAGE = "Usage: browserctl record start <name> | stop [--out PATH] | status"
+    class Recording
+      USAGE = "Usage: browserctl recording start <name> | stop [--out PATH] | status"
 
       def self.run(args)
         subcmd = args.shift
@@ -17,7 +17,7 @@ module Browserctl
         when "stop"   then run_stop(args)
         when "status" then run_status
         else
-          abort "#{USAGE}\nRun 'browserctl record <subcommand> --help' for details."
+          abort "#{USAGE}\nRun 'browserctl recording <subcommand> --help' for details."
         end
       end
 
@@ -25,28 +25,28 @@ module Browserctl
         private
 
         def run_start(args)
-          Optimist.options(args) { banner "Usage: browserctl record start <name>" }
-          name = args.shift or abort "usage: browserctl record start <name>"
+          Optimist.options(args) { banner "Usage: browserctl recording start <name>" }
+          name = args.shift or abort "usage: browserctl recording start <name>"
           abort "Invalid recording name #{name.inspect} — use only letters, digits, _ or -" \
             unless name =~ /\A[a-zA-Z0-9_-]{1,64}\z/
-          Recording.start(name)
+          Browserctl::Recording.start(name)
           puts JSON.generate({ ok: true, name: name })
         end
 
         def run_stop(args)
           opts = Optimist.options(args) do
-            banner "Usage: browserctl record stop [--out PATH]"
+            banner "Usage: browserctl recording stop [--out PATH]"
             opt :out, "Output path for workflow file", type: :string, short: "-o"
           end
-          name = Recording.stop
+          name = Browserctl::Recording.stop
           out  = opts[:out] || File.join(".browserctl/workflows", "#{name}.rb")
           FileUtils.mkdir_p(File.dirname(out))
-          Recording.generate_workflow(name, output_path: out)
+          Browserctl::Recording.generate_workflow(name, output_path: out)
           puts JSON.generate({ ok: true, name: name, path: out })
         end
 
         def run_status
-          active = Recording.active
+          active = Browserctl::Recording.active
           puts JSON.generate({ active: active })
         end
       end

--- a/lib/browserctl/commands/screenshot.rb
+++ b/lib/browserctl/commands/screenshot.rb
@@ -10,11 +10,11 @@ module Browserctl
 
       def self.run(client, args)
         opts = Optimist.options(args) do
-          banner "Usage: browserctl screenshot <page> [--out PATH] [--full]"
+          banner "Usage: browserctl page screenshot <name> [--out PATH] [--full]"
           opt :out,  "Output file path",   type: :string, short: "-o"
           opt :full, "Capture full page",  default: false, short: "-f"
         end
-        name = args.shift or abort "usage: browserctl screenshot <page> [--out PATH] [--full]"
+        name = args.shift or abort "usage: browserctl page screenshot <name> [--out PATH] [--full]"
         print_result(client.screenshot(name, path: opts[:out], full: opts[:full]))
       end
     end

--- a/lib/browserctl/commands/snapshot.rb
+++ b/lib/browserctl/commands/snapshot.rb
@@ -10,11 +10,11 @@ module Browserctl
 
       def self.run(client, args)
         opts = Optimist.options(args) do
-          banner "Usage: browserctl snapshot <page> [--format elements|html] [--diff]"
+          banner "Usage: browserctl page snapshot <name> [--format elements|html] [--diff]"
           opt :format, "Output format: elements (default) or html", default: "elements", short: "-f"
           opt :diff,   "Return only changed elements", default: false, short: "-d"
         end
-        name = args.shift or abort "usage: browserctl snapshot <page> [--format elements|html] [--diff]"
+        name = args.shift or abort "usage: browserctl page snapshot <name> [--format elements|html] [--diff]"
         unless VALID_FORMATS.include?(opts[:format])
           warn "Error: --format must be one of: #{VALID_FORMATS.join(', ')}"
           exit 1

--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -63,7 +63,7 @@ module Browserctl
 
     def self.stop
       name = active
-      raise Browserctl::Error, "no active recording — run: browserctl record start <name>" unless name
+      raise Browserctl::Error, "no active recording — run: browserctl recording start <name>" unless name
 
       File.unlink(STATE_FILE)
       name

--- a/rakelib/demo.rake
+++ b/rakelib/demo.rake
@@ -38,19 +38,19 @@ namespace :demo do
     with_daemon(headed: ENV["HEADED"] == "1") do
       sh "bundle exec browserctl page open main --url https://moatazeldebsy.github.io/test-automation-practices/#/auth"
       sleep 2
-      sh "bundle exec browserctl screenshot main --out #{frames_dir}/01_login.png"
+      sh "bundle exec browserctl page screenshot main --out #{frames_dir}/01_login.png"
 
       sh "bundle exec browserctl fill main '[data-test=username-input]' admin"
       sleep 1
-      sh "bundle exec browserctl screenshot main --out #{frames_dir}/02_username.png"
+      sh "bundle exec browserctl page screenshot main --out #{frames_dir}/02_username.png"
 
       sh "bundle exec browserctl fill main '[data-test=password-input]' admin"
       sleep 1
-      sh "bundle exec browserctl screenshot main --out #{frames_dir}/03_filled.png"
+      sh "bundle exec browserctl page screenshot main --out #{frames_dir}/03_filled.png"
 
       sh "bundle exec browserctl click main '[data-test=login-button]'"
       sleep 3
-      sh "bundle exec browserctl screenshot main --out #{frames_dir}/04_success.png"
+      sh "bundle exec browserctl page screenshot main --out #{frames_dir}/04_success.png"
     end
 
     concat = "#{frames_dir}/concat.txt"

--- a/skills/automate/SKILL.md
+++ b/skills/automate/SKILL.md
@@ -68,11 +68,11 @@ browserctl fill  login --ref e1 --value user@example.com
 browserctl click login --ref e2
 
 # Observation
-browserctl snapshot login                   # interactable elements JSON (use this first for unknown layouts)
-browserctl snapshot login --diff            # only elements changed since last snap
-browserctl snapshot login --format html     # raw HTML
-browserctl screenshot login                 # screenshot → /tmp/
-browserctl screenshot login --out /tmp/my.png --full
+browserctl page snapshot login                   # interactable elements JSON (use this first for unknown layouts)
+browserctl page snapshot login --diff            # only elements changed since last snap
+browserctl page snapshot login --format html     # raw HTML
+browserctl page screenshot login                 # screenshot → /tmp/
+browserctl page screenshot login --out /tmp/my.png --full
 browserctl evaluate  login "document.title" # evaluate a JS expression
 
 # Waiting
@@ -80,9 +80,9 @@ browserctl wait login "button#submit"            # poll until selector appears
 browserctl wait login ".toast" --timeout 5       # fail after 5s
 
 # Recording → workflow → flow (v0.11 replayable loop)
-browserctl record start my_flow              # start capturing commands
-browserctl record stop                       # end capture; recording log at ~/.browserctl/recordings/<name>.jsonl
-browserctl record status                     # check if a recording is active
+browserctl recording start my_flow            # start capturing commands
+browserctl recording stop                     # end capture; recording log at ~/.browserctl/recordings/<name>.jsonl
+browserctl recording status                   # check if a recording is active
 browserctl workflow generate my_flow         # → .browserctl/workflows/my_flow.rb
 browserctl workflow run my_flow --check      # replay + snapshot diff (run until 3× clean)
 browserctl workflow promote my_flow          # → ~/.browserctl/workflows/my_flow.rb (gated by clean streak)
@@ -211,7 +211,7 @@ Or use `selector` values with `fill` and `click`. Prefer `snapshot` over raw HTM
 After the first `snapshot`, use `--diff` to fetch only what changed — avoids re-processing the full DOM on every step:
 
 ```sh
-browserctl snapshot login --diff
+browserctl page snapshot login --diff
 ```
 
 ## Naming pages
@@ -234,7 +234,7 @@ throwaway script. Only harden once the sequence is confirmed reliable.
 ```sh
 browserd --headed &
 browserctl page open main --url https://app.example.com/login
-browserctl snapshot main                      # learn the selectors
+browserctl page snapshot main                 # learn the selectors
 browserctl fill main "input[name=email]" me@example.com
 browserctl fill main "input[name=password]" secret
 browserctl click main "button[type=submit]"
@@ -418,7 +418,7 @@ Use when the default "invoke the bound flow" doesn't fit — the lambda runs in 
 - **Use `wait`** when you need to wait for an element that appears asynchronously — more efficient than polling `snapshot`.
 - **Use named daemons** (`browserd --name X`) when running multiple parallel sessions — each gets an isolated socket and browser.
 - **Use descriptive page names.** Reuse the same name if the page is still open.
-- **Log state at the end** of multi-step tasks: `browserctl url <page>` and `browserctl snapshot <page>`.
+- **Log state at the end** of multi-step tasks: `browserctl url <page>` and `browserctl page snapshot <page>`.
 - **Use `press`** for keyboard shortcuts, form submission (`Enter`), navigation (`Tab`, `Escape`, `ArrowDown`). Prefer it over `evaluate` keyboard dispatch.
 - **Use `dialog accept/dismiss` before the triggering action** — the handler is one-shot and fires when the dialog appears. Register it first, then click the button that triggers it.
 - **Use `ask`** when automation needs a human-supplied value (2FA code, CAPTCHA answer, confirmation) but doesn't need to hand over full browser control. Cleaner than `pause` for value injection.
@@ -430,11 +430,11 @@ Use when the default "invoke the bound flow" doesn't fit — the lambda runs in 
 - **Use `secret_ref:` for credentials** — `param :password, secret_ref: "op://vault/item/field"` resolves the value from your keychain or secret manager at runtime. Never pass credentials as CLI flags or hardcode them in workflow files. `secret_ref:` always implies `secret: true`.
 - **Use `session save/load`** for v0.8/v0.9 callers only — new code should use `state save/load`. The session zip format remains readable through v0.10 with a deprecation warning.
 - **`load_session(fallback:, expired_if:)` is deprecated** — the recovery loop now lives in `load_state`. Existing usages still work through v0.10 but emit a stderr DEPRECATION warning; migrate to `save_state(name, flow: :name)` + `load_state(name)`.
-- **Save stable sequences as workflows** — ask the user first, then write the `.rb` file. Use `browserctl record` to capture a live session automatically.
+- **Save stable sequences as workflows** — ask the user first, then write the `.rb` file. Use `browserctl recording` to capture a live session automatically.
 
 ## Recording and refs
 
-`browserctl record start <name>` captures a live session. Selector-based interactions replay perfectly. Ref-based interactions (`--ref eN`) cannot replay by ref — they are captured as commented-out TODO stubs in the generated workflow:
+`browserctl recording start <name>` captures a live session. Selector-based interactions replay perfectly. Ref-based interactions (`--ref eN`) cannot replay by ref — they are captured as commented-out TODO stubs in the generated workflow:
 
 ```ruby
 # TODO: ref-based fill on "login" (ref: e1) — replace with a stable CSS selector
@@ -443,7 +443,7 @@ Use when the default "invoke the bound flow" doesn't fit — the lambda runs in 
 # end
 ```
 
-`record stop` prints a warning if any were found. Fix them by replacing the selector with the value from the snapshot JSON for that ref.
+`recording stop` prints a warning if any were found. Fix them by replacing the selector with the value from the snapshot JSON for that ref.
 
 ## The replayable loop (v0.11): explore → generate → check → promote
 
@@ -451,9 +451,9 @@ Once you have a recording, four CLI commands take you from a one-off exploration
 
 ```bash
 # 1. Explore — drive the browser interactively while recording
-browserctl record start my_flow
+browserctl recording start my_flow
 # ... navigate / fill / click ...
-browserctl record stop
+browserctl recording stop
 
 # 2. Generate — emit a Ruby workflow file
 browserctl workflow generate my_flow
@@ -507,7 +507,7 @@ How to read it:
 
 - **All events `rematch` with `score ≥ 0.85`** — the page changed cosmetically (renamed CSS class, refactored container). The workflow is fine. Continue running `--check`; once 3 clean runs land, promote. If you want to lock the new selector in, edit the recorded selector to match `matched_ref`'s current selector.
 - **`rematch` with `0.6 ≤ score < 0.85`** — the matcher is uncertain. Visually verify in `--headed` mode that the right element was hit. If it was, lock the new selector in. If not, re-record.
-- **`reason: "no candidate above threshold"`** — the original element is gone and nothing similar exists. The workflow needs a new step shape; re-record from `record start`.
+- **`reason: "no candidate above threshold"`** — the original element is gone and nothing similar exists. The workflow needs a new step shape; re-record from `recording start`.
 - **Many `rematch` events on a single run** — likely a structural redesign rather than drift. Re-record rather than rematching every step run after run.
 
 The matcher's threshold defaults are conservative; a low-confidence rematch is more likely to be wrong than a high-confidence selector. When in doubt: re-record. When the report is consistent across runs: trust it.

--- a/spec/integration/cli_error_matrix_spec.rb
+++ b/spec/integration/cli_error_matrix_spec.rb
@@ -131,14 +131,14 @@ RSpec.describe "CLI error code matrix" do
       runner: ->(ctx) { ctx.run_cli(%w[click any #x]) }
     ),
     CliErrorMatrix::Cell.new(
-      command: "snapshot", code: "DAEMON_UNREACHABLE",
+      command: "page snapshot", code: "DAEMON_UNREACHABLE",
       scenario: "no daemon socket",
-      runner: ->(ctx) { ctx.run_cli(%w[snapshot any]) }
+      runner: ->(ctx) { ctx.run_cli(%w[page snapshot any]) }
     ),
     CliErrorMatrix::Cell.new(
-      command: "screenshot", code: "DAEMON_UNREACHABLE",
+      command: "page screenshot", code: "DAEMON_UNREACHABLE",
       scenario: "no daemon socket",
-      runner: ->(ctx) { ctx.run_cli(%w[screenshot any]) }
+      runner: ->(ctx) { ctx.run_cli(%w[page screenshot any]) }
     ),
     CliErrorMatrix::Cell.new(
       command: "press", code: "DAEMON_UNREACHABLE",

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -4,7 +4,7 @@ require "tmpdir"
 require "stringio"
 require "json"
 require "browserctl/recording"
-require "browserctl/commands/record"
+require "browserctl/commands/recording"
 
 RSpec.describe Browserctl::Recording do
   around do |example|
@@ -190,7 +190,7 @@ RSpec.describe Browserctl::Recording do
       expect(File.exist?(File.join(@tmp_dir, "gen.jsonl"))).to be(true)
     end
 
-    it "deletes the log by default (record stop semantics)" do
+    it "deletes the log by default (recording stop semantics)" do
       described_class.append("click", name: "p", selector: "a")
       described_class.generate_workflow("gen")
       expect(File.exist?(File.join(@tmp_dir, "gen.jsonl"))).to be(false)
@@ -439,7 +439,7 @@ RSpec.describe Browserctl::Recording do
   end
 end
 
-RSpec.describe Browserctl::Commands::Record do
+RSpec.describe Browserctl::Commands::Recording do
   def capture_stdout
     original = $stdout
     $stdout = StringIO.new
@@ -449,7 +449,7 @@ RSpec.describe Browserctl::Commands::Record do
     $stdout = original
   end
 
-  describe "record start" do
+  describe "recording start" do
     it "emits JSON with ok and name on start" do
       allow(Browserctl::Recording).to receive(:start)
       output = capture_stdout { described_class.run(%w[start my-rec]) }
@@ -459,7 +459,7 @@ RSpec.describe Browserctl::Commands::Record do
     end
   end
 
-  describe "record stop" do
+  describe "recording stop" do
     it "emits JSON with ok, name, and path on stop" do
       allow(Browserctl::Recording).to receive(:stop).and_return("my-workflow")
       allow(Browserctl::Recording).to receive(:generate_workflow)
@@ -472,7 +472,7 @@ RSpec.describe Browserctl::Commands::Record do
     end
   end
 
-  describe "record status" do
+  describe "recording status" do
     it "emits JSON with active name when recording" do
       allow(Browserctl::Recording).to receive(:active).and_return("my-rec")
       output = capture_stdout { described_class.run(["status"]) }


### PR DESCRIPTION
## Summary

Implements **PR 3** of the v0.13 plan (`docs/plans/v0.13-lean.md`). Renames four CLI commands to fit the noun-verb grammar already used by `page`, `cookie`, `storage`, `state`, and `workflow`. Direct renames — no aliases.

| Before | After |
|---|---|
| `browserctl snapshot <page> [...]` | `browserctl page snapshot <name> [...]` |
| `browserctl screenshot <page> [...]` | `browserctl page screenshot <name> [...]` |
| `browserctl record start <name>` | `browserctl recording start <name>` |
| `browserctl record stop` | `browserctl recording stop` |
| `browserctl record status` | `browserctl recording status` |
| `browserctl trace [<name>]` | unchanged (debug-time top-level read) |

## Wire protocol unchanged

The JSON-RPC commands `snapshot` and `screenshot` on the Unix socket stay exactly as documented. Only the CLI grammar changes — `Browserctl::Commands::Page` dispatches `snapshot` / `screenshot` subcommands to the existing `Snapshot` / `Screenshot` command classes, which still send `client.snapshot` / `client.screenshot` over the wire. Verified no diff in `lib/browserctl/server/handlers/observation.rb` (which defines `cmd_snapshot` / `cmd_screenshot`).

## Notable file moves

- `lib/browserctl/commands/record.rb` → `lib/browserctl/commands/recording.rb` (via `git mv`, history follows).
- Class `Browserctl::Commands::Record` → `Browserctl::Commands::Recording`.

## Test plan

- [x] `bundle exec rspec` — 881 examples, 0 failures, 63 pending (Chrome-required tests pre-existing).
- [x] `bundle exec rubocop` — 227 files, no offenses.
- [x] Sanity grep: `grep -rn "browserctl snapshot\|browserctl screenshot\|browserctl record " . --include='*.rb' --include='*.md' --include='*.rake'` returns no live references outside `docs/plans/` and prose in `docs/vs-agent-browser.md`.
- [ ] `rake smoke:all` — not run locally (uses Ruby DSL `page(:x).snapshot` paths which were not changed; CLI strings in `rakelib/demo.rake` updated to `browserctl page screenshot`).