### PR TITLE
refactor: value object for State.save

### DIFF
--- a/lib/browserctl/server/handlers/state.rb
+++ b/lib/browserctl/server/handlers/state.rb
@@ -15,21 +15,23 @@ module Browserctl
           first_session = @global_mutex.synchronize { @pages.values.first }
           return { error: "no open pages — open a page before saving state" } unless first_session
 
-          payload, captured_origins = capture_state_payload
-          manifest = Browserctl::State.save(
-            req[:name],
-            payload: payload,
+          captured, captured_origins = capture_state_payload
+          payload = Browserctl::State::Payload.build(
+            cookies: captured[:cookies],
+            local_storage: captured[:local_storage],
+            session_storage: captured[:session_storage],
             origins: req[:origins] || captured_origins,
             flow: req[:flow],
             flow_version: req[:flow_version],
             passphrase: req[:passphrase]
           )
+          manifest = Browserctl::State.save(req[:name], payload)
 
           {
             ok: true,
             path: Browserctl::State.path(req[:name]),
             origins: manifest[:origins],
-            cookies: payload[:cookies].length,
+            cookies: payload.cookies.length,
             encrypted: manifest[:encrypted]
           }
         rescue Browserctl::Error, ArgumentError => e

--- a/lib/browserctl/state.rb
+++ b/lib/browserctl/state.rb
@@ -42,6 +42,41 @@ module Browserctl
     EXTENSION = ".bctl"
     MANIFEST_VERSION = 1
 
+    # Value object bundling everything needed to persist a state bundle. The
+    # browser-side data lives in `cookies`, `local_storage`, and
+    # `session_storage`; the manifest extras live in `origins`, `flow`, and
+    # `flow_version`; `passphrase` flips the bundle into an encrypted variant.
+    Payload = Data.define(
+      :cookies,
+      :local_storage,
+      :session_storage,
+      :origins,
+      :flow,
+      :flow_version,
+      :passphrase
+    ) do
+      def self.build(cookies: [], local_storage: {}, session_storage: {}, # rubocop:disable Metrics/ParameterLists
+                     origins: nil, flow: nil, flow_version: nil, passphrase: nil)
+        new(
+          cookies: cookies,
+          local_storage: local_storage,
+          session_storage: session_storage,
+          origins: origins,
+          flow: flow,
+          flow_version: flow_version,
+          passphrase: passphrase
+        )
+      end
+
+      def to_bundle_payload
+        {
+          cookies: cookies,
+          local_storage: local_storage,
+          session_storage: session_storage
+        }
+      end
+    end
+
     def self.path(name) = File.join(BASE_DIR, "#{name}#{EXTENSION}")
     def self.exist?(name) = File.exist?(path(name))
 
@@ -51,22 +86,24 @@ module Browserctl
       raise ArgumentError, "invalid state name #{name.inspect} — use letters, digits, _ or - (max 64 chars)"
     end
 
-    # Persist a bundle. `payload` is { cookies:, local_storage:, session_storage: }.
-    # `manifest_extras` may carry origins (override), flow, flow_version.
-    def self.save(name, payload:, origins: nil, flow: nil, flow_version: nil, passphrase: nil) # rubocop:disable Metrics/ParameterLists
+    # Persist a bundle. `payload` is a `State::Payload` value object carrying
+    # cookies, local/session storage, and the manifest extras (origins, flow,
+    # flow_version, passphrase).
+    def self.save(name, payload)
       validate_name!(name)
       FileUtils.mkdir_p(BASE_DIR)
 
+      bundle_payload = payload.to_bundle_payload
       manifest = build_manifest(
         name: name,
-        origins: origins || derive_origins(payload),
-        flow: flow,
-        flow_version: flow_version,
-        cookies: payload[:cookies] || payload["cookies"] || [],
-        encrypted: !passphrase.nil?
+        origins: payload.origins || derive_origins(bundle_payload),
+        flow: payload.flow,
+        flow_version: payload.flow_version,
+        cookies: payload.cookies || [],
+        encrypted: !payload.passphrase.nil?
       )
 
-      blob = Bundle.encode(manifest: manifest, payload: payload, passphrase: passphrase)
+      blob = Bundle.encode(manifest: manifest, payload: bundle_payload, passphrase: payload.passphrase)
       File.open(path(name), "wb", 0o600) { |f| f.write(blob) }
       manifest
     end

--- a/spec/integration/state_rotate_e2e_spec.rb
+++ b/spec/integration/state_rotate_e2e_spec.rb
@@ -69,9 +69,13 @@ RSpec.describe "v0.10 state rotate end-to-end", :integration do
     }
     Browserctl::State.save(
       name,
-      payload: payload,
-      origins: ["http://#{host}:#{port}"],
-      flow: flow
+      Browserctl::State::Payload.build(
+        cookies: payload[:cookies],
+        local_storage: payload[:local_storage],
+        session_storage: payload[:session_storage],
+        origins: ["http://#{host}:#{port}"],
+        flow: flow
+      )
     )
   end
 

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -17,8 +17,13 @@ RSpec.describe Browserctl::State do
   end
   let(:local_storage)   { { "https://example.com" => { "theme" => "dark" } } }
   let(:session_storage) { {} }
