### PR TITLE
refactor: extract RecoveryManager from ContextualPersistence

### DIFF
--- a/lib/browserctl/contextual_persistence.rb
+++ b/lib/browserctl/contextual_persistence.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "workflow/recovery_manager"
+
 module Browserctl
   # Persistence-and-state DSL mixed into {WorkflowContext}. {FlowContext}
   # does NOT mix this in — that absence is the structural enforcement of
@@ -7,9 +9,10 @@ module Browserctl
   # the daemon-backed `store`/`fetch` and `.bctl` bundles.
   #
   # Hosts must expose `@client` and may expose `@replay_context` (for the
-  # selector-rematch fallback used elsewhere). Auth-required recovery
-  # delegates back to the host's `invoke` so flows bound to a saved
-  # bundle can rotate credentials transparently.
+  # selector-rematch fallback used elsewhere). Auth-required recovery is
+  # delegated to {Workflow::RecoveryManager}, which calls back into the
+  # host's `invoke` so flows bound to a saved bundle can rotate
+  # credentials transparently.
   module ContextualPersistence
     def store(key, value)
       res = @client.store(key.to_s, value)
@@ -38,58 +41,18 @@ module Browserctl
     end
 
     # Restores a .bctl bundle. When the daemon detects AUTH_REQUIRED before
-    # applying (e.g. expired cookies in the payload), this rotates the bound
-    # flow and retries — no caller code change required.
+    # applying (e.g. expired cookies in the payload), this delegates to
+    # {Workflow::RecoveryManager}, which rotates the bound flow and retries
+    # — no caller code change required.
     #
     # @param on_auth_required [Proc, nil] override the auto-rotate path. The
     #   block runs in the workflow context, in lieu of invoking the manifest's
     #   bound flow. Use this when the recovery procedure is bespoke.
     def load_state(name, on_auth_required: nil)
       res = @client.state_load(name.to_s)
-      return res unless auth_required_response?(res)
+      return res unless Workflow::RecoveryManager.auth_required?(res)
 
-      recover_auth_required_state(name.to_s, res, on_auth_required)
-    end
-
-    private
-
-    def auth_required_response?(res)
-      (res[:code] || res["code"]) == "AUTH_REQUIRED"
-    end
-
-    def recover_auth_required_state(name, initial_res, on_auth_required)
-      if on_auth_required
-        on_auth_required.call
-      else
-        flow_name = initial_res[:suggested_flow] || initial_res["suggested_flow"]
-        unless flow_name && !flow_name.to_s.empty?
-          raise WorkflowError,
-                "state '#{name}' needs auth but bundle has no bound flow — " \
-                "save with `save_state('#{name}', flow: :NAME)` or pass on_auth_required:"
-        end
-
-        # Match the daemon's `state load` preflight: it auth-checks the first
-        # open page (insertion order). Passing that same name to the flow
-        # gives stdlib flows a `page` proxy to drive (oauth_github reads
-        # `page.url`, totp_2fa calls `page.fill`, etc.). Falls back to no
-        # page only when nothing is open — `state_save` would have errored
-        # earlier in that case, so this is a defence-in-depth nil.
-        invoke(flow_name, page: first_open_page)
-      end
-
-      after_save = @client.state_save(name)
-      raise WorkflowError, after_save[:error] if after_save[:error]
-
-      retry_res = @client.state_load(name, skip_auth_check: true)
-      raise WorkflowError, retry_res[:error] if retry_res[:error]
-
-      retry_res.merge(rotated: true)
-    end
-
-    def first_open_page
-      res = @client.page_list
-      pages = res[:pages] || res["pages"] || []
-      pages.first
+      Workflow::RecoveryManager.new(self).recover(name.to_s, res, on_auth_required: on_auth_required)
     end
   end
 end

