### PR TITLE
feat!: unified --output {json,text,silent} on every CLI command

### DIFF
--- a/bin/browserctl
+++ b/bin/browserctl
@@ -14,6 +14,7 @@ require "json"
 require "optimist"
 require "browserctl"
 require "browserctl/commands/cli_output"
+require "browserctl/commands/output_format"
 require "browserctl/commands/fill"
 require "browserctl/commands/click"
 require "browserctl/commands/snapshot"
@@ -41,9 +42,11 @@ def structured_stderr_payload(res, message)
   [code, JSON.generate(code: code, message: message, context: context, suggested_action: action)]
 end
 
-def print_result(res)
+def print_result(res, text_block = nil)
+  fmt = Browserctl::Commands::OutputFormat.current
+
   unless res.is_a?(Hash) && (res[:error] || res["error"])
-    puts res.to_json
+    fmt.emit(res, text_block)
     return
   end
 
@@ -51,7 +54,7 @@ def print_result(res)
   code, payload = structured_stderr_payload(res, message)
   warn "Error: #{message}"
   warn payload
-  puts res.to_json
+  puts res.to_json unless fmt.silent?
   exit Browserctl::Error::ExitCodes.for(code)
 end
 
@@ -153,9 +156,21 @@ def usage
 
     Global options:
       --daemon <name>    Connect to named or auto-indexed daemon (d1, d2, work, ...)
+      --output <fmt>     Output format: json | text | silent (default: text;
+                         override with BROWSERCTL_OUTPUT)
       --version, -v
   USAGE
   exit 0
+end
+
+# Resolve --output {json,text,silent} (or BROWSERCTL_OUTPUT) once, globally,
+# before per-command parsers run. Strips the flag from ARGV in place so
+# downstream Optimist/positional parsers don't see it.
+begin
+  Browserctl::Commands::OutputFormat.install!(ARGV)
+rescue Browserctl::Commands::OutputFormat::InvalidFormat => e
+  warn "Error: #{e.message}"
+  exit 2
 end
 
 daemon_idx  = ARGV.index("--daemon")
@@ -239,9 +254,12 @@ begin
         warn "Error: #{res[:error]}"
         exit 1
       end
-      puts "Page '#{name}' paused. Browser is live — interact freely."
-      puts "(#{opts[:message]})" if opts[:message]
-      puts "When done: browserctl resume #{name}"
+      print_result(res.merge(paused: name, message: opts[:message])) do
+        lines = ["Page '#{name}' paused. Browser is live — interact freely."]
+        lines << "(#{opts[:message]})" if opts[:message]
+        lines << "When done: browserctl resume #{name}"
+        lines.join("\n")
+      end
     when "resume" then Browserctl::Commands::Resume.run(client, args)
     when "press"
       name = args.shift or abort "usage: browserctl press <page> <key>"
@@ -270,8 +288,9 @@ begin
         exit 1
       end
       url = res[:devtools_url]
-      puts "Opening DevTools for '#{name}':"
-      puts "  #{url}"
+      print_result(res) do
+        "Opening DevTools for '#{name}':\n  #{url}"
+      end
       opener = RUBY_PLATFORM =~ /darwin/ ? "open" : "xdg-open"
       system(opener, url)
     else

--- a/docs/guides/agent-integration.md
+++ b/docs/guides/agent-integration.md
@@ -179,6 +179,48 @@ Each daemon has its own socket, its own browser, and its own session state.
 
 ---
 
