### PR TITLE
refactor: extract CallableDefinition base for Flow/Workflow

### DIFF
--- a/lib/browserctl/callable_definition.rb
+++ b/lib/browserctl/callable_definition.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "timeout"
+require_relative "errors"
+require_relative "secret_resolvers"
+
+module Browserctl
+  # Shared base for {Flow} and {WorkflowDefinition}. Holds the duplicated
+  # DSL surface (`desc`, `param`, `step`) and the shared execution helpers
+  # for resolving params and running step blocks with retry + timeout.
+  #
+  # Subclasses provide:
+  # - their own `call`/`run` entry point and context object;
+  # - {#callable_kind} so cross-type composition can be rejected at
+  #   definition time (e.g. a flow trying to `compose` a workflow);
+  # - {#step_failure_message} for the typed error wording.
+  #
+  # The persistence DSL (`store`/`fetch`/`save_state`/`load_state`) is
+  # mixed into `WorkflowContext` via {ContextualPersistence} and is
+  # deliberately absent from `FlowContext` — flows return state, workflows
+  # share state.
+  class CallableDefinition
+    ParamDef = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
+    StepDef  = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
+
+    attr_reader :name, :description, :param_defs, :steps
+
+    def initialize(name)
+      @name        = name.to_s
+      @description = nil
+      @param_defs  = {}
+      @steps       = []
+    end
+
+    def desc(text)
+      @description = text.to_s
+    end
+
+    def param(name, required: false, secret: false, default: nil, secret_ref: nil)
+      secret = true if secret_ref
+      @param_defs[name] = ParamDef.new(
+        name: name,
+        required: required,
+        secret: secret,
+        default: default,
+        secret_ref: secret_ref
+      )
+    end
+
+    def step(label, retry_count: 0, timeout: nil, &block)
+      raise ArgumentError, "#{callable_kind} step '#{label}' requires a block" unless block
+
+      @steps << StepDef.new(label: label, block: block, retry_count: retry_count, timeout: timeout)
+    end
+
+    # Subclasses override these to specialise the base behaviour.
+
+    # @return [Symbol] :flow or :workflow — used for cross-type composition checks.
+    def callable_kind
+      raise NotImplementedError
+    end
+
+    private
+
+    def resolve_params(provided)
+      @param_defs.each_with_object({}) do |(name, defn), out|
+        val = if defn.secret_ref
+                SecretResolverRegistry.resolve(defn.secret_ref)
+              elsif provided.key?(name)
+                provided[name]
+              else
+                defn.default
+              end
+
+        raise missing_param_error(name) if defn.required && val.nil?
+
+        out[name] = val
+      end
+    end
+
+    # Override for typed error wording.
+    def missing_param_error(_name)
+      raise NotImplementedError
+    end
+
+    # Runs a step block with retry + timeout. Yields the recoverable error
+    # to the caller (via the returned exception in `:error`) so subclasses
+    # can decide how to surface a failure (raise vs StepResult).
+    def execute_step_block(ctx, defn)
+      if defn.timeout
+        ::Timeout.timeout(defn.timeout) { ctx.instance_exec(&defn.block) }
+      else
+        ctx.instance_exec(&defn.block)
+      end
+    rescue ::Timeout::Error
+      raise step_timeout_error(defn)
+    end
+
+    def with_retries(defn)
+      last_error = nil
+      (defn.retry_count + 1).times do
+        return yield
+      rescue StandardError => e
+        last_error = e
+      end
+      [:error, last_error]
+    end
+
+    # Subclasses override to raise their typed timeout error.
+    def step_timeout_error(_defn)
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/browserctl/contextual_persistence.rb
+++ b/lib/browserctl/contextual_persistence.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Browserctl
+  # Persistence-and-state DSL mixed into {WorkflowContext}. {FlowContext}
+  # does NOT mix this in — that absence is the structural enforcement of
+  # the doctrinal split: flows return state, workflows share state through
+  # the daemon-backed `store`/`fetch` and `.bctl` bundles.
+  #
+  # Hosts must expose `@client` and may expose `@replay_context` (for the
+  # selector-rematch fallback used elsewhere). Auth-required recovery
+  # delegates back to the host's `invoke` so flows bound to a saved
+  # bundle can rotate credentials transparently.
+  module ContextualPersistence
+    def store(key, value)
+      res = @client.store(key.to_s, value)
+      raise WorkflowError, res[:error] if res[:error]
+
+      value
+    end
+
+    def fetch(key)
+      res = @client.fetch(key.to_s)
+      raise WorkflowError, res[:error] if res[:error]
+
+      res[:value]
+    end
+
+    # Persists the daemon's current cookies + storage as a .bctl bundle.
+    # Optional flow binding lets `load_state` auto-rotate when the bundle
+    # is detected as needing authentication.
+    def save_state(name, flow: nil, origins: nil, encrypt: false)
+      passphrase = encrypt ? ENV.fetch("BROWSERCTL_STATE_PASSPHRASE", nil) : nil
+      res = @client.state_save(name.to_s,
+                               flow: flow&.to_s, origins: origins, passphrase: passphrase)
+      raise WorkflowError, res[:error] if res[:error]
+
+      res
+    end
+
+    # Restores a .bctl bundle. When the daemon detects AUTH_REQUIRED before
+    # applying (e.g. expired cookies in the payload), this rotates the bound
+    # flow and retries — no caller code change required.
+    #
+    # @param on_auth_required [Proc, nil] override the auto-rotate path. The
+    #   block runs in the workflow context, in lieu of invoking the manifest's
+    #   bound flow. Use this when the recovery procedure is bespoke.
+    def load_state(name, on_auth_required: nil)
+      res = @client.state_load(name.to_s)
+      return res unless auth_required_response?(res)
+
+      recover_auth_required_state(name.to_s, res, on_auth_required)
+    end
+
+    private
+
+    def auth_required_response?(res)
+      (res[:code] || res["code"]) == "AUTH_REQUIRED"
+    end
+
+    def recover_auth_required_state(name, initial_res, on_auth_required)
+      if on_auth_required
+        on_auth_required.call
+      else
+        flow_name = initial_res[:suggested_flow] || initial_res["suggested_flow"]
+        unless flow_name && !flow_name.to_s.empty?
+          raise WorkflowError,
+                "state '#{name}' needs auth but bundle has no bound flow — " \
+                "save with `save_state('#{name}', flow: :NAME)` or pass on_auth_required:"
+        end
+
+        # Match the daemon's `state load` preflight: it auth-checks the first
+        # open page (insertion order). Passing that same name to the flow
+        # gives stdlib flows a `page` proxy to drive (oauth_github reads
+        # `page.url`, totp_2fa calls `page.fill`, etc.). Falls back to no
+        # page only when nothing is open — `state_save` would have errored
+        # earlier in that case, so this is a defence-in-depth nil.
+        invoke(flow_name, page: first_open_page)
+      end
+
+      after_save = @client.state_save(name)
+      raise WorkflowError, after_save[:error] if after_save[:error]
+
+      retry_res = @client.state_load(name, skip_auth_check: true)
+      raise WorkflowError, retry_res[:error] if retry_res[:error]
+
+      retry_res.merge(rotated: true)
+    end
+
+    def first_open_page
+      res = @client.page_list
+      pages = res[:pages] || res["pages"] || []
+      pages.first
+    end
+  end
+end

