### PR TITLE
fix(daemon): sweep orphaned Ferrum chromes on browserd startup

### DIFF
--- a/lib/browserctl/orphan_sweeper.rb
+++ b/lib/browserctl/orphan_sweeper.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Browserctl
+  # Terminates orphaned Ferrum-spawned browser processes left behind by previous
+  # daemon or rspec runs that did not shut down cleanly (SIGKILL, OOM, crash).
+  #
+  # Only targets processes whose argv contains the Ferrum temp user-data-dir marker
+  # AND whose PPID is 1 — so children of any live daemon are never touched.
+  module OrphanSweeper
+    USER_DATA_DIR_MARKER = "ferrum_user_data_dir_"
+
+    module_function
+
+    def sweep(logger: Browserctl.logger, lister: method(:list_processes), killer: method(:kill_process))
+      return unless supported_platform?
+
+      orphans = find_orphans(lister.call)
+      return if orphans.empty?
+
+      logger&.info("orphan sweep: found #{orphans.size} stale browser process(es) from previous run")
+      orphans.each { |pid| killer.call(pid, logger) }
+    end
+
+    def find_orphans(processes)
+      processes.filter_map do |p|
+        next unless p[:ppid] == 1 && p[:command].to_s.include?(USER_DATA_DIR_MARKER)
+
+        p[:pid]
+      end
+    end
+
+    def list_processes
+      output = `ps -eo pid=,ppid=,command= 2>/dev/null`
+      return [] if output.empty?
+
+      output.lines.filter_map do |line|
+        pid, ppid, command = line.strip.split(" ", 3)
+        next unless pid && ppid && command
+
+        { pid: pid.to_i, ppid: ppid.to_i, command: command }
+      end
+    end
+
+    def kill_process(pid, logger)
+      Process.kill("TERM", pid)
+      logger&.info("orphan sweep: terminated PID #{pid}")
+    rescue Errno::ESRCH
+      # already gone
+    rescue Errno::EPERM
+      logger&.debug("orphan sweep: no permission to kill PID #{pid}")
+    end
+
+    def supported_platform?
+      !RUBY_PLATFORM.match?(/mingw|mswin|windows/)
+    end
+  end
+end

--- a/lib/browserctl/server.rb
+++ b/lib/browserctl/server.rb
@@ -6,6 +6,7 @@ require "fileutils"
 require "timeout"
 require_relative "constants"
 require_relative "logger"
+require_relative "orphan_sweeper"
 require_relative "driver/cdp_page"
 require_relative "driver/cdp"
 require_relative "server/command_dispatcher"
@@ -23,6 +24,7 @@ module Browserctl
 
     def run
       guard_already_running!
+      OrphanSweeper.sweep
       write_pid
       server, idle = setup_server
       serve(server)

