### PR TITLE
refactor: extract EncryptionService from State::Bundle

### DIFF
--- a/lib/browserctl/encryption_service.rb
+++ b/lib/browserctl/encryption_service.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "openssl"
+require "securerandom"
+
+module Browserctl
+  # Cryptographic primitives for browserctl-managed payloads.
+  #
+  # Raised when decryption fails (tampered ciphertext or wrong key). Callers
+  # should catch this rather than `OpenSSL::Cipher::CipherError` so they
+  # don't have to take a direct dependency on the underlying cipher library.
+  #
+  # Owns AES-256-GCM cipher setup and PBKDF2 key derivation so callers like
+  # `State::Bundle` don't reach into `OpenSSL::Cipher` directly. The contract
+  # is intentionally narrow:
+  #
+  #   * `derive_keys(passphrase, salt)` returns a `[enc_key, hmac_key]` pair
+  #     derived via PBKDF2-HMAC-SHA256 with `PBKDF2_ITERS` iterations and a
+  #     64-byte output split in half. The first half is the AES-256-GCM key,
+  #     the second is the HMAC-SHA-256 key for the bundle footer.
+  #   * `encrypt(plaintext, key)` returns `nonce || ciphertext || tag`.
+  #   * `decrypt(blob, key)` reverses it; raises `OpenSSL::Cipher::CipherError`
+  #     on tampered blobs / wrong key.
+  #   * `random_salt` / `random_nonce` are exposed so callers can keep bundle
+  #     wire-format assembly in one place without re-deriving sizes.
+  #
+  # The constants here are duplicated in `State::Bundle` only as named
+  # references to the wire format positions; the source of truth lives here.
+  module EncryptionService
+    class DecryptionError < StandardError; end
+
+    SALT_SIZE    = 16
+    NONCE_SIZE   = 12
+    TAG_SIZE     = 16
+    KEY_SIZE     = 32
+    PBKDF2_ITERS = 200_000
+    DIGEST       = "SHA256"
+    CIPHER       = "aes-256-gcm"
+
+    module_function
+
+    # Returns `[enc_key, hmac_key]`, each `KEY_SIZE` bytes.
+    def derive_keys(passphrase, salt)
+      material = OpenSSL::PKCS5.pbkdf2_hmac(passphrase.to_s, salt, PBKDF2_ITERS, KEY_SIZE * 2, DIGEST)
+      [material.byteslice(0, KEY_SIZE), material.byteslice(KEY_SIZE, KEY_SIZE)]
+    end
+
+    # AES-256-GCM. Returns `nonce || ciphertext || tag`.
+    def encrypt(plaintext, key)
+      cipher = OpenSSL::Cipher.new(CIPHER)
+      cipher.encrypt
+      cipher.key = key
+      nonce = SecureRandom.bytes(NONCE_SIZE)
+      cipher.iv = nonce
+      ct = cipher.update(plaintext) + cipher.final
+      nonce + ct + cipher.auth_tag
+    end
+
+    # Inverse of `encrypt`. Raises `DecryptionError` on tampered ciphertext
+    # or wrong key so callers don't need to reach into `OpenSSL::Cipher`.
+    def decrypt(blob, key)
+      nonce      = blob.byteslice(0, NONCE_SIZE)
+      tag        = blob.byteslice(-TAG_SIZE, TAG_SIZE)
+      ciphertext = blob.byteslice(NONCE_SIZE, blob.bytesize - NONCE_SIZE - TAG_SIZE)
+
+      cipher = OpenSSL::Cipher.new(CIPHER)
+      cipher.decrypt
+      cipher.key      = key
+      cipher.iv       = nonce
+      cipher.auth_tag = tag
+      cipher.update(ciphertext) + cipher.final
+    rescue OpenSSL::Cipher::CipherError => e
+      raise DecryptionError, e.message
+    end
+
+    def random_salt
+      SecureRandom.bytes(SALT_SIZE)
+    end
+
+    def random_nonce
+      SecureRandom.bytes(NONCE_SIZE)
+    end
+  end
+end