--- a/lib/browserctl/flow.rb
+++ b/lib/browserctl/flow.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-require "timeout"
+require_relative "callable_definition"
 require_relative "errors"
-require_relative "secret_resolvers"
 
 module Browserctl
-  FlowParamDef    = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
-  FlowStepDef     = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
   FlowConditionDef = Struct.new(:kind, :label, :block, keyword_init: true)
+
+  # Back-compat aliases — flow_wrapper specs reference these directly.
+  FlowParamDef = CallableDefinition::ParamDef
+  FlowStepDef  = CallableDefinition::StepDef
 
   class FlowContext
     attr_reader :page, :client, :params
@@ -29,29 +30,26 @@ module Browserctl
     end
   end
 
-  class Flow
+  class Flow < CallableDefinition
     SEMVER_RE = /\A\d+\.\d+\.\d+\z/
 
-    attr_reader :name,
-                :version_string,
-                :description,
-                :param_defs,
-                :steps,
+    attr_reader :version_string,
                 :preconditions,
                 :postconditions,
                 :produces_state_block,
                 :min_browserctl_version
 
     def initialize(name)
-      @name                   = name.to_s
+      super
       @version_string         = "0.0.0"
-      @description            = nil
-      @param_defs             = {}
-      @steps                  = []
       @preconditions          = []
       @postconditions         = []
       @produces_state_block   = nil
       @min_browserctl_version = nil