-  let(:payload) do
-    { cookies: cookies, local_storage: local_storage, session_storage: session_storage }
+  def build_payload(**overrides)
+    Browserctl::State::Payload.build(
+      cookies: cookies,
+      local_storage: local_storage,
+      session_storage: session_storage,
+      **overrides
+    )
   end
 
   def future_ts = (Time.now + 86_400).to_i
@@ -36,7 +41,7 @@ RSpec.describe Browserctl::State do
 
   describe ".save / .load" do
     it "round-trips a plaintext bundle and writes to disk with 0600" do
-      manifest = described_class.save("github", payload: payload, flow: "github_login")
+      manifest = described_class.save("github", build_payload(flow: "github_login"))
       expect(manifest[:flow]).to eq("github_login")
       expect(manifest[:origins]).to include("https://example.com")
       expect(manifest[:expires_at]).not_to be_nil
@@ -52,7 +57,7 @@ RSpec.describe Browserctl::State do
     end
 
     it "encrypts when a passphrase is provided and refuses to load without it" do
-      described_class.save("github", payload: payload, passphrase: "hunter2")
+      described_class.save("github", build_payload(passphrase: "hunter2"))
 
       expect { described_class.load("github") }
         .to raise_error(Browserctl::State::Bundle::PassphraseError)
@@ -68,16 +73,15 @@ RSpec.describe Browserctl::State do
 
     it "honours an explicit --origins override" do
       manifest = described_class.save("multi",
-                                      payload: payload,
-                                      origins: %w[https://a.test https://b.test])
+                                      build_payload(origins: %w[https://a.test https://b.test]))
       expect(manifest[:origins]).to eq(%w[https://a.test https://b.test])
     end
   end
 
   describe ".info / .all" do
     before do
-      described_class.save("github", payload: payload, flow: "github_login")
-      described_class.save("private", payload: payload, passphrase: "p")
+      described_class.save("github", build_payload(flow: "github_login"))
+      described_class.save("private", build_payload(passphrase: "p"))
     end
 
     it "info returns manifest plus path and size, without needing passphrase" do
@@ -101,7 +105,7 @@ RSpec.describe Browserctl::State do
 
   describe ".export / .import via file transport" do
     it "round-trips a bundle through a file destination" do
-      described_class.save("github", payload: payload, flow: "github_login")
+      described_class.save("github", build_payload(flow: "github_login"))
 
       Dir.mktmpdir do |tmp|
         dest = File.join(tmp, "github.bctl")
@@ -119,7 +123,7 @@ RSpec.describe Browserctl::State do
     end
 
     it "honours --name on import" do
-      described_class.save("github", payload: payload)
+      described_class.save("github", build_payload)
       Dir.mktmpdir do |tmp|
         dest = File.join(tmp, "github.bctl")
         described_class.export("github", dest)
@@ -145,7 +149,7 @@ RSpec.describe Browserctl::State do
 
   describe ".delete" do
     it "removes the file, no-ops when absent" do
-      described_class.save("github", payload: payload)
+      described_class.save("github", build_payload)
       expect(described_class.exist?("github")).to be(true)
 
       described_class.delete("github")


### PR DESCRIPTION
## Summary

- Replaces `State.save`'s 5+ keyword-arg surface with a single `State::Payload` value object built via `Data.define`. New signature: `State.save(name, payload)`.
- Updates all call sites in the same PR (server handler + state specs + state rotate integration spec). No shim retained.

## Stability call

`Browserctl::State.save` is internal Ruby — it falls under the **Extension** zone per `docs/reference/api-stability.md` (which lists `Browserctl::Client`, `PageProxy`, CLI flags, and wire commands as Stable/Fixed but not arbitrary internal Ruby APIs like `State.save`). No `BREAKING CHANGE:` footer; this is part of the v0.13 PR 9 internal refactor sequence.

## Test plan

- [x] `bundle exec rspec spec/unit` — 717 examples, 0 failures
- [x] `bundle exec rspec spec/unit/state_spec.rb` — 14/14
- [x] `bundle exec rspec spec/integration/state_rotate_e2e_spec.rb` — pending without local Chromium (expected)
- [x] `bundle exec rubocop` — 214 files, no offenses