--- a/lib/browserctl/state/bundle.rb
+++ b/lib/browserctl/state/bundle.rb
@@ -2,9 +2,9 @@
 
 require "json"
 require "openssl"
-require "securerandom"
 require_relative "../errors"
 require_relative "../error/codes"
+require_relative "../encryption_service"
 
 module Browserctl
   module State
@@ -37,6 +37,11 @@ module Browserctl
     #   first 32 bytes are the AES-256-GCM encryption key, last 32 bytes are
     #   the HMAC-SHA-256 key.
     #
+    # AES-256-GCM cipher setup and PBKDF2 key derivation are delegated to
+    # `Browserctl::EncryptionService` so this class stays focused on the
+    # bundle wire format. The service translates `OpenSSL::Cipher` errors
+    # into `EncryptionService::DecryptionError`, which we map to
+    # `PassphraseError` for the public API.
     class Bundle
       MAGIC          = "BCTL\x00".b.freeze
       VERSION        = 1
@@ -50,10 +55,12 @@ module Browserctl
       HEADER_SIZE    = MAGIC.bytesize + 3 # version + flags + reserved
       LEN_SIZE       = 4
       FOOTER_SIZE    = 32
-      SALT_SIZE      = 16
-      NONCE_SIZE     = 12
-      TAG_SIZE       = 16
-      PBKDF2_ITERS   = 200_000
+      # Cryptographic primitive sizes are sourced from EncryptionService so
+      # there is exactly one source of truth for cipher parameters.
+      SALT_SIZE      = Browserctl::EncryptionService::SALT_SIZE
+      NONCE_SIZE     = Browserctl::EncryptionService::NONCE_SIZE
+      TAG_SIZE       = Browserctl::EncryptionService::TAG_SIZE
+      PBKDF2_ITERS   = Browserctl::EncryptionService::PBKDF2_ITERS
 
       class BundleError      < Browserctl::Error; def self.default_code = "bundle_error"      end
       class TamperError      < BundleError;       def self.default_code = "bundle_tampered"   end
@@ -74,9 +81,9 @@ module Browserctl
         hmac_key       = nil
 
         if passphrase
-          salt = SecureRandom.bytes(SALT_SIZE)
-          enc_key, hmac_key = derive_keys(passphrase, salt)
-          payload_bytes = salt + aes_gcm_encrypt(payload_json, enc_key)
+          salt = EncryptionService.random_salt
+          enc_key, hmac_key = EncryptionService.derive_keys(passphrase, salt)
+          payload_bytes = salt + EncryptionService.encrypt(payload_json, enc_key)
           flags |= FLAG_ENCRYPTED
         else
           payload_bytes = payload_json
@@ -204,7 +211,7 @@ module Browserctl
           # We need the HMAC key, which depends on the salt embedded in the
           # payload. Pull the salt from the payload bytes inside `body`.
           salt = extract_salt!(body)
-          _, hmac_key = derive_keys(passphrase, salt)
+          _, hmac_key = EncryptionService.derive_keys(passphrase, salt)
           expected = OpenSSL::HMAC.digest("SHA256", hmac_key, body)
           raise PassphraseError, "wrong passphrase or tampered bundle" unless secure_eq?(footer, expected)
         else
@@ -227,47 +234,16 @@ module Browserctl
         if encrypted
           salt       = bytes.byteslice(0, SALT_SIZE)
           ciphertext = bytes.byteslice(SALT_SIZE, bytes.bytesize - SALT_SIZE)
-          enc_key, = derive_keys(passphrase, salt)
-          plaintext  = aes_gcm_decrypt(ciphertext, enc_key)
+          enc_key, = EncryptionService.derive_keys(passphrase, salt)
+          plaintext  = EncryptionService.decrypt(ciphertext, enc_key)
           JSON.parse(plaintext)
         else
           JSON.parse(bytes)
         end