+    end
+
+    def callable_kind
+      :flow
     end
 
     def version(value)
@@ -62,27 +60,6 @@ module Browserctl
     def requires_browserctl(value)
       validate_semver!(value, label: "requires_browserctl")
       @min_browserctl_version = value.to_s
-    end
-
-    def desc(text)
-      @description = text.to_s
-    end
-
-    def param(name, required: false, secret: false, default: nil, secret_ref: nil)
-      secret = true if secret_ref
-      @param_defs[name] = FlowParamDef.new(
-        name: name,
-        required: required,
-        secret: secret,
-        default: default,
-        secret_ref: secret_ref
-      )
-    end
-
-    def step(label, retry_count: 0, timeout: nil, &block)
-      raise ArgumentError, "flow step '#{label}' requires a block" unless block
-
-      @steps << FlowStepDef.new(label: label, block: block, retry_count: retry_count, timeout: timeout)
     end
 
     def precondition(label = "precondition", &block)
@@ -103,6 +80,24 @@ module Browserctl
       @produces_state_block = block
     end
 
+    # Definition-time guard against cross-type composition. A flow may only
+    # compose other flows; pulling steps from a workflow would smuggle
+    # `store`/`fetch` into a flow context that has no daemon-backed
+    # persistence.
+    def compose(target_name)
+      name = target_name.to_s
+      if Browserctl.respond_to?(:lookup_workflow) && Browserctl.lookup_workflow(name)
+        raise ArgumentError,
+              "flow '#{@name}' cannot compose workflow '#{name}': flows return state, " \
+              "workflows share state — composition across kinds is not supported"
+      end
+
+      source = Browserctl.lookup_flow(name)
+      raise ArgumentError, "flow '#{name}' not found for composition" unless source
+
+      @steps.concat(source.steps)
+    end
+
     def run(page: nil, client: nil, **params)
       ctx = FlowContext.new(page: page, client: client, params: resolve_params(params))
 
@@ -121,20 +116,12 @@ module Browserctl
       raise ArgumentError, "#{label} must be MAJOR.MINOR.PATCH (got #{value.inspect})"
     end
 
-    def resolve_params(provided)
-      @param_defs.each_with_object({}) do |(name, defn), out|
-        val = if defn.secret_ref
-                SecretResolverRegistry.resolve(defn.secret_ref)
-              elsif provided.key?(name)
-                provided[name]
-              else
-                defn.default
-              end
+    def missing_param_error(name)
+      FlowParamError.new("flow '#{@name}' requires param '#{name}'")
+    end
 
-        raise FlowParamError, "flow '#{@name}' requires param '#{name}'" if defn.required && val.nil?
-
-        out[name] = val
-      end
+    def step_timeout_error(defn)
+      FlowStepError.new("flow '#{@name}' step '#{defn.label}' timed out after #{defn.timeout}s")
     end
 
     def run_conditions(ctx, conditions, error_class:)
@@ -166,17 +153,6 @@ module Browserctl
       end
       raise FlowStepError,
             "flow '#{@name}' step '#{defn.label}' failed: #{last_error.message}"
-    end
-
-    def execute_step_block(ctx, defn)
-      if defn.timeout
-        ::Timeout.timeout(defn.timeout) { ctx.instance_exec(&defn.block) }
-      else
-        ctx.instance_exec(&defn.block)
-      end
-    rescue ::Timeout::Error
-      raise FlowStepError,
-            "flow '#{@name}' step '#{defn.label}' timed out after #{defn.timeout}s"
     end
 
     def produce_state(ctx)

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "timeout"
+require_relative "callable_definition"
 require_relative "client"
+require_relative "contextual_persistence"
 require_relative "errors"
 require_relative "flow_registry"
 require_relative "replay/context"
 require_relative "replay/fingerprint_matcher"
 require_relative "replay/snapshot_diff"
-require_relative "secret_resolvers"
 
 module Browserctl
   # Workflow-file format version. Workflows are Ruby files; the schema gate
@@ -65,31 +65,21 @@ module Browserctl
     version
   end
 
