### PR TITLE
fix(test): raise daemon start timeout to 30s for snap Chromium

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,9 @@ module BrowserctlHelpers
       ).run
     end
 
-    deadline = Time.now + 10
+    # Match Ferrum's process_timeout (30s) — snap-packaged Chromium on Ubuntu CI
+    # can take >10s on first launch while snapd mounts and applies security profiles.
+    deadline = Time.now + 30
     sleep 0.1 until File.exist?(socket) || Time.now > deadline
     raise "browserd failed to start" unless File.exist?(socket)
 


### PR DESCRIPTION
## Summary
- Bump the spec helper's `start_daemon` socket-wait deadline from 10s to 30s.
- Matches Ferrum's `process_timeout: 30` so the spec doesn't time out before the browser does.

## Why
The `Replay (chromium)` job intermittently fails with `browserd failed to start` (e.g. run 25632959161). On Ubuntu 22.04, `chromium-browser` is a snap shim — first launch on a fresh runner can exceed 10s while snapd mounts cores and applies security profiles. The previous run on the same workflow passed, confirming the failure mode is a timeout flake rather than a regression.

## Test plan
- [ ] Replay (chromium) job passes on this branch
- [ ] Re-run a few times to confirm the flake is gone