--- a/lib/browserctl/workflow/recovery_manager.rb
+++ b/lib/browserctl/workflow/recovery_manager.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Workflow
+    # Owns the AUTH_REQUIRED recovery state machine for `load_state`.
+    #
+    # When the daemon reports AUTH_REQUIRED on a `state_load` (e.g. expired
+    # cookies in the bundle), the manager either runs the bound flow or
+    # the caller-provided override, re-saves the bundle, and reloads it
+    # with `skip_auth_check: true`.
+    #
+    # Decoupled from {ContextualPersistence} so the multi-step recovery
+    # logic has a dedicated home and a dedicated spec. The host context
+    # only needs to expose `client` (for daemon RPCs) and `invoke` (for
+    # running the bound flow); see {ContextualPersistence#load_state}.
+    class RecoveryManager
+      AUTH_REQUIRED_CODE = "AUTH_REQUIRED"
+
+      # @param context [#client, #invoke] a workflow context exposing
+      #   the daemon client and an `invoke(flow_name, page:)` entry point.
+      def initialize(context)
+        @context = context
+      end
+
+      # True when `res` is the daemon's AUTH_REQUIRED preflight signal.
+      def self.auth_required?(res)
+        (res[:code] || res["code"]) == AUTH_REQUIRED_CODE
+      end
+
+      # Run recovery for `state_name` given the daemon's initial AUTH_REQUIRED
+      # response. Returns the merged retry result (with `rotated: true`) or
+      # raises {WorkflowError} when no flow is bound and no override is
+      # supplied, or when the post-rotation reload still fails.
+      #
+      # @param state_name      [String]  the bundle name being loaded
+      # @param initial_res     [Hash]    the original AUTH_REQUIRED response
+      # @param on_auth_required [Proc, nil] optional override; when given,
+      #   it runs in lieu of invoking the suggested flow.
+      def recover(state_name, initial_res, on_auth_required: nil)
+        if on_auth_required
+          on_auth_required.call
+        else
+          invoke_bound_flow(state_name, initial_res)
+        end
+
+        rotate_and_reload(state_name)
+      end
+
+      private
+
+      attr_reader :context
+
+      def invoke_bound_flow(state_name, initial_res)
+        flow_name = initial_res[:suggested_flow] || initial_res["suggested_flow"]
+        if flow_name.nil? || flow_name.to_s.empty?
+          raise WorkflowError,
+                "state '#{state_name}' needs auth but bundle has no bound flow — " \
+                "save with `save_state('#{state_name}', flow: :NAME)` or pass on_auth_required:"
+        end
+
+        # Match the daemon's `state load` preflight: it auth-checks the first
+        # open page (insertion order). Passing that same name to the flow
+        # gives stdlib flows a `page` proxy to drive (oauth_github reads
+        # `page.url`, totp_2fa calls `page.fill`, etc.). Falls back to no
+        # page only when nothing is open — `state_save` would have errored
+        # earlier in that case, so this is a defence-in-depth nil.
+        context.invoke(flow_name, page: first_open_page)
+      end
+
+      def rotate_and_reload(state_name)
+        after_save = context.client.state_save(state_name)
+        raise WorkflowError, after_save[:error] if after_save[:error]
+
+        retry_res = context.client.state_load(state_name, skip_auth_check: true)
+        raise WorkflowError, retry_res[:error] if retry_res[:error]
+
+        retry_res.merge(rotated: true)
+      end
+
+      def first_open_page
+        res = context.client.page_list
+        pages = res[:pages] || res["pages"] || []
+        pages.first
+      end
+    end
+  end
+end