-  ParamDef = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
+  # Back-compat aliases — exposed in the public surface (flow_wrapper specs,
+  # workflow specs reference these directly).
+  ParamDef = CallableDefinition::ParamDef
+  StepDef  = CallableDefinition::StepDef
   StepResult = Struct.new(:name, :ok, :error, keyword_init: true)
-  StepDef = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
 
   class WorkflowContext
+    include ContextualPersistence
+
     attr_reader :client, :replay_context, :params
 
     def initialize(params, client, replay_context: nil)
       @params = params
       @client = client
       @replay_context = replay_context
-    end
-
-    def store(key, value)
-      res = @client.store(key.to_s, value)
-      raise WorkflowError, res[:error] if res[:error]
-
-      value
-    end
-
-    def fetch(key)
-      res = @client.fetch(key.to_s)
-      raise WorkflowError, res[:error] if res[:error]
-
-      res[:value]
     end
 
     def method_missing(name, *args)
@@ -118,32 +108,6 @@ module Browserctl
       raise WorkflowError, res[:error] if res[:error]
 
       res
-    end
-
-    # Persists the daemon's current cookies + storage as a .bctl bundle.
-    # Optional flow binding lets `load_state` auto-rotate when the bundle
-    # is detected as needing authentication.
-    def save_state(name, flow: nil, origins: nil, encrypt: false)
-      passphrase = encrypt ? ENV.fetch("BROWSERCTL_STATE_PASSPHRASE", nil) : nil
-      res = @client.state_save(name.to_s,
-                               flow: flow&.to_s, origins: origins, passphrase: passphrase)
-      raise WorkflowError, res[:error] if res[:error]
-
-      res
-    end
-
-    # Restores a .bctl bundle. When the daemon detects AUTH_REQUIRED before
-    # applying (e.g. expired cookies in the payload), this rotates the bound
-    # flow and retries — no caller code change required.
-    #
-    # @param on_auth_required [Proc, nil] override the auto-rotate path. The
-    #   block runs in the workflow context, in lieu of invoking the manifest's
-    #   bound flow. Use this when the recovery procedure is bespoke.
-    def load_state(name, on_auth_required: nil)
-      res = @client.state_load(name.to_s)
-      return res unless auth_required_response?(res)
-
-      recover_auth_required_state(name.to_s, res, on_auth_required)
     end
 
     def ask(prompt)
@@ -193,45 +157,6 @@ module Browserctl
     end
 
     private
-
-    def auth_required_response?(res)
-      (res[:code] || res["code"]) == "AUTH_REQUIRED"
-    end
-
-    def recover_auth_required_state(name, initial_res, on_auth_required)
-      if on_auth_required
-        on_auth_required.call
-      else
-        flow_name = initial_res[:suggested_flow] || initial_res["suggested_flow"]
-        unless flow_name && !flow_name.to_s.empty?
-          raise WorkflowError,
-                "state '#{name}' needs auth but bundle has no bound flow — " \
-                "save with `save_state('#{name}', flow: :NAME)` or pass on_auth_required:"
-        end
-
-        # Match the daemon's `state load` preflight: it auth-checks the first
-        # open page (insertion order). Passing that same name to the flow
-        # gives stdlib flows a `page` proxy to drive (oauth_github reads
-        # `page.url`, totp_2fa calls `page.fill`, etc.). Falls back to no
-        # page only when nothing is open — `state_save` would have errored
-        # earlier in that case, so this is a defence-in-depth nil.
-        invoke(flow_name, page: first_open_page)
-      end
-
-      after_save = @client.state_save(name)
-      raise WorkflowError, after_save[:error] if after_save[:error]
-
-      retry_res = @client.state_load(name, skip_auth_check: true)
-      raise WorkflowError, retry_res[:error] if retry_res[:error]
-
-      retry_res.merge(rotated: true)
-    end
-
-    def first_open_page
-      res = @client.page_list
-      pages = res[:pages] || res["pages"] || []
-      pages.first
-    end
 
     def invoke_stack
       @invoke_stack ||= []
@@ -376,32 +301,24 @@ module Browserctl
     end
   end
 
-  class WorkflowDefinition
-    attr_reader :name, :description, :param_defs, :steps
-
-    def initialize(name)
-      @name = name
-      @description = nil
-      @param_defs  = {}
-      @steps       = []
+  class WorkflowDefinition < CallableDefinition
+    def callable_kind
+      :workflow
     end
 