-      rescue OpenSSL::Cipher::CipherError
+      rescue EncryptionService::DecryptionError
         raise PassphraseError, "wrong passphrase — payload could not be decrypted"
       end
       private_class_method :decode_payload
-
-      def self.derive_keys(passphrase, salt)
-        material = OpenSSL::PKCS5.pbkdf2_hmac(passphrase.to_s, salt, PBKDF2_ITERS, 64, "SHA256")
-        [material.byteslice(0, 32), material.byteslice(32, 32)]
-      end
-      private_class_method :derive_keys
-
-      def self.aes_gcm_encrypt(plaintext, key)
-        cipher = OpenSSL::Cipher.new("aes-256-gcm")
-        cipher.encrypt
-        cipher.key = key
-        nonce = SecureRandom.bytes(NONCE_SIZE)
-        cipher.iv = nonce
-        ct = cipher.update(plaintext) + cipher.final
-        nonce + ct + cipher.auth_tag
-      end
-      private_class_method :aes_gcm_encrypt
-
-      def self.aes_gcm_decrypt(blob, key)
-        nonce      = blob.byteslice(0, NONCE_SIZE)
-        tag        = blob.byteslice(-TAG_SIZE, TAG_SIZE)
-        ciphertext = blob.byteslice(NONCE_SIZE, blob.bytesize - NONCE_SIZE - TAG_SIZE)
-
-        cipher = OpenSSL::Cipher.new("aes-256-gcm")
-        cipher.decrypt
-        cipher.key      = key
-        cipher.iv       = nonce
-        cipher.auth_tag = tag
-        cipher.update(ciphertext) + cipher.final
-      end
-      private_class_method :aes_gcm_decrypt
 
       def self.secure_eq?(actual, expected)
         return false if actual.bytesize != expected.bytesize

