### PR TITLE
refactor: split Recording into focused objects

### DIFF
--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -1,76 +1,46 @@
 # frozen_string_literal: true
 
-require "json"
-require "date"
-require "time"
-require "fileutils"
 require "tmpdir"
-require "uri"
 require_relative "errors"
 require_relative "error/codes"
 
 module Browserctl
-  class Recording # rubocop:disable Metrics/ClassLength
+  # Captures a sequence of daemon commands as a JSONL log and renders it
+  # back out as a Ruby workflow file. This class is the public facade;
+  # the focused responsibilities live under `Browserctl::Recording::*`:
+  #
+  # - `Recording::State`            — singleton over the on-disk marker.
+  # - `Recording::Redactor`         — secret-aware redaction.
+  # - `Recording::LogWriter`        — log file I/O and JSONL formatting.
+  # - `Recording::WorkflowRenderer` — log-to-Ruby workflow translation.
+  class Recording
     RECORDINGS_DIR = File.join(Dir.tmpdir, "browserctl-recordings")
     STATE_FILE     = File.expand_path("~/.browserctl/active_recording")
 
     # Recording-log format version, written into the `_meta` header and
-    # validated when generate_workflow loads a recording. Distinct from
-    # LOG_FORMAT below — that string ("v0.11") tracks the human-readable
-    # log shape; this integer is the machine-readable schema gate per the
-    # WS-1 format-version convention. See docs/reference/format-versions.md.
+    # validated when generate_workflow loads a recording. See
+    # docs/reference/format-versions.md.
     RECORDING_FORMAT_VERSION = 1
     SUPPORTED_FORMAT_VERSIONS = [RECORDING_FORMAT_VERSION].freeze
-
-    RECORDABLE = %w[page_open navigate fill click screenshot evaluate].freeze
-
-    SENSITIVE_PARAM_PATTERN = /\A(token|key|secret|auth|code|access_token|api_key|client_secret|state)\z/ix
-
-    # Selector tokens that signal a fill is targeting a secret-shaped field.
-    # The captured group (or matched substring) is used as the inferred field
-    # name; that name later drives the generated `secret_ref:` placeholder.
-    SECRET_FIELD_PATTERN = /\b(password|passwd|api[_-]?key|token|secret|otp|pin|client[_-]?secret|access[_-]?token)\b/i
-
-    # Conservative thresholds for inferring an explicit wait between recorded
-    # steps. Gaps shorter than the threshold come from natural input cadence;
-    # gaps above it usually mean the page actually had work to do.
-    WAIT_THRESHOLD_SECONDS = 1.5
-    WAIT_PADDING_SECONDS   = 5
-    WAIT_FLOOR_SECONDS     = 5
 
     # Bumped when the recording log shape changes in a way that older
     # tooling (workflow generate, replay) cannot read.
     LOG_FORMAT = "v0.11"
 
+    RECORDABLE = %w[page_open navigate fill click screenshot evaluate].freeze
+
     def self.start(name)
-      FileUtils.mkdir_p(RECORDINGS_DIR, mode: 0o700)
-      FileUtils.mkdir_p(File.dirname(STATE_FILE))
-      File.write(STATE_FILE, name)
-      FileUtils.rm_f(log_path(name))
-      FileUtils.touch(log_path(name))
-      File.chmod(0o600, log_path(name))
-      File.open(log_path(name), "a") do |f|
-        f.puts JSON.generate(
-          cmd: "_meta",
-          format_version: RECORDING_FORMAT_VERSION,
-          log_format: LOG_FORMAT,
-          recording: name,
-          started_at: Time.now.utc.iso8601
-        )
-      end
+      LogWriter.init_log(name)
+      State.write(name)
       name
     end
 
     def self.stop
-      name = active
-      raise Browserctl::Error, "no active recording — run: browserctl recording start <name>" unless name
-
-      File.unlink(STATE_FILE)
-      name
+      State.clear!
     end
 
     def self.active
-      File.exist?(STATE_FILE) ? File.read(STATE_FILE).strip : nil
+      State.active
     end
 
     def self.append(cmd, response: nil, **attrs)
@@ -87,24 +57,22 @@ module Browserctl
       entry = { cmd: cmd.to_s, ts: now }.merge(attrs.transform_keys(&:to_s))
       entry.merge!(replay_metadata(response)) if response
 
-      File.open(log_path(name), "a") do |f|
-        f.puts JSON.generate(entry)
-      end
+      LogWriter.append_entry(name, entry)
     end
 
     def self.generate_workflow(name, output_path: nil, keep_log: false)
-      log = log_path(name)
+      log = LogWriter.log_path(name)
       raise Browserctl::Error, "no recording found for '#{name}'" unless File.exist?(log)
 
-      raw   = File.readlines(log).map { |l| JSON.parse(l, symbolize_names: true) }
-      verify_format_version!(raw, path: log)
+      raw   = LogWriter.read_entries(name)
+      LogWriter.verify_format_version!(raw, path: log)
       lines = raw.reject { |l| l[:cmd] == "_meta" }
-      ruby  = build_workflow_ruby(name, lines)
+      ruby  = WorkflowRenderer.render(name, lines)
       File.write(output_path, ruby) if output_path
       warn_about_ref_interactions(lines)
       ruby
     ensure
-      FileUtils.rm_f(log) if log && !keep_log
+      LogWriter.delete_log(name) unless keep_log
     end
 
     def self.warn_about_ref_interactions(lines)
@@ -118,44 +86,19 @@ module Browserctl
     class << self
       private
 