-    def desc(text)
-      @description = text
-    end
-
-    def param(name, required: false, secret: false, default: nil, secret_ref: nil)
-      secret = true if secret_ref
-      @param_defs[name] =
-        ParamDef.new(name: name, required: required, secret: secret, default: default, secret_ref: secret_ref)
-    end
-
-    def step(label, retry_count: 0, timeout: nil, &block)
-      @steps << StepDef.new(label: label, block: block, retry_count: retry_count, timeout: timeout)
-    end
-
+    # Definition-time guard: composing a flow into a workflow would copy
+    # flow steps that may close over `page` (a flow-only DSL) into a
+    # context that doesn't expose it. Cross-kind composition is rejected
+    # here rather than failing later inside an `instance_exec`.
     def compose(workflow_name)
-      source = Browserctl.lookup_workflow(workflow_name.to_s)
+      name = workflow_name.to_s
+      if Browserctl.lookup_flow(name)
+        raise ArgumentError,
+              "workflow '#{@name}' cannot compose flow '#{name}': flows return state, " \
+              "workflows share state — composition across kinds is not supported"
+      end
+
+      source = Browserctl.lookup_workflow(name)
       raise WorkflowError, "workflow '#{workflow_name}' not found for composition" unless source
 
       @steps.concat(source.steps)
@@ -414,6 +331,14 @@ module Browserctl
 
     private
 
+    def missing_param_error(name)
+      WorkflowError.new("required param '#{name}' missing")
+    end
+
+    def step_timeout_error(defn)
+      WorkflowError.new("step '#{defn.label}' timed out after #{defn.timeout}s")
+    end
+
     def execute_steps(ctx)
       @steps.map { |defn| run_step(ctx, defn) }.each do |r|
         raise WorkflowError, "step '#{r.name}' failed: #{r.error}" unless r.ok
@@ -423,35 +348,12 @@ module Browserctl
     def run_step(ctx, defn)
       last_error = nil
       (defn.retry_count + 1).times do
-        execute_block(ctx, defn)
+        execute_step_block(ctx, defn)
         return StepResult.new(name: defn.label, ok: true)
       rescue StandardError => e
         last_error = e
       end
       StepResult.new(name: defn.label, ok: false, error: last_error.message)
-    end
-
-    def execute_block(ctx, defn)
-      if defn.timeout
-        ::Timeout.timeout(defn.timeout) { ctx.instance_exec(&defn.block) }
-      else
-        ctx.instance_exec(&defn.block)
-      end
-    rescue ::Timeout::Error
-      raise WorkflowError, "step '#{defn.label}' timed out after #{defn.timeout}s"
-    end
-
-    def resolve_params(provided)
-      @param_defs.each_with_object({}) do |(name, defn), out|
-        val = if defn.secret_ref
-                SecretResolverRegistry.resolve(defn.secret_ref)
-              else
-                provided[name] || defn.default
-              end
-        raise WorkflowError, "required param '#{name}' missing" if defn.required && val.nil?
-
-        out[name] = val
-      end
     end
   end
 