--- a/spec/unit/encryption_service_spec.rb
+++ b/spec/unit/encryption_service_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/encryption_service"
+
+RSpec.describe Browserctl::EncryptionService do
+  let(:passphrase) { "correct horse battery staple" }
+  let(:salt) { described_class.random_salt }
+  let(:enc_key) { described_class.derive_keys(passphrase, salt).first }
+
+  describe ".derive_keys" do
+    it "returns an [enc_key, hmac_key] pair of KEY_SIZE bytes each" do
+      enc, hmac = described_class.derive_keys(passphrase, salt)
+      expect(enc.bytesize).to eq(described_class::KEY_SIZE)
+      expect(hmac.bytesize).to eq(described_class::KEY_SIZE)
+      expect(enc).not_to eq(hmac)
+    end
+
+    it "is deterministic for the same passphrase and salt" do
+      keys_a = described_class.derive_keys(passphrase, salt)
+      keys_b = described_class.derive_keys(passphrase, salt)
+      expect(keys_a).to eq(keys_b)
+    end
+
+    it "diverges when the salt changes" do
+      other = described_class.random_salt
+      expect(described_class.derive_keys(passphrase, salt))
+        .not_to eq(described_class.derive_keys(passphrase, other))
+    end
+
+    it "diverges when the passphrase changes" do
+      expect(described_class.derive_keys(passphrase, salt))
+        .not_to eq(described_class.derive_keys("different", salt))
+    end
+
+    it "coerces non-string passphrases via to_s" do
+      expect { described_class.derive_keys(:symbol_passphrase, salt) }.not_to raise_error
+    end
+  end
+
+  describe ".encrypt / .decrypt" do
+    let(:plaintext) { "hello, browserctl" }
+
+    it "round-trips plaintext" do
+      blob = described_class.encrypt(plaintext, enc_key)
+      expect(described_class.decrypt(blob, enc_key)).to eq(plaintext)
+    end
+
+    it "produces a fresh nonce each call (so output differs)" do
+      a = described_class.encrypt(plaintext, enc_key)
+      b = described_class.encrypt(plaintext, enc_key)
+      expect(a).not_to eq(b)
+    end
+
+    it "lays out the ciphertext as nonce || ciphertext || tag" do
+      blob = described_class.encrypt(plaintext, enc_key)
+      expected_min = described_class::NONCE_SIZE + described_class::TAG_SIZE
+      expect(blob.bytesize).to be > expected_min
+    end
+
+    it "raises DecryptionError on a wrong key" do
+      blob = described_class.encrypt(plaintext, enc_key)
+      wrong_key = described_class.derive_keys("wrong", salt).first
+      expect { described_class.decrypt(blob, wrong_key) }
+        .to raise_error(described_class::DecryptionError)
+    end
+
+    it "raises DecryptionError when the ciphertext is tampered" do
+      blob = described_class.encrypt(plaintext, enc_key)
+      tampered = blob.dup
+      # Flip a byte in the ciphertext region (after the nonce, before the tag).
+      idx = described_class::NONCE_SIZE
+      tampered.setbyte(idx, tampered.getbyte(idx) ^ 0x01)
+      expect { described_class.decrypt(tampered, enc_key) }
+        .to raise_error(described_class::DecryptionError)
+    end
+
+    it "raises DecryptionError when the auth tag is tampered" do
+      blob = described_class.encrypt(plaintext, enc_key)
+      tampered = blob.dup
+      tampered.setbyte(-1, tampered.getbyte(-1) ^ 0xFF)
+      expect { described_class.decrypt(tampered, enc_key) }
+        .to raise_error(described_class::DecryptionError)
+    end
+  end
+
+  describe ".random_salt / .random_nonce" do
+    it "returns SALT_SIZE bytes" do
+      expect(described_class.random_salt.bytesize).to eq(described_class::SALT_SIZE)
+    end
+
+    it "returns NONCE_SIZE bytes" do
+      expect(described_class.random_nonce.bytesize).to eq(described_class::NONCE_SIZE)
+    end
+
+    it "produces fresh values on each call" do
+      expect(described_class.random_salt).not_to eq(described_class.random_salt)
+      expect(described_class.random_nonce).not_to eq(described_class.random_nonce)
+    end
+  end
+
+  describe "constants" do
+    it "exposes the bundle-wire-format sizes" do
+      expect(described_class::SALT_SIZE).to eq(16)
+      expect(described_class::NONCE_SIZE).to eq(12)
+      expect(described_class::TAG_SIZE).to eq(16)
+      expect(described_class::KEY_SIZE).to eq(32)
+      expect(described_class::PBKDF2_ITERS).to eq(200_000)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New `lib/browserctl/encryption_service.rb` owns AES-256-GCM cipher setup and PBKDF2 key derivation, exposing `derive_keys`, `encrypt`, `decrypt`, `random_salt`, and `random_nonce`.
- `State::Bundle` delegates encrypt/decrypt to the service and no longer references `OpenSSL::Cipher` (or `SecureRandom`) directly. Cipher errors surface as `EncryptionService::DecryptionError`, which the bundle decoder maps to its existing `PassphraseError`.
- Wire-format crypto sizes (`SALT_SIZE`, `NONCE_SIZE`, `TAG_SIZE`, `PBKDF2_ITERS`) are sourced from the service so there is one source of truth.

Part of v0.13 lean track (PR 11).

## Test plan

- [x] `bundle exec rspec` (896 examples, 0 failures, 63 chromium-pending)
- [x] `bundle exec rubocop` (229 files, no offenses)
- [x] New `spec/unit/encryption_service_spec.rb` covers key derivation determinism, round-trip encryption, tampered ciphertext / auth tag, wrong-key decryption, and constant exposure (15 examples).
- [x] Existing `spec/unit/state/bundle_spec.rb` still passes unchanged via the new service (45 examples).
- [x] Confirmed `State::Bundle` no longer mentions `OpenSSL::Cipher` outside of a docstring.