-      # Raises Browserctl::ProtocolMismatch when the recording log's _meta
-      # header is missing or declares a format_version this build does not
-      # support. Mirrors Browserctl::State::Bundle.verify_format_version!.
-      def verify_format_version!(raw_lines, path: nil)
-        meta = raw_lines.first
-        version = meta && meta[:cmd] == "_meta" ? meta[:format_version] : nil
-        return if version && SUPPORTED_FORMAT_VERSIONS.include?(version)
-
-        where = path ? " at #{path}" : ""
-        msg = if version.nil?
-                "recording log#{where} is missing format_version " \
-                  "(supported: #{SUPPORTED_FORMAT_VERSIONS.inspect})"
-              else
-                "recording log#{where} declares format_version=#{version.inspect}, " \
-                  "this build supports #{SUPPORTED_FORMAT_VERSIONS.inspect}"
-              end
-        raise Browserctl::ProtocolMismatch.new(msg, code: Browserctl::Error::Codes::PROTOCOL_MISMATCH)
-      end
-
-      def log_path(name)
-        File.join(RECORDINGS_DIR, "#{name}.jsonl")
+      def now
+        Time.now.utc.to_f
       end
 
       def record_ref_interaction(recording_name, cmd, attrs, response)
         entry = { cmd: "_ref_interaction", ts: now, action: cmd, ref: attrs[:ref], name: attrs[:name] }
         entry.merge!(replay_metadata(response)) if response
-        File.open(log_path(recording_name), "a") do |f|
-          f.puts JSON.generate(entry)
-        end
+        LogWriter.append_entry(recording_name, entry)
       end
 
       # Pulls the replay-relevant fields out of a daemon response. Each
       # is optional — older daemons or non-resolving commands may omit
       # any of them.
-      def now
-        Time.now.utc.to_f
-      end
-
       def replay_metadata(response)
         meta = {}
         meta[:ref]                  = response[:ref]                  if response[:ref]
@@ -166,228 +109,24 @@ module Browserctl
         meta.transform_keys(&:to_s)
       end
 