--- a/spec/unit/workflow/recovery_manager_spec.rb
+++ b/spec/unit/workflow/recovery_manager_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/workflow/recovery_manager"
+require "browserctl/errors"
+
+RSpec.describe Browserctl::Workflow::RecoveryManager do
+  let(:client)  { instance_double(Browserctl::Client) }
+  let(:context) { instance_double("WorkflowContext", client: client) }
+  let(:manager) { described_class.new(context) }
+
+  describe ".auth_required?" do
+    it "returns true when symbol code is AUTH_REQUIRED" do
+      expect(described_class.auth_required?(code: "AUTH_REQUIRED")).to be(true)
+    end
+
+    it "returns true when string code is AUTH_REQUIRED" do
+      expect(described_class.auth_required?("code" => "AUTH_REQUIRED")).to be(true)
+    end
+
+    it "returns false on a fresh ok response" do
+      expect(described_class.auth_required?(ok: true, cookies: 4)).to be(false)
+    end
+
+    it "returns false on other error codes" do
+      expect(described_class.auth_required?(code: "NOT_FOUND")).to be(false)
+    end
+  end
+
+  describe "#recover" do
+    let(:auth_response) do
+      { error: "expired cookies", code: "AUTH_REQUIRED",
+        state: "github", suggested_flow: "github_login" }
+    end
+    let(:fresh_response) { { ok: true, cookies: 4 } }
+
+    before do
+      allow(client).to receive(:state_save).with("github").and_return(ok: true)
+      allow(client).to receive(:state_load).with("github", skip_auth_check: true)
+                                           .and_return(fresh_response)
+      allow(client).to receive(:page_list).and_return(pages: ["work"])
+      allow(context).to receive(:invoke)
+    end
+
+    it "invokes the suggested flow with the first open page, re-saves and reloads" do
+      result = manager.recover("github", auth_response)
+
+      expect(context).to have_received(:invoke).with("github_login", page: "work")
+      expect(client).to have_received(:state_save).with("github")
+      expect(client).to have_received(:state_load).with("github", skip_auth_check: true)
+      expect(result).to include(rotated: true, ok: true, cookies: 4)
+    end
+
+    it "passes page: nil when no pages are open (defence-in-depth)" do
+      allow(client).to receive(:page_list).and_return(pages: [])
+
+      manager.recover("github", auth_response)
+
+      expect(context).to have_received(:invoke).with("github_login", page: nil)
+    end
+
+    it "honours an explicit on_auth_required override over the auto path" do
+      ran = false
+      manager.recover("github", auth_response, on_auth_required: -> { ran = true })
+
+      expect(ran).to be(true)
+      expect(context).not_to have_received(:invoke)
+    end
+
+    it "raises WorkflowError when no flow is bound and no override given" do
+      expect do
+        manager.recover("github", { error: "expired", code: "AUTH_REQUIRED" })
+      end.to raise_error(Browserctl::WorkflowError, /no bound flow/)
+    end
+
+    it "raises WorkflowError when state_save fails after rotation" do
+      allow(client).to receive(:state_save).with("github").and_return(error: "save kaput")
+
+      expect { manager.recover("github", auth_response) }
+        .to raise_error(Browserctl::WorkflowError, "save kaput")
+    end
+
+    it "raises WorkflowError when the rotated reload still fails" do
+      allow(client).to receive(:state_load).with("github", skip_auth_check: true)
+                                           .and_return(error: "still bad")
+
+      expect { manager.recover("github", auth_response) }
+        .to raise_error(Browserctl::WorkflowError, "still bad")
+    end
+
+    it "reads suggested_flow under string keys too" do
+      string_auth = { "error" => "expired", "code" => "AUTH_REQUIRED",
+                      "suggested_flow" => "github_login" }
+
+      manager.recover("github", string_auth)
+
+      expect(context).to have_received(:invoke).with("github_login", page: "work")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR 8 of the v0.13 lean plan. Pulls the AUTH_REQUIRED recovery state machine out of `ContextualPersistence` into a dedicated `Browserctl::Workflow::RecoveryManager`.

- New `lib/browserctl/workflow/recovery_manager.rb` — single class, public surface: `RecoveryManager.auth_required?(res)` class predicate and `RecoveryManager.new(context).recover(state_name, initial_res, on_auth_required:)` instance entry point.
- `ContextualPersistence#load_state` delegates the recovery branch; the mixin keeps the public DSL methods (`store`/`fetch`/`save_state`/`load_state`) untouched.
- New `spec/unit/workflow/recovery_manager_spec.rb` covers the recovery flow in isolation: auto-rotate via the bound flow, defence-in-depth nil page, explicit `on_auth_required:` override, missing-flow / state_save-failure / reload-failure error paths, and string-key tolerance.

## Plan deviation

The plan (`docs/plans/v0.13-lean.md` PR 8) describes extracting from `WorkflowContext`, but PR 7 already moved this code into the `ContextualPersistence` mixin. Extraction targets the mixin instead — same shape, just one indirection later.

## Test plan

- [x] `bundle exec rspec spec/unit` — 772 examples, 0 failures
- [x] `bundle exec rubocop` — 222 files, no offenses
- [x] Existing `spec/unit/workflow_load_state_spec.rb` passes unchanged (verifies the delegation preserves observed behaviour through `WorkflowContext#load_state`)
- [x] New `spec/unit/workflow/recovery_manager_spec.rb` covers manager directly