--- a/spec/unit/orphan_sweeper_spec.rb
+++ b/spec/unit/orphan_sweeper_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/orphan_sweeper"
+
+RSpec.describe Browserctl::OrphanSweeper do
+  describe ".find_orphans" do
+    it "returns PIDs of ferrum-spawned chromes reparented to init" do
+      ferrum_a = "Chrome --user-data-dir=/tmp/ferrum_user_data_dir_a --headless"
+      ferrum_b = "Chrome --user-data-dir=/tmp/ferrum_user_data_dir_b"
+      processes = [
+        { pid: 100, ppid: 1,   command: ferrum_a },
+        { pid: 200, ppid: 1,   command: ferrum_b },
+        { pid: 300, ppid: 500, command: "Chrome --user-data-dir=/tmp/ferrum_user_data_dir_live" },
+        { pid: 400, ppid: 1,   command: "Chrome --user-data-dir=/some/other/profile" }
+      ]
+
+      expect(described_class.find_orphans(processes)).to contain_exactly(100, 200)
+    end
+
+    it "ignores ferrum-spawned chromes whose parent is still alive" do
+      processes = [
+        { pid: 100, ppid: 12_345, command: "Chrome --user-data-dir=/tmp/ferrum_user_data_dir_live" }
+      ]
+
+      expect(described_class.find_orphans(processes)).to be_empty
+    end
+
+    it "returns nothing for an empty process list" do
+      expect(described_class.find_orphans([])).to be_empty
+    end
+  end
+
+  describe ".sweep" do
+    let(:logger) { instance_double(Logger, info: nil, debug: nil) }
+
+    it "kills every detected orphan via the injected killer" do
+      processes = [
+        { pid: 100, ppid: 1, command: "Chrome --user-data-dir=/tmp/ferrum_user_data_dir_a" },
+        { pid: 200, ppid: 1, command: "Chrome --user-data-dir=/tmp/ferrum_user_data_dir_b" }
+      ]
+      killed = []
+      killer = ->(pid, _log) { killed << pid }
+
+      described_class.sweep(logger: logger, lister: -> { processes }, killer: killer)
+
+      expect(killed).to contain_exactly(100, 200)
+    end
+
+    it "does nothing when no orphans are present" do
+      killed = []
+      killer = ->(pid, _log) { killed << pid }
+
+      described_class.sweep(logger: logger, lister: -> { [] }, killer: killer)
+
+      expect(killed).to be_empty
+    end
+
+    it "is a no-op on Windows" do
+      stub_const("RUBY_PLATFORM", "x86_64-mingw32")
+      lister_called = false
+      lister = lambda do
+        lister_called = true
+        []
+      end
+
+      described_class.sweep(logger: logger, lister: lister, killer: ->(_pid, _log) {})
+
+      expect(lister_called).to be false
+    end
+  end
+
+  describe ".kill_process" do
+    let(:logger) { instance_double(Logger, info: nil, debug: nil) }
+
+    it "swallows ESRCH when the process is already gone" do
+      allow(Process).to receive(:kill).and_raise(Errno::ESRCH)
+      expect { described_class.kill_process(999, logger) }.not_to raise_error
+    end
+
+    it "swallows EPERM when we lack permission" do
+      allow(Process).to receive(:kill).and_raise(Errno::EPERM)
+      expect { described_class.kill_process(999, logger) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Cleans up the leak reported in #176. When `browserd` (or an rspec integration run) dies without going through `Driver::CDP#quit`, the Ferrum-spawned Chrome stays alive because of Ferrum's `--keep-alive-for-test` default and gets reparented to PID 1. These accumulate — I just swept ~200 locally.

This PR adds a startup sweep in `browserd`:

- New `Browserctl::OrphanSweeper` module (`lib/browserctl/orphan_sweeper.rb`).
- Identifies orphans by two-factor match: argv contains `ferrum_user_data_dir_` **and** PPID is 1. The PPID=1 guard means a concurrently running daemon's Chrome (PPID=daemon\_pid) is never touched.
- Called once at the top of `Server#run`, before the socket is opened. By that point our own newly spawned Chrome has PPID=daemon\_pid, so the sweep can't kill it.
- Skipped on Windows (no POSIX `ps`).
- `SIGTERM`, not `SIGKILL` — gives Chrome a chance to clean up its own temp dir. `ESRCH` / `EPERM` are swallowed.

## Out of scope (deliberately)

- `at_exit` safety net — wouldn't help the actual leak case (SIGKILL skips Ruby's exit hooks).
- Spec-helper teardown for interrupted rspec runs — separate concern, can land later.
- Sweeping stale `ferrum_user_data_dir_*` temp dirs — risk of racing concurrent daemons. The startup sweep alone is the high-value piece.

## Test plan

- [x] `bundle exec rspec spec/unit/orphan_sweeper_spec.rb spec/unit/server_spec.rb` — 10 examples, 0 failures
- [x] `bundle exec rubocop lib/browserctl/orphan_sweeper.rb lib/browserctl/server.rb spec/unit/orphan_sweeper_spec.rb` — clean
- [ ] Manual: kill a `browserd` with `SIGKILL`, confirm leaked Chrome, restart `browserd`, observe sweep log line and Chrome gone

Closes #176