-      def build_workflow_ruby(name, commands)
-        steps   = annotated_steps(commands).join("\n\n")
-        secrets = commands.map { |c| c[:secret_field] }.compact.uniq
-        header  = secret_header(secrets)
-        <<~RUBY
-          # frozen_string_literal: true
-          # format_version: #{Browserctl::WORKFLOW_FORMAT_VERSION}
-          #{header}
-          Browserctl.workflow #{name.inspect} do
-            desc "Recorded on #{Date.today}"
-          #{secrets.map { |f| "  param :secret_#{f}, secret: true" }.join("\n")}
-          #{steps.gsub(/^/, '  ')}
-          end
-        RUBY
-      end
-
-      # Walks the recorded events and emits the rendered step strings,
-      # interleaving inferred waits before selector-driven actions whose
-      # preceding gap exceeds WAIT_THRESHOLD_SECONDS, and inferred URL
-      # postconditions after click/fill steps that triggered navigation.
-      def annotated_steps(commands)
-        last_url = {}
-        commands.each_with_index.flat_map do |cmd, i|
-          rendered = []
-          if i.positive? && (wait = inferred_wait_step(commands[i - 1], cmd))
-            rendered << wait
-          end
-          rendered << build_step(cmd)
-          if (post = url_postcondition_step(cmd, last_url))
-            rendered << post
-          end
-          if (snap = snapshot_postcondition_step(cmd))
-            rendered << snap
-          end
-          update_last_url!(cmd, last_url)
-          rendered
-        end
-      end
-
-      # Emits a postcondition assertion when a click/fill resulted in a URL
-      # change. Compares the canonical (scheme+host+path) form so query
-      # strings and fragments don't make every replay flaky.
-      def url_postcondition_step(cmd, last_url)
-        return nil unless %w[click fill].include?(cmd[:cmd])
-        return nil unless cmd[:postcondition_hint] && cmd[:postcondition_hint][:url]
-
-        page = cmd[:name]
-        observed = cmd[:postcondition_hint][:url]
-        prior    = last_url[page]
-        return nil if canonical_url(observed) == canonical_url(prior)
-
-        prefix = canonical_url(observed)
-        return nil unless prefix
-
-        <<~RUBY.chomp
-          step "assert url after #{cmd[:cmd]} on #{page}" do
-            current = page(:#{page}).url
-            assert current.start_with?(#{prefix.inspect}), "expected URL to start with #{prefix}, got \#{current}"
-          end
-        RUBY
-      end
-
-      # Emits an assert_snapshot_stable step when the recording captured a
-      # post-step DOM digest. Under workflow run --check the helper records
-      # drift on mismatch instead of raising, so a wiggly page surfaces in
-      # the report rather than failing the run outright.
-      def snapshot_postcondition_step(cmd)
-        return nil unless %w[click fill].include?(cmd[:cmd])
-        return nil unless cmd[:post_snapshot_digest]
-
-        page = cmd[:name]
-        digest = cmd[:post_snapshot_digest]
-        <<~RUBY.chomp
-          step "assert post-snapshot stable on #{page}" do
-            assert_snapshot_stable(:#{page}, expected_digest: #{digest.inspect})
-          end
-        RUBY
-      end
-
-      def update_last_url!(cmd, last_url)
-        case cmd[:cmd]
-        when "navigate", "page_open"
-          last_url[cmd[:name]] = cmd[:url] if cmd[:url]
-        when "click", "fill"
-          observed = cmd[:postcondition_hint] && cmd[:postcondition_hint][:url]
-          last_url[cmd[:name]] = observed if observed
-        end
-      end
-
-      def canonical_url(url)
-        return nil if url.nil? || url.empty?
-
-        uri = URI.parse(url)
-        path = uri.path.to_s
-        path = "/" if path.empty?
-        "#{uri.scheme}://#{uri.host}#{path}"
-      rescue URI::InvalidURIError
-        nil
-      end
-
-      def inferred_wait_step(prev, current)
-        return nil unless %w[fill click].include?(current[:cmd])
-        return nil unless current[:selector]
-
-        delta = elapsed(prev, current)
-        return nil unless delta && delta >= WAIT_THRESHOLD_SECONDS
-
-        timeout = [WAIT_FLOOR_SECONDS, delta.ceil + WAIT_PADDING_SECONDS].max
-        page = current[:name]
-        sel  = current[:selector]
-        <<~RUBY.chomp
-          # inferred wait: prior step took ~#{format('%.1f', delta)}s
-          step "wait for #{sel} on #{page}" do
-            page(:#{page}).wait(#{sel.inspect}, timeout: #{timeout})
-          end
-        RUBY
-      end
-
-      def elapsed(prev, current)
-        return nil unless prev && current && prev[:ts] && current[:ts]
-
-        current[:ts] - prev[:ts]
-      end
-
-      def secret_header(secrets)
-        return "" if secrets.empty?
-
-        lines = ["# TODO: review the following secret-shaped fields detected during recording.",
-                 "# Configure a secret_ref: source for each before running:"]
-        secrets.each { |f| lines << "#   - secret_#{f}" }
-        "\n#{lines.join("\n")}\n"
-      end
-
-      def build_step(cmd)
-        label, body = step_parts(cmd)
-
-        if body.nil?
-          page_sym = cmd[:name].to_s.gsub(/[^a-zA-Z0-9_]/, "_")
-          action   = cmd[:action].to_s.gsub(/[^a-z_]/, "")
-          return "# TODO: ref-based #{action} on #{cmd[:name].inspect} (ref: #{cmd[:ref].inspect}) — " \
-                 "replace with a stable CSS selector\n" \
-                 "# step #{label.inspect} do\n" \
-                 "#   page(:#{page_sym}).#{action}(\"YOUR_SELECTOR_HERE\")\n" \
-                 "# end"
-        end
-
-        prefix = []
-        prefix << "# NOTE: sensitive query params were redacted during recording" \
-          if cmd[:url].to_s.include?("[REDACTED]")
-        prefix << "# fingerprint fallback: #{cmd[:fingerprint].to_json}" if cmd[:fingerprint]
-
-        head = prefix.empty? ? "" : "#{prefix.join("\n")}\n"
-        "#{head}step #{label.inspect} do\n  #{body}\nend"
-      end
-
-      def step_parts(cmd)
-        return ref_interaction_parts(cmd) if cmd[:cmd] == "_ref_interaction"
-        return selector_parts(cmd) if %w[fill click].include?(cmd[:cmd])
-
-        page = cmd[:name]
-        case cmd[:cmd]
-        when "page_open"  then ["open #{page}", "page(:#{page}).navigate(#{cmd[:url].inspect})"]
-        when "navigate"   then ["navigate #{page}", "page(:#{page}).navigate(#{cmd[:url].inspect})"]
-        when "screenshot" then ["screenshot #{page}", "page(:#{page}).screenshot"]
-        when "evaluate"   then ["eval on #{page}", "page(:#{page}).evaluate(#{cmd[:expression].inspect})"]
-        else ["#{cmd[:cmd]} on #{page}", "# unrecognised command: #{cmd.inspect}"]
-        end
-      end
-
-      def ref_interaction_parts(cmd)
-        ["TODO: ref-based #{cmd[:action]} on #{cmd[:name]} (ref: #{cmd[:ref]})", nil]
-      end
-
-      def selector_parts(cmd)
-        page = cmd[:name]
-        case cmd[:cmd]
-        when "fill"
-          value_arg = cmd[:secret_field] ? "params[:secret_#{cmd[:secret_field]}]" : "params[:fill_value]"
-          ["fill #{cmd[:selector]} on #{page}",
-           "page(:#{page}).fill(#{cmd[:selector].inspect}, #{value_arg})"]
-        when "click"
-          ["click #{cmd[:selector]} on #{page}",
-           "page(:#{page}).click(#{cmd[:selector].inspect})"]
-        end
-      end
-
       def prepare_attrs(cmd, attrs)
         attrs = attrs.except(:capture_post_snapshot)
         if cmd == "fill"
           attrs = attrs.except(:value)
-          field = infer_secret_field(attrs[:selector])
+          field = Redactor.infer_secret_field(attrs[:selector])
           if field
             attrs[:secret_hint]  = true
             attrs[:secret_field] = field
           end
         end
-        attrs[:url] = redact_url(attrs[:url]) if %w[navigate page_open].include?(cmd) && attrs[:url]
+        attrs[:url] = Redactor.redact_url(attrs[:url]) if %w[navigate page_open].include?(cmd) && attrs[:url]
         attrs
-      end
-
-      def infer_secret_field(selector)
-        return nil unless selector
-
-        match = selector.match(SECRET_FIELD_PATTERN)
-        return nil unless match
-
-        match[1].downcase.gsub(/[^a-z0-9]/, "_")
-      end
-
-      def redact_url(url)
-        uri = URI.parse(url)
-        return url if uri.query.nil?
-
-        uri.query = uri.query.gsub(/([^&=]+)=([^&]*)/) do |full_match|
-          raw_key = ::Regexp.last_match(1)
-          key = URI.decode_www_form_component(raw_key)
-          key =~ SENSITIVE_PARAM_PATTERN ? "#{raw_key}=[REDACTED]" : full_match
-        end
-        uri.to_s
-      rescue URI::InvalidURIError
-        url
       end
     end
   end
 end
+
+require_relative "recording/state"
+require_relative "recording/redactor"
+require_relative "recording/log_writer"
+require_relative "recording/workflow_renderer"

--- a/lib/browserctl/recording/log_writer.rb
+++ b/lib/browserctl/recording/log_writer.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "time"
+require_relative "../errors"
+require_relative "../error/codes"
+
+module Browserctl
+  class Recording
+    # Owns recording-log file I/O: path resolution, header initialisation,
+    # JSONL append, raw read, deletion, and format-version validation.
+    #
+    # All paths are resolved against the parent `Recording::RECORDINGS_DIR`
+    # constant on each call so RSpec `stub_const` calls remain effective.
+    module LogWriter
+      module_function
+
+      # Returns the on-disk JSONL path for a named recording.
+      def log_path(name)
+        File.join(Browserctl::Recording::RECORDINGS_DIR, "#{name}.jsonl")
+      end
+
+      # Truncates (or creates) the log for `name`, locks it down to user
+      # permissions, and writes the `_meta` header line. Returns the path.
+      def init_log(name)
+        FileUtils.mkdir_p(Browserctl::Recording::RECORDINGS_DIR, mode: 0o700)
+        path = log_path(name)
+        FileUtils.rm_f(path)
+        FileUtils.touch(path)
+        File.chmod(0o600, path)
+        File.open(path, "a") do |f|
+          f.puts JSON.generate(
+            cmd: "_meta",
+            format_version: Browserctl::Recording::RECORDING_FORMAT_VERSION,
+            log_format: Browserctl::Recording::LOG_FORMAT,
+            recording: name,
+            started_at: Time.now.utc.iso8601
+          )
+        end
+        path
+      end
+
+      # Appends a single JSONL entry to the log for `name`.
+      def append_entry(name, entry)
+        File.open(log_path(name), "a") do |f|
+          f.puts JSON.generate(entry)
+        end
+      end
+
+      # Returns the parsed lines for `name`, with symbolised keys.
+      def read_entries(name)
+        File.readlines(log_path(name)).map { |l| JSON.parse(l, symbolize_names: true) }
+      end
+
+      # Removes the log file for `name` if present.
+      def delete_log(name)
+        FileUtils.rm_f(log_path(name))
+      end
+
+      # Raises Browserctl::ProtocolMismatch when the recording log's
+      # `_meta` header is missing or declares a `format_version` that this
+      # build does not support. Mirrors `Browserctl::State::Bundle`.
+      def verify_format_version!(raw_lines, path: nil)
+        meta = raw_lines.first
+        version = meta && meta[:cmd] == "_meta" ? meta[:format_version] : nil
+        supported = Browserctl::Recording::SUPPORTED_FORMAT_VERSIONS
+        return if version && supported.include?(version)
+
+        where = path ? " at #{path}" : ""
+        msg = if version.nil?
+                "recording log#{where} is missing format_version " \
+                  "(supported: #{supported.inspect})"
+              else
+                "recording log#{where} declares format_version=#{version.inspect}, " \
+                  "this build supports #{supported.inspect}"
+              end
+        raise Browserctl::ProtocolMismatch.new(msg, code: Browserctl::Error::Codes::PROTOCOL_MISMATCH)
+      end
+    end
+  end
+end

--- a/lib/browserctl/recording/redactor.rb
+++ b/lib/browserctl/recording/redactor.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Browserctl
+  class Recording
+    # Secret-aware redaction helpers used while a recording is being
+    # captured. Two responsibilities:
+    #
+    # 1. Inferring whether a `fill` selector is targeting a secret-shaped
+    #    field, so the generated workflow can wire a `secret_ref:` param.
+    # 2. Stripping sensitive query-string values out of recorded URLs so
+    #    they never reach disk.
+    module Redactor
+      # Query-string parameter names whose values are scrubbed when a
+      # navigate/page_open URL is recorded.
+      SENSITIVE_PARAM_PATTERN = /\A(token|key|secret|auth|code|access_token|api_key|client_secret|state)\z/ix
+
+      # Selector tokens that signal a fill is targeting a secret-shaped
+      # field. The captured group is used as the inferred field name; that
+      # name later drives the generated `secret_ref:` placeholder.
+      SECRET_FIELD_PATTERN = Regexp.new(
+        '\b(password|passwd|api[_-]?key|token|secret|otp|pin|client[_-]?secret|access[_-]?token)\b',
+        Regexp::IGNORECASE
+      )
+
+      module_function
+
+      # Returns a normalised secret-field name (e.g. "api_key") inferred
+      # from the selector, or nil when the selector is missing or does not
+      # match the secret-field pattern.
+      def infer_secret_field(selector)
+        return nil unless selector
+
+        match = selector.match(SECRET_FIELD_PATTERN)
+        return nil unless match
+
+        match[1].downcase.gsub(/[^a-z0-9]/, "_")
+      end
+
+      # Returns `url` with any sensitive query parameter values replaced
+      # by `[REDACTED]`. URLs that fail to parse are returned unchanged.
+      def redact_url(url)
+        uri = URI.parse(url)
+        return url if uri.query.nil?
+
+        uri.query = uri.query.gsub(/([^&=]+)=([^&]*)/) do |full_match|
+          raw_key = ::Regexp.last_match(1)
+          key = URI.decode_www_form_component(raw_key)
+          key =~ SENSITIVE_PARAM_PATTERN ? "#{raw_key}=[REDACTED]" : full_match
+        end
+        uri.to_s
+      rescue URI::InvalidURIError
+        url
+      end
+    end
+  end
+end

--- a/lib/browserctl/recording/state.rb
+++ b/lib/browserctl/recording/state.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require_relative "../errors"
+require_relative "../error/codes"
+
+module Browserctl
+  class Recording
+    # Singleton over the on-disk marker (`STATE_FILE`) that tracks which
+    # recording, if any, is currently active. Carved out of `Recording` so
+    # the facade stays focused on dispatch.
+    module State
+      module_function
+
+      # Returns the active recording name, or nil when no marker exists.
+      # Reads the constant lazily so RSpec `stub_const` calls on the parent
+      # `Recording::STATE_FILE` continue to take effect.
+      def active
+        path = Browserctl::Recording::STATE_FILE
+        File.exist?(path) ? File.read(path).strip : nil
+      end
+
+      # Writes the marker for `name`. Caller is responsible for any
+      # additional setup (e.g. log initialisation).
+      def write(name)
+        path = Browserctl::Recording::STATE_FILE
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, name)
+        name
+      end
+
+      # Removes the marker. Raises Browserctl::Error when no recording is
+      # active. The message is preserved verbatim from the pre-split
+      # facade so existing specs and CLI surfaces stay stable.
+      def clear!
+        name = active
+        raise Browserctl::Error, "no active recording — run: browserctl recording start <name>" unless name
+
+        File.unlink(Browserctl::Recording::STATE_FILE)
+        name
+      end
+    end
+  end
+end

--- a/lib/browserctl/recording/workflow_renderer.rb
+++ b/lib/browserctl/recording/workflow_renderer.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "date"
+require "uri"
+
+module Browserctl
+  class Recording
+    # Renders a recording log into the Ruby source of a workflow. Pure
+    # function over the parsed log entries — no I/O, no clock, no globals.
+    #
+    # Carved out of `Recording` so the facade stays focused on dispatch;
+    # the step-rendering rules (selector vs ref, inferred waits, URL and
+    # snapshot postconditions, secret param wiring) all live here.
+    module WorkflowRenderer
+      # Conservative thresholds for inferring an explicit wait between
+      # recorded steps. Gaps shorter than the threshold come from natural
+      # input cadence; gaps above it usually mean the page actually had
+      # work to do.
+      WAIT_THRESHOLD_SECONDS = 1.5
+      WAIT_PADDING_SECONDS   = 5
+      WAIT_FLOOR_SECONDS     = 5
+
+      module_function
+
+      # Returns the Ruby source string for the workflow named `name`,
+      # given the parsed (non-meta) command entries.
+      def render(name, commands)
+        steps   = annotated_steps(commands).join("\n\n")
+        secrets = commands.map { |c| c[:secret_field] }.compact.uniq
+        header  = secret_header(secrets)
+        <<~RUBY
+          # frozen_string_literal: true
+          # format_version: #{Browserctl::WORKFLOW_FORMAT_VERSION}
+          #{header}
+          Browserctl.workflow #{name.inspect} do
+            desc "Recorded on #{Date.today}"
+          #{secrets.map { |f| "  param :secret_#{f}, secret: true" }.join("\n")}
+          #{steps.gsub(/^/, '  ')}
+          end
+        RUBY
+      end
+
+      # Walks the recorded events and emits the rendered step strings,
+      # interleaving inferred waits before selector-driven actions whose
+      # preceding gap exceeds WAIT_THRESHOLD_SECONDS, and inferred URL
+      # postconditions after click/fill steps that triggered navigation.
+      def annotated_steps(commands)
+        last_url = {}
+        commands.each_with_index.flat_map do |cmd, i|
+          rendered = []
+          if i.positive? && (wait = inferred_wait_step(commands[i - 1], cmd))
+            rendered << wait
+          end
+          rendered << build_step(cmd)
+          if (post = url_postcondition_step(cmd, last_url))
+            rendered << post
+          end
+          if (snap = snapshot_postcondition_step(cmd))
+            rendered << snap
+          end
+          update_last_url!(cmd, last_url)
+          rendered
+        end
+      end
+
+      # Emits a postcondition assertion when a click/fill resulted in a URL
+      # change. Compares the canonical (scheme+host+path) form so query
+      # strings and fragments don't make every replay flaky.
+      def url_postcondition_step(cmd, last_url)
+        return nil unless %w[click fill].include?(cmd[:cmd])
+        return nil unless cmd[:postcondition_hint] && cmd[:postcondition_hint][:url]
+
+        page = cmd[:name]
+        observed = cmd[:postcondition_hint][:url]
+        prior    = last_url[page]
+        return nil if canonical_url(observed) == canonical_url(prior)
+
+        prefix = canonical_url(observed)
+        return nil unless prefix
+
+        <<~RUBY.chomp
+          step "assert url after #{cmd[:cmd]} on #{page}" do
+            current = page(:#{page}).url
+            assert current.start_with?(#{prefix.inspect}), "expected URL to start with #{prefix}, got \#{current}"
+          end
+        RUBY
+      end
+
+      # Emits an assert_snapshot_stable step when the recording captured a
+      # post-step DOM digest. Under workflow run --check the helper records
+      # drift on mismatch instead of raising, so a wiggly page surfaces in
+      # the report rather than failing the run outright.
+      def snapshot_postcondition_step(cmd)
+        return nil unless %w[click fill].include?(cmd[:cmd])
+        return nil unless cmd[:post_snapshot_digest]
+
+        page = cmd[:name]
+        digest = cmd[:post_snapshot_digest]
+        <<~RUBY.chomp
+          step "assert post-snapshot stable on #{page}" do
+            assert_snapshot_stable(:#{page}, expected_digest: #{digest.inspect})
+          end
+        RUBY
+      end
+
+      def update_last_url!(cmd, last_url)
+        case cmd[:cmd]
+        when "navigate", "page_open"
+          last_url[cmd[:name]] = cmd[:url] if cmd[:url]
+        when "click", "fill"
+          observed = cmd[:postcondition_hint] && cmd[:postcondition_hint][:url]
+          last_url[cmd[:name]] = observed if observed
+        end
+      end
+
+      def canonical_url(url)
+        return nil if url.nil? || url.empty?
+
+        uri = URI.parse(url)
+        path = uri.path.to_s
+        path = "/" if path.empty?
+        "#{uri.scheme}://#{uri.host}#{path}"
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      def inferred_wait_step(prev, current)
+        return nil unless %w[fill click].include?(current[:cmd])
+        return nil unless current[:selector]
+
+        delta = elapsed(prev, current)
+        return nil unless delta && delta >= WAIT_THRESHOLD_SECONDS
+
+        timeout = [WAIT_FLOOR_SECONDS, delta.ceil + WAIT_PADDING_SECONDS].max
+        page = current[:name]
+        sel  = current[:selector]
+        <<~RUBY.chomp
+          # inferred wait: prior step took ~#{format('%.1f', delta)}s
+          step "wait for #{sel} on #{page}" do
+            page(:#{page}).wait(#{sel.inspect}, timeout: #{timeout})
+          end
+        RUBY
+      end
+
+      def elapsed(prev, current)
+        return nil unless prev && current && prev[:ts] && current[:ts]
+
+        current[:ts] - prev[:ts]
+      end
+
+      def secret_header(secrets)
+        return "" if secrets.empty?
+
+        lines = ["# TODO: review the following secret-shaped fields detected during recording.",
+                 "# Configure a secret_ref: source for each before running:"]
+        secrets.each { |f| lines << "#   - secret_#{f}" }
+        "\n#{lines.join("\n")}\n"
+      end
+
+      def build_step(cmd)
+        label, body = step_parts(cmd)
+
+        if body.nil?
+          page_sym = cmd[:name].to_s.gsub(/[^a-zA-Z0-9_]/, "_")
+          action   = cmd[:action].to_s.gsub(/[^a-z_]/, "")
+          return "# TODO: ref-based #{action} on #{cmd[:name].inspect} (ref: #{cmd[:ref].inspect}) — " \
+                 "replace with a stable CSS selector\n" \
+                 "# step #{label.inspect} do\n" \
+                 "#   page(:#{page_sym}).#{action}(\"YOUR_SELECTOR_HERE\")\n" \
+                 "# end"
+        end
+
+        prefix = []
+        prefix << "# NOTE: sensitive query params were redacted during recording" \
+          if cmd[:url].to_s.include?("[REDACTED]")
+        prefix << "# fingerprint fallback: #{cmd[:fingerprint].to_json}" if cmd[:fingerprint]
+
+        head = prefix.empty? ? "" : "#{prefix.join("\n")}\n"
+        "#{head}step #{label.inspect} do\n  #{body}\nend"
+      end
+
+      def step_parts(cmd)
+        return ref_interaction_parts(cmd) if cmd[:cmd] == "_ref_interaction"
+        return selector_parts(cmd) if %w[fill click].include?(cmd[:cmd])
+
+        page = cmd[:name]
+        case cmd[:cmd]
+        when "page_open"  then ["open #{page}", "page(:#{page}).navigate(#{cmd[:url].inspect})"]
+        when "navigate"   then ["navigate #{page}", "page(:#{page}).navigate(#{cmd[:url].inspect})"]
+        when "screenshot" then ["screenshot #{page}", "page(:#{page}).screenshot"]
+        when "evaluate"   then ["eval on #{page}", "page(:#{page}).evaluate(#{cmd[:expression].inspect})"]
+        else ["#{cmd[:cmd]} on #{page}", "# unrecognised command: #{cmd.inspect}"]
+        end
+      end
+
+      def ref_interaction_parts(cmd)
+        ["TODO: ref-based #{cmd[:action]} on #{cmd[:name]} (ref: #{cmd[:ref]})", nil]
+      end
+
+      def selector_parts(cmd)
+        page = cmd[:name]
+        case cmd[:cmd]
+        when "fill"
+          value_arg = cmd[:secret_field] ? "params[:secret_#{cmd[:secret_field]}]" : "params[:fill_value]"
+          ["fill #{cmd[:selector]} on #{page}",
+           "page(:#{page}).fill(#{cmd[:selector].inspect}, #{value_arg})"]
+        when "click"
+          ["click #{cmd[:selector]} on #{page}",
+           "page(:#{page}).click(#{cmd[:selector].inspect})"]
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/recording/log_writer_spec.rb
+++ b/spec/unit/recording/log_writer_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "json"
+require "browserctl/recording"
+
+RSpec.describe Browserctl::Recording::LogWriter do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmp_dir = dir
+      example.run
+    end
+  end
+
+  before do
+    stub_const("Browserctl::Recording::RECORDINGS_DIR", @tmp_dir)
+  end
+
+  describe ".log_path" do
+    it "returns the JSONL path under the recordings dir" do
+      expect(described_class.log_path("scrape_issues"))
+        .to eq(File.join(@tmp_dir, "scrape_issues.jsonl"))
+    end
+  end
+
+  describe ".init_log" do
+    it "creates the log with a _meta header carrying format and recording name" do
+      described_class.init_log("scrape_issues")
+      lines = File.readlines(described_class.log_path("scrape_issues"))
+      expect(lines.size).to eq(1)
+      meta = JSON.parse(lines.first)
+      expect(meta["cmd"]).to eq("_meta")
+      expect(meta["recording"]).to eq("scrape_issues")
+      expect(meta["format_version"]).to eq(Browserctl::Recording::RECORDING_FORMAT_VERSION)
+      expect(meta["log_format"]).to eq(Browserctl::Recording::LOG_FORMAT)
+      expect(meta["started_at"]).to match(/\A\d{4}-\d{2}-\d{2}T/)
+    end
+
+    it "truncates an existing log" do
+      path = described_class.log_path("scrape_issues")
+      described_class.init_log("scrape_issues")
+      File.open(path, "a") { |f| f.puts(JSON.generate(cmd: "noise")) }
+      described_class.init_log("scrape_issues")
+      lines = File.readlines(path)
+      expect(lines.size).to eq(1)
+    end
+
+    it "locks the log to user-only permissions" do
+      path = described_class.init_log("scrape_issues")
+      mode = File.stat(path).mode & 0o777
+      expect(mode).to eq(0o600)
+    end
+  end
+
+  describe ".append_entry and .read_entries" do
+    it "round-trips JSONL entries with symbolised keys" do
+      described_class.init_log("scrape_issues")
+      described_class.append_entry("scrape_issues", { cmd: "navigate", url: "https://example.com" })
+      entries = described_class.read_entries("scrape_issues")
+      expect(entries.size).to eq(2)
+      expect(entries.last).to eq(cmd: "navigate", url: "https://example.com")
+    end
+  end
+
+  describe ".delete_log" do
+    it "removes the log file" do
+      described_class.init_log("scrape_issues")
+      path = described_class.log_path("scrape_issues")
+      expect(File.exist?(path)).to be(true)
+      described_class.delete_log("scrape_issues")
+      expect(File.exist?(path)).to be(false)
+    end
+
+    it "is a no-op when the log is missing" do
+      expect { described_class.delete_log("never_started") }.not_to raise_error
+    end
+  end
+
+  describe ".verify_format_version!" do
+    it "passes when the _meta header declares a supported version" do
+      lines = [{ cmd: "_meta", format_version: Browserctl::Recording::RECORDING_FORMAT_VERSION }]
+      expect { described_class.verify_format_version!(lines) }.not_to raise_error
+    end
+
+    it "raises ProtocolMismatch when the _meta header is missing" do
+      expect { described_class.verify_format_version!([{ cmd: "navigate" }]) }
+        .to raise_error(Browserctl::ProtocolMismatch, /missing format_version/)
+    end
+
+    it "raises ProtocolMismatch when the declared version is unsupported" do
+      lines = [{ cmd: "_meta", format_version: 999 }]
+      expect { described_class.verify_format_version!(lines, path: "/tmp/x.jsonl") }
+        .to raise_error(Browserctl::ProtocolMismatch, /declares format_version=999/)
+    end
+  end
+end

--- a/spec/unit/recording/redactor_spec.rb
+++ b/spec/unit/recording/redactor_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "browserctl/recording"
+
+RSpec.describe Browserctl::Recording::Redactor do
+  describe ".infer_secret_field" do
+    it "returns nil for nil selector" do
+      expect(described_class.infer_secret_field(nil)).to be_nil
+    end
+
+    it "returns nil for selectors with no secret-shaped tokens" do
+      expect(described_class.infer_secret_field("input[name='email']")).to be_nil
+    end
+
+    it "extracts a normalised name when the selector matches a secret token" do
+      expect(described_class.infer_secret_field("input[name='password']")).to eq("password")
+    end
+
+    it "normalises hyphens and case (api_key)" do
+      expect(described_class.infer_secret_field("[data-test='Api-Key']")).to eq("api_key")
+    end
+
+    it "matches client_secret variants" do
+      expect(described_class.infer_secret_field("#client-secret")).to eq("client_secret")
+    end
+  end
+
+  describe ".redact_url" do
+    it "returns the url unchanged when there is no query string" do
+      url = "https://example.com/path"
+      expect(described_class.redact_url(url)).to eq(url)
+    end
+
+    it "redacts sensitive parameter values" do
+      out = described_class.redact_url("https://example.com/cb?token=abc&id=1")
+      expect(out).to eq("https://example.com/cb?token=[REDACTED]&id=1")
+    end
+
+    it "redacts api_key, secret, code, access_token, client_secret, state" do
+      sensitive = %w[api_key secret code access_token client_secret state token key auth]
+      sensitive.each do |key|
+        out = described_class.redact_url("https://example.com/?#{key}=v")
+        expect(out).to include("#{key}=[REDACTED]"), "expected #{key} to be redacted, got #{out}"
+      end
+    end
+
+    it "preserves non-sensitive query params" do
+      out = described_class.redact_url("https://example.com/?id=1&name=patrick")
+      expect(out).to eq("https://example.com/?id=1&name=patrick")
+    end
+
+    it "returns the url unchanged on URI parse failure" do
+      bad = "http://exa mple.com/?token=x"
+      expect(described_class.redact_url(bad)).to eq(bad)
+    end
+  end
+end

--- a/spec/unit/recording/state_spec.rb
+++ b/spec/unit/recording/state_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "browserctl/recording"
+
+RSpec.describe Browserctl::Recording::State do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmp_dir = dir
+      example.run
+    end
+  end
+
+  before do
+    stub_const("Browserctl::Recording::STATE_FILE", File.join(@tmp_dir, "active_recording"))
+  end
+
+  describe ".active" do
+    it "returns nil when no marker file is present" do
+      expect(described_class.active).to be_nil
+    end
+
+    it "returns the recording name when the marker exists" do
+      File.write(Browserctl::Recording::STATE_FILE, "my_flow\n")
+      expect(described_class.active).to eq("my_flow")
+    end
+
+    it "strips trailing whitespace" do
+      File.write(Browserctl::Recording::STATE_FILE, "my_flow\n\n")
+      expect(described_class.active).to eq("my_flow")
+    end
+  end
+
+  describe ".write" do
+    it "creates the parent directory and writes the marker" do
+      nested = File.join(@tmp_dir, "nested", "active_recording")
+      stub_const("Browserctl::Recording::STATE_FILE", nested)
+
+      described_class.write("scrape_issues")
+
+      expect(File.read(nested)).to eq("scrape_issues")
+    end
+
+    it "returns the recording name" do
+      expect(described_class.write("scrape_issues")).to eq("scrape_issues")
+    end
+  end
+
+  describe ".clear!" do
+    it "removes the marker and returns the recording name" do
+      described_class.write("scrape_issues")
+      expect(described_class.clear!).to eq("scrape_issues")
+      expect(described_class.active).to be_nil
+    end
+
+    it "raises Browserctl::Error when no recording is active" do
+      expect { described_class.clear! }
+        .to raise_error(Browserctl::Error, /no active recording/)
+    end
+  end
+end

--- a/spec/unit/recording/workflow_renderer_spec.rb
+++ b/spec/unit/recording/workflow_renderer_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "browserctl"
+
+RSpec.describe Browserctl::Recording::WorkflowRenderer do
+  describe ".render" do
+    it "produces a workflow with a format_version comment header" do
+      ruby = described_class.render("noop", [])
+      expect(ruby).to include("# format_version: #{Browserctl::WORKFLOW_FORMAT_VERSION}")
+      expect(ruby).to include('Browserctl.workflow "noop" do')
+    end
+
+    it "renders a navigate command into a page().navigate step" do
+      ruby = described_class.render("ex", [{ cmd: "navigate", name: "home", url: "https://example.com" }])
+      expect(ruby).to include('step "navigate home" do')
+      expect(ruby).to include('page(:home).navigate("https://example.com")')
+    end
+
+    it "wires fill values to params[:fill_value] by default" do
+      ruby = described_class.render("ex", [{ cmd: "fill", name: "login", selector: "input" }])
+      expect(ruby).to include('page(:login).fill("input", params[:fill_value])')
+    end
+
+    it "wires secret-shaped fills to params[:secret_<field>]" do
+      cmds = [{ cmd: "fill", name: "login", selector: "input[name=password]", secret_field: "password" }]
+      ruby = described_class.render("ex", cmds)
+      expect(ruby).to include("param :secret_password, secret: true")
+      expect(ruby).to include("page(:login).fill(\"input[name=password]\", params[:secret_password])")
+    end
+
+    it "emits a TODO when a ref-interaction is present (no replayable selector)" do
+      cmds = [{ cmd: "_ref_interaction", name: "p", action: "click", ref: "abc123" }]
+      ruby = described_class.render("ex", cmds)
+      expect(ruby).to include("TODO: ref-based click")
+    end
+  end
+
+  describe ".canonical_url" do
+    it "strips query and fragment, keeping scheme/host/path" do
+      expect(described_class.canonical_url("https://e.com/p?x=1#y")).to eq("https://e.com/p")
+    end
+
+    it "normalises an empty path to /" do
+      expect(described_class.canonical_url("https://e.com")).to eq("https://e.com/")
+    end
+
+    it "returns nil for blank input" do
+      expect(described_class.canonical_url(nil)).to be_nil
+      expect(described_class.canonical_url("")).to be_nil
+    end
+
+    it "returns nil for unparseable URLs" do
+      expect(described_class.canonical_url("http://exa mple.com")).to be_nil
+    end
+  end
+
+  describe ".inferred_wait_step" do
+    it "emits a wait when the gap exceeds the threshold for a selector step" do
+      prev = { cmd: "navigate", ts: 0.0 }
+      cur  = { cmd: "click", name: "p", selector: "a.next", ts: 3.0 }
+      out  = described_class.inferred_wait_step(prev, cur)
+      expect(out).to include('page(:p).wait("a.next"')
+    end
+
+    it "returns nil for sub-threshold gaps" do
+      prev = { cmd: "navigate", ts: 0.0 }
+      cur  = { cmd: "click", name: "p", selector: "a", ts: 0.5 }
+      expect(described_class.inferred_wait_step(prev, cur)).to be_nil
+    end
+
+    it "returns nil when timestamps are missing" do
+      prev = { cmd: "navigate" }
+      cur  = { cmd: "click", name: "p", selector: "a" }
+      expect(described_class.inferred_wait_step(prev, cur)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR 6 of the v0.13 lean plan. `lib/browserctl/recording.rb` was 390 LOC across 27 methods, owning recording I/O, redaction, log formatting, JSON parsing, timestamp inference, secret-field detection, and workflow rendering all at once. This PR carves it into a thin facade over four focused collaborators:

- `Browserctl::Recording::State` — singleton over the on-disk `STATE_FILE` marker.
- `Browserctl::Recording::Redactor` — secret-aware redaction (URLs and selector-inferred secret fields).
- `Browserctl::Recording::LogWriter` — log file I/O, JSONL formatting, and format-version validation.
- `Browserctl::Recording::WorkflowRenderer` — pure translation of recorded entries into a workflow Ruby file.

`recording.rb` is now 132 LOC (under the 150 LOC acceptance bar).

## Public surface

Unchanged. Diff before vs after:

```text
public_methods: [active, append, generate_workflow, start, stop, warn_about_ref_interactions]   (identical)
externally-referenced constants: RECORDINGS_DIR, STATE_FILE, RECORDING_FORMAT_VERSION,
                                 SUPPORTED_FORMAT_VERSIONS, LOG_FORMAT, RECORDABLE   (preserved)
```

The `WAIT_*` thresholds and the `SECRET_FIELD_PATTERN` / `SENSITIVE_PARAM_PATTERN` regex constants moved into `WorkflowRenderer` and `Redactor` respectively. They were never referenced outside `recording.rb` (verified with `grep -rn` across `lib/`, `exe/`, `spec/`).

## Test plan

- [x] `bundle exec rspec` — 841 examples, 0 failures, 50 pending (pre-existing chrome-required integration specs).
- [x] `bundle exec rubocop` — 222 files, no offenses.
- [x] Existing `spec/unit/recording_spec.rb` unchanged and green.
- [x] New per-object specs under `spec/unit/recording/` cover State, Redactor, LogWriter, and WorkflowRenderer in isolation.
- [x] Integration spec `spec/integration/v0_11_replayable_acceptance_spec.rb` (which `stub_const`s `RECORDINGS_DIR` / `STATE_FILE`) still passes — constants are read lazily inside method bodies, so stubs continue to take effect.