--- a/spec/unit/callable_definition_spec.rb
+++ b/spec/unit/callable_definition_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/flow"
+require "browserctl/workflow"
+
+RSpec.describe Browserctl::CallableDefinition do
+  before do
+    Browserctl.flow_registry_reset!
+    Browserctl.instance_variable_get(:@registry_mutex).synchronize do
+      Browserctl.instance_variable_get(:@registry).clear
+    end
+  end
+
+  describe "structural persistence whitelist" do
+    it "FlowContext does not include ContextualPersistence (no store/fetch)" do
+      expect(Browserctl::FlowContext.include?(Browserctl::ContextualPersistence)).to be(false)
+      ctx = Browserctl::FlowContext.new(page: nil, params: {})
+      expect(ctx.respond_to?(:store)).to be(false)
+      expect(ctx.respond_to?(:fetch)).to be(false)
+      expect(ctx.respond_to?(:save_state)).to be(false)
+      expect(ctx.respond_to?(:load_state)).to be(false)
+    end
+
+    it "WorkflowContext mixes in ContextualPersistence (store/fetch present)" do
+      expect(Browserctl::WorkflowContext.include?(Browserctl::ContextualPersistence)).to be(true)
+      ctx = Browserctl::WorkflowContext.new({}, double("client"))
+      expect(ctx).to respond_to(:store)
+      expect(ctx).to respond_to(:fetch)
+      expect(ctx).to respond_to(:save_state)
+      expect(ctx).to respond_to(:load_state)
+    end
+  end
+
+  describe "cross-type composition raises at definition time" do
+    it "rejects a workflow composing a flow" do
+      Browserctl.flow(:my_flow) do
+        step :noop do
+          :ok
+        end
+      end
+
+      expect do
+        Browserctl.workflow("composing_wf") do
+          compose :my_flow
+        end
+      end.to raise_error(ArgumentError, /cannot compose flow/)
+    end
+
+    it "rejects a flow composing a workflow" do
+      Browserctl.workflow("my_wf") do
+        step("noop") { :ok }
+      end
+
+      expect do
+        Browserctl.flow(:composing_flow) do
+          compose :my_wf
+        end
+      end.to raise_error(ArgumentError, /cannot compose workflow/)
+    end
+
+    it "allows a workflow to compose another workflow" do
+      Browserctl.workflow("base") do
+        step("a") { :ok }
+      end
+
+      expect do
+        Browserctl.workflow("composer") do
+          compose :base
+        end
+      end.not_to raise_error
+    end
+
+    it "allows a flow to compose another flow" do
+      Browserctl.flow(:base_flow) do
+        step :a do
+          :ok
+        end
+      end
+
+      expect do
+        Browserctl.flow(:composer_flow) do
+          compose :base_flow
+        end
+      end.not_to raise_error
+    end
+  end
+
+  describe "callable_kind" do
+    it "exposes :flow on Flow definitions" do
+      flow = Browserctl::Flow.new("f")
+      expect(flow.callable_kind).to eq(:flow)
+    end
+
+    it "exposes :workflow on WorkflowDefinition" do
+      defn = Browserctl::WorkflowDefinition.new("w")
+      expect(defn.callable_kind).to eq(:workflow)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR 7 of the v0.13 lean plan. Pulls the duplicated DSL out of `Flow` and `WorkflowDefinition` into a shared `CallableDefinition` base, and converts the flow-vs-workflow persistence whitelist from a runtime check into a structural one.

- New `lib/browserctl/callable_definition.rb` holds the shared DSL: `desc`, `param`, `step`, plus helpers for resolving params and running step blocks with retry + timeout. `Flow` and `WorkflowDefinition` now both inherit from it.
- New `lib/browserctl/contextual_persistence.rb` holds `store` / `fetch` / `save_state` / `load_state` plus auth-required recovery. `WorkflowContext` mixes it in; `FlowContext` does not — the doctrinal split (flows return state, workflows share state) is now enforced by the class graph rather than by a runtime whitelist.
- Cross-type composition now raises at definition time: a workflow that calls `compose :some_flow` (or a flow that calls `compose :some_workflow`) raises `ArgumentError` while the definition block runs, not later inside an `instance_exec`.
- Top-level constants `Browserctl::ParamDef`, `StepDef`, `FlowParamDef`, `FlowStepDef` are kept as aliases for back-compat with existing specs and tools (`flow_wrapper`, etc.).

## LOC

- `lib/browserctl/workflow.rb`: 559 -> 376
- `lib/browserctl/flow.rb`: 215 -> 191
- `lib/browserctl/callable_definition.rb` (new): 114
- `lib/browserctl/contextual_persistence.rb` (new): 95

## Test plan

- [x] `bundle exec rspec` (846 examples, 0 failures, 50 chrome-pending)
- [x] `bundle exec rubocop` clean
- [x] New `spec/unit/callable_definition_spec.rb` covers the structural persistence whitelist and cross-type compose rejection (workflow-composes-flow and flow-composes-workflow both raise at definition time)
- [x] Existing `flow_spec`, `workflow_spec`, `flow_registry_spec`, `flow_wrapper_spec`, `workflow_load_state_spec` pass unchanged

## Notes for review

This PR rewrites a lot of `lib/browserctl/workflow.rb`. PRs 8 and 10 of the v0.13 plan also touch this file (extracting `SessionRecoveryManager` and other concerns) and will follow sequentially. Sequencing is intentional to keep diffs reviewable.

No public class-level API changes — `Flow.new`, `WorkflowDefinition.new`, the global `Browserctl.flow` / `Browserctl.workflow` registries, and the `ParamDef` / `StepDef` constants are all preserved.