+## Output formats: `--output {json,text,silent}`
+
+Every command accepts `--output` and honours `BROWSERCTL_OUTPUT` (env var). Resolution order is **flag → env → `text` (default)**.
+
+| Mode     | Stdout                                                                                                          | When to use                                          |
+| -------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `text`   | Human-readable (today's default — JSON for most commands, prose for `init`/`pause`/`devtools`/`migrate`/`trace`). | Interactive shell use.                               |
+| `json`   | A JSON document on stdout. Stable shape per command.                                                            | Agents and scripts.                                  |
+| `silent` | Nothing. Exit code carries the result; structured error payload still goes to stderr.                           | Side-effect-only steps where output is noise.        |
+
+Errors always emit a structured JSON line on stderr (regardless of `--output`) — see [errors.md](../reference/errors.md).
+
+```bash
+# One-off: ask a single command for JSON.
+browserctl page list --output json
+
+# Run an entire agent session in JSON mode via env.
+export BROWSERCTL_OUTPUT=json
+browserctl page open main --url https://example.com
+browserctl page snapshot main                # JSON array of refs
+browserctl click main --ref e3
+browserctl page close main --output silent   # don't care about the response
+```
+
+A minimal Python tool wrapper:
+
+```python
+import json, os, subprocess
+
+env = {**os.environ, "BROWSERCTL_OUTPUT": "json"}
+
+def ctl(*args):
+    r = subprocess.run(["browserctl", *args], env=env, capture_output=True, text=True)
+    if r.returncode != 0:
+        # last line of stderr is the structured error payload
+        err = json.loads(r.stderr.strip().splitlines()[-1])
+        raise RuntimeError(f"{err['code']}: {err['message']}")
+    return json.loads(r.stdout) if r.stdout.strip() else None
+```
+
+---
+
 ## What next?
 
 - [Sessions and Pages](../concepts/sessions-and-pages.md) — how named pages and session persistence work

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2,6 +2,27 @@
 
 All commands require `browserd` to be running unless noted.
 
+## Global flags
+
+These flags work on every command listed below.
+
+| Flag                            | Description                                                                                                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--daemon <name>`               | Connect to a named or auto-indexed daemon (`d1`, `d2`, `work`, ...). See [agent-integration.md](../guides/agent-integration.md#multi-agent-isolation). |
+| `--log-level <level>`, `-l`     | One of `debug`, `info`, `warn`, `error`. Default: `info` (or `BROWSERCTL_LOG_LEVEL`).                                                                  |
+| `--output <json\|text\|silent>` | Stdout format. Default: `text` (or `BROWSERCTL_OUTPUT`). See "Output formats" below.                                                                   |
+| `--version`, `-v`               | Print the gem version and exit.                                                                                                                        |
+
+### Output formats
+
+Resolution order: explicit `--output` flag -> `BROWSERCTL_OUTPUT` env var -> `text`.
+
+- **`text`** — Human-readable. For most commands the human form already is JSON; commands like `init`, `pause`, `devtools`, `migrate`, and `trace` print prose.
+- **`json`** — A JSON document on stdout. Stable per-command shape. Recommended for agents and scripts.
+- **`silent`** — No stdout. The exit code still carries the result; the structured stderr error payload is still emitted on failure (errors are the result, not cosmetic output).
+
+See [Using browserctl from AI Agents](../guides/agent-integration.md#output-formats---output-jsontextsilent) for end-to-end recipes.
+
 ---
 
 ## Setup

--- a/lib/browserctl/commands/cli_output.rb
+++ b/lib/browserctl/commands/cli_output.rb
@@ -3,21 +3,35 @@
 require "json"
 require_relative "../errors"
 require_relative "../error/suggested_actions"
+require_relative "output_format"
 
 module Browserctl
   module Commands
     module CliOutput
       AUTH_REQUIRED_EXIT_CODE = Browserctl::AuthRequiredError::AUTH_REQUIRED_EXIT_CODE
 
-      def print_result(res)
+      # Print the JSON-RPC daemon response, routed through the active
+      # `OutputFormat`. The historical default behaviour was `puts res.to_json`
+      # — keeping that as the `text` branch preserves byte-identical output
+      # for existing callers and golden files. `json` mode emits the same
+      # JSON explicitly. `silent` suppresses stdout entirely; errors still
+      # write the structured payload to stderr because errors are the
+      # result, not cosmetic output.
+      #
+      # `text_block` (optional) overrides the JSON dump in `text` mode for
+      # commands that have a distinct human-readable form (e.g. `init`).
+      def print_result(res, text_block = nil)
+        fmt = OutputFormat.current
+
         if res.is_a?(Hash) && (res[:error] || res["error"])
           message = res[:error] || res["error"]
           warn "Error: #{message}"
           warn structured_error_line(res, message)
-          puts res.to_json
+          puts res.to_json unless fmt.silent?
           exit exit_code_for(res)
         end
-        puts res.to_json
+
+        fmt.emit(res, text_block)
       end
 
       # Maps a daemon error response onto a process exit code. Defaults to 1;

--- a/lib/browserctl/commands/daemon.rb
+++ b/lib/browserctl/commands/daemon.rb
@@ -3,6 +3,7 @@
 require "json"
 require "optimist"
 require_relative "cli_output"
+require_relative "output_format"
 
 module Browserctl
   module Commands
@@ -18,7 +19,8 @@ module Browserctl
           begin
             print_result(client.ping)
           rescue Browserctl::DaemonUnavailableError => e
-            puts JSON.generate({ ok: false, daemon: "offline", error: e.message })
+            payload = { ok: false, daemon: "offline", error: e.message }
+            OutputFormat.current.emit(payload)
             exit 1
           end
         when "status" then run_status(client)
@@ -36,14 +38,16 @@ module Browserctl
           url_res = client.url(name)
           { name: name, url: url_res[:url] || url_res[:error] }
         end
-        puts JSON.pretty_generate(
+        payload = {
           daemon: "online",
           pid: ping[:pid],
           protocol_version: ping[:protocol_version],
           pages: page_info
-        )
+        }
+        OutputFormat.current.emit(payload, JSON.pretty_generate(payload))
       rescue Browserctl::DaemonUnavailableError => e
-        puts JSON.pretty_generate(daemon: "offline", error: e.message)
+        payload = { daemon: "offline", error: e.message }
+        OutputFormat.current.emit(payload, JSON.pretty_generate(payload))
         exit 1
       end
 
@@ -57,7 +61,7 @@ module Browserctl
         flags += ["--name", opts[:name]] if opts[:name]
         pid = Process.spawn("browserd", *flags, out: File::NULL, err: File::NULL)
         Process.detach(pid)
-        puts "browserd started (pid #{pid})"
+        OutputFormat.current.emit({ ok: true, pid: pid }) { "browserd started (pid #{pid})" }
       end
 
       def self.run_list
@@ -74,7 +78,7 @@ module Browserctl
         rescue Browserctl::DaemonUnavailableError, RuntimeError
           nil
         end.compact
-        puts({ daemons: rows }.to_json)
+        OutputFormat.current.emit({ daemons: rows })
       end
     end
   end

--- a/lib/browserctl/commands/flow.rb
+++ b/lib/browserctl/commands/flow.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require_relative "cli_output"
+require_relative "output_format"
 require_relative "../flow_registry"
 require_relative "../runner"
 
@@ -31,22 +32,22 @@ module Browserctl
         page_proxy = page_name ? Browserctl::PageProxy.new(page_name, client) : nil
 
         result = flow.run(page: page_proxy, client: client, **params)
-        puts JSON.generate(ok: true, flow: flow.name, result: serialisable(result))
+        OutputFormat.current.emit({ ok: true, flow: flow.name, result: serialisable(result) })
       rescue Browserctl::FlowError => e
         warn "Error: #{e.message}"
-        puts JSON.generate(ok: false, code: e.code, error: e.message)
+        OutputFormat.current.emit({ ok: false, code: e.code, error: e.message }) unless OutputFormat.current.silent?
         exit 1
       end
 
       def self.run_list
         entries = Browserctl::FlowRegistry.list
-        puts JSON.generate(flows: entries)
+        OutputFormat.current.emit({ flows: entries })
       end
 
       def self.run_describe(args)
         name = args.shift or abort "usage: browserctl flow describe <name>"
         flow = resolve(name)
-        puts JSON.pretty_generate(
+        payload = {
           name: flow.name,
           desc: flow.description,
           version: flow.version_string,
@@ -56,7 +57,8 @@ module Browserctl
           steps: flow.steps.map(&:label),
           postconditions: flow.postconditions.map(&:label),
           produces_state: !flow.produces_state_block.nil?
-        )
+        }
+        OutputFormat.current.emit(payload, JSON.pretty_generate(payload))
       end
 
       def self.resolve(name_or_path)

--- a/lib/browserctl/commands/init.rb
+++ b/lib/browserctl/commands/init.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require_relative "output_format"
 
 module Browserctl
   module Commands
@@ -30,10 +31,22 @@ module Browserctl
         config_path = ".browserctl/config.yml"
         File.write(config_path, CONFIG_TEMPLATE) unless File.exist?(config_path)
 
-        puts "Initialised browserctl project:"
-        puts "  .browserctl/workflows/   (place workflow .rb files here)"
-        puts "  .browserctl/state/       (state bundles — git-ignored)"
-        puts "  .browserctl/config.yml   (project settings)"
+        payload = {
+          ok: true,
+          paths: {
+            workflows: ".browserctl/workflows",
+            state: ".browserctl/state",
+            config: ".browserctl/config.yml"
+          }
+        }
+        OutputFormat.current.emit(payload) do
+          <<~TEXT.chomp
+            Initialised browserctl project:
+              .browserctl/workflows/   (place workflow .rb files here)
+              .browserctl/state/       (state bundles — git-ignored)
+              .browserctl/config.yml   (project settings)
+          TEXT
+        end
       end
     end
   end

--- a/lib/browserctl/commands/migrate.rb
+++ b/lib/browserctl/commands/migrate.rb
@@ -4,6 +4,7 @@ require_relative "../migrations"
 require_relative "../errors"
 require_relative "../error/codes"
 require_relative "../error/exit_codes"
+require_relative "output_format"
 
 module Browserctl
   module Commands
@@ -43,21 +44,42 @@ module Browserctl
       end
 
       def self.execute(path, target_version:, dry_run:, out:, err:)
-        format = Browserctl::Migrations.detect_format(path)
-        unless format
-          err.puts "Error: could not detect format for #{path} (expected .bctl, .jsonl, or .rb)"
-          exit Browserctl::Error::ExitCodes::PROTOCOL_MISMATCH
-        end
-
+        format = detect_format!(path, err: err)
         current = Browserctl::Migrations.detect_version(path, format)
-        out.puts "Detected: format=#{format} version=#{current.inspect} path=#{path}"
+        emit_detected(format, current, path, out)
 
-        if dry_run
-          plan_dry_run(format, current, target_version, out)
-          return
-        end
+        return plan_dry_run(format, current, target_version, out) if dry_run
 
         result = Browserctl::Migrations.run(path, target_version: target_version)
+        emit_applied(format, current, result, out)
+      end
+
+      def self.detect_format!(path, err:)
+        format = Browserctl::Migrations.detect_format(path)
+        return format if format
+
+        err.puts "Error: could not detect format for #{path} (expected .bctl, .jsonl, or .rb)"
+        exit Browserctl::Error::ExitCodes::PROTOCOL_MISMATCH
+      end
+      private_class_method :detect_format!
+
+      def self.emit_detected(format, current, path, out)
+        return unless OutputFormat.current.text?
+
+        out.puts "Detected: format=#{format} version=#{current.inspect} path=#{path}"
+      end
+      private_class_method :emit_detected
+
+      def self.emit_applied(format, current, result, out)
+        fmt = OutputFormat.current
+        if fmt.json?
+          fmt.emit({ ok: true, format: format, from: result.from, to: result.to,
+                     applied: result.applied.map { |m| { from: m.from_version, to: m.to_version } } },
+                   io: out)
+          return
+        end
+        return if fmt.silent?
+
         if result.applied.empty?
           out.puts "No migrations registered for #{format} v#{current}; nothing to do."
         else
@@ -65,11 +87,36 @@ module Browserctl
           result.applied.each { |m| out.puts "  - #{format} v#{m.from_version} -> v#{m.to_version}" }
         end
       end
+      private_class_method :emit_applied
 
       def self.plan_dry_run(format, current, target_version, out)
         target = target_version || latest_target(format, current)
         chain  = Browserctl::Migrations.find_path(format: format, from: current, to: target)
+        emit_plan(format, current, target, chain, out)
+      end
 
+      def self.emit_plan(format, current, target, chain, out)
+        fmt = OutputFormat.current
+        if fmt.json?
+          fmt.emit(plan_payload(format, current, target, chain), io: out)
+          return
+        end
+        return if fmt.silent?
+
+        emit_plan_text(format, current, target, chain, out)
+      end
+      private_class_method :emit_plan
+
+      def self.plan_payload(format, current, target, chain)
+        {
+          format: format, from: current, to: target, dry_run: true,
+          plan: chain&.map { |m| { from: m.from_version, to: m.to_version } },
+          registered: registered_for(format)
+        }
+      end
+      private_class_method :plan_payload
+
+      def self.emit_plan_text(format, current, target, chain, out)
         if chain.nil?
           out.puts "No migration path #{format} v#{current} -> v#{target} (registered: " \
                    "#{registered_for(format).inspect})"
@@ -80,6 +127,7 @@ module Browserctl
           chain.each { |m| out.puts "  - #{format} v#{m.from_version} -> v#{m.to_version}" }
         end
       end
+      private_class_method :emit_plan_text
 
       def self.latest_target(format, current)
         targets = registered_for(format)

--- a/lib/browserctl/commands/output_format.rb
+++ b/lib/browserctl/commands/output_format.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Browserctl
+  module Commands
+    # Resolves and applies the unified `--output {json,text,silent}` flag.
+    #
+    # Resolution order: explicit flag value -> `BROWSERCTL_OUTPUT` env var ->
+    # `text` (default).
+    #
+    # Usage from a command:
+    #
+    #   fmt = OutputFormat.from(flag, ENV)
+    #   fmt.emit(payload_hash) { "human readable text" }
+    #
+    # Per the v0.13 contract:
+    #
+    #   text   - prints the human-readable block; this is byte-identical to
+    #            today's output. For most commands the human block already IS
+    #            the JSON payload (legacy CLI shape) so the two collapse.
+    #   json   - prints the JSON payload via `to_json` (no pretty printing).
+    #   silent - prints nothing on stdout. Exit codes still carry the result.
+    #
+    # The current format is also exposed as a process-wide default
+    # (`OutputFormat.current`) so that `CliOutput#print_result` and other
+    # legacy helpers can consult it without every callsite threading the
+    # value through.
+    module OutputFormat
+      VALID = %w[json text silent].freeze
+      DEFAULT = "text"
+      ENV_VAR = "BROWSERCTL_OUTPUT"
+      FLAG = "--output"
+
+      class InvalidFormat < ArgumentError; end
+
+      class Formatter
+        attr_reader :mode
+
+        def initialize(mode)
+          @mode = mode
+        end
+
+        # Print success output for a command.
+        # `payload` is a JSON-serialisable Hash (or Array). `text_block` is
+        # either a String or a block that returns a String — only evaluated
+        # when needed.
+        def emit(payload, text_block = nil, io: $stdout)
+          case @mode
+          when "silent"
+            nil
+          when "json"
+            io.puts payload.to_json
+          else # "text"
+            text = if block_given?
+                     yield
+                   elsif text_block.respond_to?(:call)
+                     text_block.call
+                   elsif text_block.nil?
+                     payload.to_json
+                   else
+                     text_block
+                   end
+            io.puts text
+          end
+        end
+
+        def silent?
+          @mode == "silent"
+        end
+
+        def json?
+          @mode == "json"
+        end
+
+        def text?
+          @mode == "text"
+        end
+      end
+
+      module_function
+
+      # Build a Formatter from an explicit flag value (or nil) and an env hash.
+      def from(flag, env = ENV)
+        raw = flag || env[ENV_VAR] || DEFAULT
+        mode = raw.to_s.strip.downcase
+        mode = DEFAULT if mode.empty?
+        unless VALID.include?(mode)
+          raise InvalidFormat,
+                "invalid --output value '#{raw}' (expected one of: #{VALID.join(', ')})"
+        end
+        Formatter.new(mode)
+      end
+
+      # Strip `--output VALUE` (or `--output=VALUE`) from `args` in place and
+      # return the extracted value (or nil). Recognises the long form only —
+      # there is intentionally no short alias.
+      def extract!(args)
+        i = 0
+        while i < args.length
+          arg = args[i]
+          if arg == FLAG
+            args.delete_at(i)
+            value = args.delete_at(i) or
+              raise InvalidFormat, "missing value for #{FLAG}"
+            return value
+          elsif arg.is_a?(String) && arg.start_with?("#{FLAG}=")
+            value = arg.split("=", 2)[1]
+            args.delete_at(i)
+            return value
+          else
+            i += 1
+          end
+        end
+        nil
+      end
+
+      # Process-wide current format. Set once by the CLI entry point after
+      # parsing the global flag; consulted by helpers that don't otherwise
+      # have a reference to a Formatter (notably `CliOutput#print_result`).
+      def current
+        @current ||= Formatter.new(DEFAULT)
+      end
+
+      def current=(formatter)
+        @current = formatter
+      end
+
+      # Convenience: parse the flag out of `args`, build a Formatter, set it
+      # as current, and return it.
+      def install!(args, env = ENV)
+        flag = extract!(args)
+        fmt  = from(flag, env)
+        self.current = fmt
+        fmt
+      end
+
+      # Reset to default — for tests.
+      def reset!
+        @current = Formatter.new(DEFAULT)
+      end
+    end
+  end
+end

--- a/lib/browserctl/commands/recording.rb
+++ b/lib/browserctl/commands/recording.rb
@@ -4,6 +4,7 @@ require "fileutils"
 require "json"
 require "optimist"
 require "browserctl/recording"
+require_relative "output_format"
 
 module Browserctl
   module Commands
@@ -30,7 +31,7 @@ module Browserctl
           abort "Invalid recording name #{name.inspect} — use only letters, digits, _ or -" \
             unless name =~ /\A[a-zA-Z0-9_-]{1,64}\z/
           Browserctl::Recording.start(name)
-          puts JSON.generate({ ok: true, name: name })
+          OutputFormat.current.emit({ ok: true, name: name })
         end
 
         def run_stop(args)
@@ -42,12 +43,12 @@ module Browserctl
           out  = opts[:out] || File.join(".browserctl/workflows", "#{name}.rb")
           FileUtils.mkdir_p(File.dirname(out))
           Browserctl::Recording.generate_workflow(name, output_path: out)
-          puts JSON.generate({ ok: true, name: name, path: out })
+          OutputFormat.current.emit({ ok: true, name: name, path: out })
         end
 
         def run_status
           active = Browserctl::Recording.active
-          puts JSON.generate({ active: active })
+          OutputFormat.current.emit({ active: active })
         end
       end
     end

--- a/lib/browserctl/commands/resume.rb
+++ b/lib/browserctl/commands/resume.rb
@@ -14,7 +14,7 @@ module Browserctl
           warn "Error: #{res[:error]}"
           exit 1
         end
-        puts "Page '#{name}' resumed."
+        print_result(res.merge(resumed: name)) { "Page '#{name}' resumed." }
       end
     end
   end

--- a/lib/browserctl/commands/snapshot.rb
+++ b/lib/browserctl/commands/snapshot.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "optimist"
+require_relative "output_format"
 
 module Browserctl
   module Commands
@@ -31,7 +32,11 @@ module Browserctl
             warn "Error: #{res[:error]}"
             exit 1
           end
-          puts(format == "elements" ? JSON.pretty_generate(res[:snapshot]) : res[:html])
+          if format == "elements"
+            OutputFormat.current.emit(res[:snapshot], JSON.pretty_generate(res[:snapshot]))
+          else
+            OutputFormat.current.emit({ html: res[:html] }, res[:html])
+          end
         end
       end
     end

--- a/lib/browserctl/commands/state.rb
+++ b/lib/browserctl/commands/state.rb
@@ -3,6 +3,7 @@
 require "io/console"
 require "json"
 require_relative "cli_output"
+require_relative "output_format"
 
 module Browserctl
   module Commands
@@ -131,7 +132,7 @@ module Browserctl
         destination = args.shift or abort "usage: browserctl state export <name> <destination>"
         require "browserctl/state"
         result = Browserctl::State.export(name, destination)
-        puts result.to_json
+        OutputFormat.current.emit(result)
       rescue Browserctl::State::Transport::TransportError, Browserctl::Error, ArgumentError => e
         warn "Error: #{e.message}"
         exit 1
@@ -142,7 +143,7 @@ module Browserctl
         source        = args.shift or abort "usage: browserctl state import <source> [--name NAME]"
         require "browserctl/state"
         result = Browserctl::State.import(source, name: name_override)
-        puts result.to_json
+        OutputFormat.current.emit(result)
       rescue Browserctl::State::Transport::TransportError,
              Browserctl::State::Bundle::BundleError,
              Browserctl::Error, ArgumentError => e

--- a/lib/browserctl/commands/trace.rb
+++ b/lib/browserctl/commands/trace.rb
@@ -5,6 +5,7 @@ require "time"
 require_relative "../logger"
 require_relative "../redactor"
 require_relative "../secret_resolver_registry"
+require_relative "output_format"
 
 module Browserctl
   module Commands
@@ -49,27 +50,55 @@ module Browserctl
         args = args.dup
         redact = !args.delete("--no-redact")
         session_filter = args.shift
+        redactor = resolve_redactor(redact, err)
+        records = collect_records(log_dir, session_filter, out)
+        emit_records(records, redactor, out) if records
+      end
 
-        if redact
-          redactor = build_redactor
-        else
-          redactor = nil
-          warn_no_redact(err)
-        end
+      def self.resolve_redactor(redact, err)
+        return nil unless redact
 
+        build_redactor
+      ensure
+        warn_no_redact(err) unless redact
+      end
+
+      def self.collect_records(log_dir, session_filter, out)
         records = load_records(log_dir)
         if records.empty?
-          out.puts "No log entries found in #{log_dir}"
-          return
+          emit_empty("No log entries found in #{log_dir}", out)
+          return nil
         end
 
         records = filter_session(records, session_filter)
         if records.empty?
-          out.puts "No entries match session=#{session_filter}"
-          return
+          emit_empty("No entries match session=#{session_filter}", out)
+          return nil
         end
 
-        render(records, out: out, redactor: redactor)
+        records
+      end
+
+      def self.emit_empty(message, out)
+        OutputFormat.current.emit({ records: [], message: message }, message, io: out)
+      end
+
+      def self.emit_records(records, redactor, out)
+        fmt = OutputFormat.current
+        if fmt.json?
+          fmt.emit({ records: records.map { |r| redact_record(r, redactor) } }, io: out)
+        elsif !fmt.silent?
+          render(records, out: out, redactor: redactor)
+        end
+      end
+
+      def self.redact_record(record, redactor)
+        return record unless redactor
+
+        line = JSON.generate(record)
+        JSON.parse(redactor.redact(line))
+      rescue JSON::ParserError
+        record
       end
 
       def self.build_redactor

--- a/lib/browserctl/commands/workflow.rb
+++ b/lib/browserctl/commands/workflow.rb
@@ -3,6 +3,7 @@
 require "fileutils"
 require "json"
 require_relative "cli_output"
+require_relative "output_format"
 require_relative "../recording"
 require_relative "../workflow/promoter"
 
@@ -44,11 +45,11 @@ module Browserctl
         result = Browserctl::Workflow::Promoter.promote(
           workflow: name, force: force, threshold: threshold, as_flow: as_flow
         )
-        puts JSON.generate(ok: true, **result)
+        OutputFormat.current.emit({ ok: true, **result })
       rescue Browserctl::Workflow::Promoter::IneligibleError => e
-        puts JSON.generate(
-          ok: false, error: "ineligible",
-          message: e.message, streak: e.streak, threshold: e.threshold
+        OutputFormat.current.emit(
+          { ok: false, error: "ineligible",
+            message: e.message, streak: e.streak, threshold: e.threshold }
         )
         exit 1
       rescue Browserctl::Workflow::Promoter::NotFoundError => e
@@ -68,7 +69,7 @@ module Browserctl
               end
         FileUtils.mkdir_p(File.dirname(out))
         Browserctl::Recording.generate_workflow(name, output_path: out, keep_log: true)
-        puts JSON.generate({ ok: true, name: name, path: out })
+        OutputFormat.current.emit({ ok: true, name: name, path: out })
       rescue StandardError => e
         abort "Error generating workflow: #{e.message}"
       end
@@ -111,12 +112,13 @@ module Browserctl
 
       def self.run_list(runner)
         list = runner.list_workflows
-        puts JSON.generate({ workflows: list.map { |w| { name: w[:name], desc: w[:desc] } } })
+        OutputFormat.current.emit({ workflows: list.map { |w| { name: w[:name], desc: w[:desc] } } })
       end
 
       def self.run_describe(runner, args)
         name = args.shift or abort "usage: browserctl workflow describe <name>"
-        puts JSON.pretty_generate(runner.describe_workflow(name))
+        payload = runner.describe_workflow(name)
+        OutputFormat.current.emit(payload, JSON.pretty_generate(payload))
       end
     end
   end

--- a/spec/unit/cli_output_spec.rb
+++ b/spec/unit/cli_output_spec.rb
@@ -6,6 +6,8 @@ require "browserctl/commands/cli_output"
 RSpec.describe Browserctl::Commands::CliOutput do
   let(:host) { Class.new { extend Browserctl::Commands::CliOutput } }
 
+  after { Browserctl::Commands::OutputFormat.reset! }
+
   describe "#exit_code_for" do
     it "returns 7 for AUTH_REQUIRED" do
       expect(host.exit_code_for(error: "x", code: "AUTH_REQUIRED")).to eq(7)
@@ -64,6 +66,40 @@ RSpec.describe Browserctl::Commands::CliOutput do
         "context" => { "selector" => ".x" },
         "suggested_action" => "Re-run snapshot."
       )
+    end
+
+    context "with the unified --output formatter" do
+      let(:res) { { ok: true, items: [1, 2, 3] } }
+
+      it "default (text) mode is byte-identical to the historical puts res.to_json" do
+        out, = capture_io { host.print_result(res) }
+        expect(out).to eq("#{res.to_json}\n")
+      end
+
+      it "json mode emits the same JSON" do
+        Browserctl::Commands::OutputFormat.current =
+          Browserctl::Commands::OutputFormat::Formatter.new("json")
+        out, = capture_io { host.print_result(res) }
+        expect(out).to eq("#{res.to_json}\n")
+      end
+
+      it "silent mode suppresses success stdout" do
+        Browserctl::Commands::OutputFormat.current =
+          Browserctl::Commands::OutputFormat::Formatter.new("silent")
+        out, = capture_io { host.print_result(res) }
+        expect(out).to eq("")
+      end
+
+      it "silent mode still emits the structured stderr line on errors" do
+        Browserctl::Commands::OutputFormat.current =
+          Browserctl::Commands::OutputFormat::Formatter.new("silent")
+        out, err = capture_io do
+          expect { host.print_result(error: "boom") }.to raise_error(SystemExit)
+        end
+        expect(out).to eq("")
+        expect(err).to include("Error: boom")
+        expect(err.split("\n").last).to start_with("{")
+      end
     end
 
     it "fills in suggested_action and GENERIC code when missing from the daemon response" do

--- a/spec/unit/output_format_dispatch_spec.rb
+++ b/spec/unit/output_format_dispatch_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require "spec_helper"
+require "browserctl/commands/output_format"
+require "browserctl/commands/page"
+require "browserctl/commands/cookie"
+require "browserctl/commands/storage"
+require "browserctl/commands/state"
+require "browserctl/commands/workflow"
+
+# Per-command verification that all three --output modes are honoured for
+# one command in each domain (page, cookie, storage, state, workflow).
+# Drives the command modules directly with a stubbed client/runner so we
+# don't need a live daemon.
+RSpec.describe "Browserctl::Commands::OutputFormat (per-domain dispatch)" do
+  before { Browserctl::Commands::OutputFormat.reset! }
+  after  { Browserctl::Commands::OutputFormat.reset! }
+
+  def with_format(mode)
+    Browserctl::Commands::OutputFormat.current =
+      Browserctl::Commands::OutputFormat::Formatter.new(mode)
+    yield
+  end
+
+  def capture_io
+    out = StringIO.new
+    err = StringIO.new
+    orig_out = $stdout
+    orig_err = $stderr
+    $stdout = out
+    $stderr = err
+    yield
+    [out.string, err.string]
+  ensure
+    $stdout = orig_out
+    $stderr = orig_err
+  end
+
+  shared_examples "honours --output across modes" do
+    it "text mode prints payload.to_json + newline (byte-identical to legacy)" do
+      with_format("text") do
+        out, = capture_io { invoke }
+        expect(out).to eq("#{payload.to_json}\n")
+      end
+    end
+
+    it "json mode prints payload as JSON" do
+      with_format("json") do
+        out, = capture_io { invoke }
+        expect(JSON.parse(out)).to eq(JSON.parse(payload.to_json))
+      end
+    end
+
+    it "silent mode prints nothing on stdout" do
+      with_format("silent") do
+        out, = capture_io { invoke }
+        expect(out).to eq("")
+      end
+    end
+  end
+
+  describe "page list" do
+    let(:payload) { { pages: %w[main popup] } }
+    let(:client) { instance_double(Browserctl::Client, page_list: payload) }
+
+    define_method(:invoke) { Browserctl::Commands::Page.run(client, ["list"]) }
+
+    include_examples "honours --output across modes"
+  end
+
+  describe "cookie list" do
+    let(:payload) { { cookies: [{ name: "sid", value: "x" }] } }
+    let(:client) { instance_double(Browserctl::Client, cookies: payload) }
+
+    define_method(:invoke) { Browserctl::Commands::Cookie.run(client, %w[list main]) }
+
+    include_examples "honours --output across modes"
+  end
+
+  describe "storage get" do
+    let(:payload) { { value: "hello" } }
+    let(:client) do
+      instance_double(Browserctl::Client).tap do |c|
+        allow(c).to receive(:storage_get).with("main", "k", store: "local").and_return(payload)
+      end
+    end
+
+    define_method(:invoke) { Browserctl::Commands::Storage.run(client, %w[get main k]) }
+
+    include_examples "honours --output across modes"
+  end
+
+  describe "state list" do
+    let(:payload) { { states: %w[a b] } }
+    let(:client) { instance_double(Browserctl::Client, state_list: payload) }
+
+    define_method(:invoke) { Browserctl::Commands::State.run(client, ["list"]) }
+
+    include_examples "honours --output across modes"
+  end
+
+  describe "workflow list" do
+    let(:listing) { [{ name: "login", desc: "Login flow" }] }
+    let(:payload) { { workflows: [{ name: "login", desc: "Login flow" }] } }
+    let(:runner) { instance_double(Browserctl::Runner, list_workflows: listing) }
+
+    define_method(:invoke) { Browserctl::Commands::Workflow.run(runner, ["list"]) }
+
+    include_examples "honours --output across modes"
+  end
+end

--- a/spec/unit/output_format_spec.rb
+++ b/spec/unit/output_format_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "stringio"
+require "browserctl/commands/output_format"
+
+RSpec.describe Browserctl::Commands::OutputFormat do
+  after { Browserctl::Commands::OutputFormat.reset! }
+
+  describe ".from" do
+    it "defaults to text when neither flag nor env is set" do
+      fmt = described_class.from(nil, {})
+      expect(fmt.mode).to eq("text")
+      expect(fmt).to be_text
+    end
+
+    it "honours the explicit flag over the env var" do
+      fmt = described_class.from("silent", { "BROWSERCTL_OUTPUT" => "json" })
+      expect(fmt.mode).to eq("silent")
+    end
+
+    it "falls back to BROWSERCTL_OUTPUT when no flag is given" do
+      fmt = described_class.from(nil, { "BROWSERCTL_OUTPUT" => "json" })
+      expect(fmt.mode).to eq("json")
+    end
+
+    it "is case-insensitive and trims whitespace" do
+      fmt = described_class.from(" JSON ", {})
+      expect(fmt.mode).to eq("json")
+    end
+
+    it "raises InvalidFormat for unknown values" do
+      expect { described_class.from("yaml", {}) }
+        .to raise_error(described_class::InvalidFormat, /yaml/)
+    end
+  end
+
+  describe ".extract!" do
+    it "removes --output and its value from args, returning the value" do
+      args = ["page", "list", "--output", "json", "--daemon", "d1"]
+      expect(described_class.extract!(args)).to eq("json")
+      expect(args).to eq(["page", "list", "--daemon", "d1"])
+    end
+
+    it "supports --output=value form" do
+      args = ["--output=silent", "page", "list"]
+      expect(described_class.extract!(args)).to eq("silent")
+      expect(args).to eq(%w[page list])
+    end
+
+    it "returns nil and leaves args untouched when flag is absent" do
+      args = %w[page list]
+      expect(described_class.extract!(args)).to be_nil
+      expect(args).to eq(%w[page list])
+    end
+
+    it "raises when the flag has no value" do
+      args = ["page", "--output"]
+      expect { described_class.extract!(args) }.to raise_error(described_class::InvalidFormat)
+    end
+  end
+
+  describe Browserctl::Commands::OutputFormat::Formatter do
+    let(:io) { StringIO.new }
+    let(:payload) { { ok: true, items: [1, 2, 3] } }
+
+    context "in text mode" do
+      let(:fmt) { described_class.new("text") }
+
+      it "prints the JSON payload when no text override is provided" do
+        fmt.emit(payload, io: io)
+        expect(io.string).to eq("#{payload.to_json}\n")
+      end
+
+      it "prints the text override when given" do
+        fmt.emit(payload, "human readable", io: io)
+        expect(io.string).to eq("human readable\n")
+      end
+
+      it "prints the block result when a block is given" do
+        fmt.emit(payload, io: io) { "from block" }
+        expect(io.string).to eq("from block\n")
+      end
+    end
+
+    context "in json mode" do
+      let(:fmt) { described_class.new("json") }
+
+      it "prints the payload as JSON regardless of any text override" do
+        fmt.emit(payload, "human readable", io: io)
+        expect(io.string).to eq("#{payload.to_json}\n")
+      end
+    end
+
+    context "in silent mode" do
+      let(:fmt) { described_class.new("silent") }
+
+      it "prints nothing on success" do
+        fmt.emit(payload, "human readable", io: io)
+        expect(io.string).to eq("")
+      end
+
+      it "does not evaluate the text block" do
+        called = false
+        fmt.emit(payload, io: io) do
+          called = true
+          "x"
+        end
+        expect(called).to be(false)
+      end
+    end
+  end
+
+  describe ".install!" do
+    it "extracts the flag from args and updates the current formatter" do
+      args = ["page", "list", "--output", "json"]
+      fmt = described_class.install!(args, {})
+      expect(fmt).to be_json
+      expect(described_class.current).to be(fmt)
+      expect(args).to eq(%w[page list])
+    end
+
+    it "uses the env var when no explicit flag is provided" do
+      args = %w[page list]
+      fmt = described_class.install!(args, { "BROWSERCTL_OUTPUT" => "silent" })
+      expect(fmt).to be_silent
+    end
+  end
+end


### PR DESCRIPTION
PR 5 of the [v0.13 lean plan](docs/plans/v0.13-lean.md#pr-5--feat-unified---output-jsontextsilent-on-every-cli-command).

PR 3 (noun-verb CLI) has already merged into `main` (#162) so this stacks against `main` directly. Rebased on top of the current `main` after PR 3 + PR 2 (session removal) landed.

## Summary

- Adds `Browserctl::Commands::OutputFormat` — a single resolution path for `--output {json,text,silent}` (with `BROWSERCTL_OUTPUT` env var). Resolution order: explicit flag -> env -> `text` (default).
- `--output` is now a reserved global flag on every command, parsed once in `bin/browserctl` before per-command parsers run.
- `text` output is byte-identical to today's output for every command we touched. The legacy `print_result` was already `puts res.to_json` for most commands; the `text` branch preserves that exact byte stream. Prose-output commands (`init`, `pause`, `devtools`, `daemon start`, `migrate`, `trace`) keep their text and gain a structured `json` payload.
- `silent` suppresses stdout entirely. The structured stderr error payload still ships on failure — errors are the result, not cosmetic output.
- Errors continue to honour the v0.12 typed-error contract; no duplication.

## Files

- New: `lib/browserctl/commands/output_format.rb` (Formatter + parse/install helpers).
- New specs:
  - `spec/unit/output_format_spec.rb` — module unit tests.
  - `spec/unit/output_format_dispatch_spec.rb` — per-domain coverage of all three modes (page, cookie, storage, state, workflow).
- Edited: every file under `lib/browserctl/commands/*.rb` plus `bin/browserctl` to route success output through the formatter.
- Docs:
  - `docs/reference/commands.md` — new "Global flags" + "Output formats" section at the top.
  - `docs/guides/agent-integration.md` — agent recipe using `BROWSERCTL_OUTPUT=json`, including a Python wrapper.

## Test plan

- [x] `bundle exec rspec` — 838 examples, 0 failures, 50 pending (chrome-needed integration specs).
- [x] `bundle exec rubocop` — clean.
- [x] Byte-identical `text` mode verified by:
  - The dispatch spec asserting `out == payload.to_json + "\n"` for `page list`, `cookie list`, `storage get`, `state list`, `workflow list`.
  - `cli_output_spec.rb` confirming `print_result` default text matches the legacy byte stream.
- [ ] Manual smoke: `BROWSERCTL_OUTPUT=json browserctl page list` returns valid JSON; `--output silent` produces no stdout.

## Notes

- `pause`, `devtools`, and `daemon start` previously printed multi-line prose. In `text` mode the bytes are unchanged. In `json` mode they emit a structured payload.
- `trace` and `migrate` have inherently human-shaped output; in `json` mode they now serialize their records / migration plan as structured payloads.