### PR TITLE
docs: add v0.13 lean and v0.14 polish plans

### DIFF
--- a/docs/plans/v0.13-lean.md
+++ b/docs/plans/v0.13-lean.md
@@ -1,0 +1,371 @@
+# v0.13 — Lean: execution plan
+
+> Companion to v0.12 ("Solid"). v0.12 hardens what exists; v0.13 cuts what shouldn't.
+> Per-PR breakdown intended to be picked up by any contributor (human or agent) cold,
+> without prior session context.
+
+## Goal
+
+Earn the right to lock the 1.0 surface by removing accreted complexity, retiring
+deprecated paths, and consolidating the CLI grammar. **All breaking changes land in
+this single milestone** so users absorb breakage in one upgrade window.
+
+## Non-goals
+
+- New product surface, commands, or workflow features.
+- Deprecation aliases or shim layers — direct removal, breaking changes are explicit.
+- Wire-protocol consolidation (cookies vs storage). Deferred to v2.0 and documented as such.
+- 1.0 itself. v0.13 ships, then we run on it for two months before cutting 1.0.
+
+## Dependencies
+
+- v0.12 must ship first (format-versioning, error model, observability, test pyramid).
+- Anyone executing this plan should read `docs/reference/api-stability.md` first to
+  understand the Fixed / Stable / Extension zone split. v0.13 narrows the Fixed zone
+  in a few well-defined places; the wire protocol stays untouched.
+
+## Conventions for every PR in this plan
+
+- Branch off `main`, open a PR, never push to `main`.
+- Conventional Commits: `feat!:` / `refactor:` / `chore:` / `docs:`.
+- Add `BREAKING CHANGE:` footer to commits in WS-1 (release-please picks this up).
+- No `Co-Authored-By` lines. No "Generated with Claude Code" or AI attribution
+  anywhere project-facing.
+- New error paths get table-driven integration tests via the v0.12 error code enum.
+- All persisted artifacts must keep their `version:` header (per v0.12 WS-1).
+
+---
+
+## WS-1 · Surface cuts (BREAKING)
+
+**Outcome:** The user-facing surface has fewer concepts, consistent grammar, and a
+narrower Fixed zone. Bunch all breakage into the early PRs of this workstream.
+
+### PR 1 · `chore: delete unused driver abstraction`
+
+ADR-0012 mandated a browser-agnostic driver layer. Inspection: `Driver::Base`
+(13 LOC stub), `driver.rb` (5-line re-export), and `Driver::CDP` (the only
+subclass). No handler code uses the abstract interface; Brave/Chromium support
+already lives inside CDP via the `browser:` constructor param. The abstraction
+earns zero rent today.
+
+**Files:**
+- Delete `lib/browserctl/driver/base.rb`
+- Delete `lib/browserctl/driver.rb` (re-export shim)
+- Flatten `lib/browserctl/driver/cdp.rb` and `cdp_page.rb` if the namespace is
+  now redundant (decide one — keep the `Browserctl::Driver::CDP` namespace, or
+  promote to `Browserctl::CDP`).
+- Update `require_relative` in `lib/browserctl.rb`.
+- Strike or amend `docs/architecture/decisions/0012-browser-agnostic-driver.md`
+  with a "deferred until a second driver exists" note.
+
+**Acceptance:** `bundle exec rspec` green. `bundle exec rubocop` green.
+ADR-0012 marked superseded.
+
+**Risk:** None. Nothing references `Driver::Base`.
+
+---
+
+### PR 2 · `feat!: remove session commands and code path`
+
+The CLI carries both `session *` and `state *`. `state` is the better-designed
+successor (single portable `.bctl` file, encryption, flow binding, transport
+pluggability). Today the docs say "use `state` 99% of the time" — at v0.13 we
+commit fully. **No migrate command, no warning period.** Users on v0.12 sessions
+must re-capture state via `state save` before upgrading.
+
+**Files to delete:**
+- `lib/browserctl/commands/session.rb`
+- `lib/browserctl/session.rb`
+- All session-related specs and fixtures under `spec/`.
+
+**Files to edit (strip session paths):**
+- `lib/browserctl/workflow.rb` — remove `load_session` / `recover_expired_session`
+  references; keep state-only recovery via `recover_auth_required_state`.
+- `lib/browserctl/client.rb` — remove session-related methods.
+- `docs/reference/commands.md` — remove the session table.
+- `docs/reference/api-stability.md` — remove session entries from the Stable zone.
+- `docs/reference/compatibility.md` — record the v0.13 removal.
+
+**Release notes:** add upgrade paragraph to the release-please CHANGELOG entry —
+"users on v0.12 sessions must regenerate via `state save` before upgrading."
+
+**Acceptance:** `rspec` green; no `session` references remain in `lib/` or `docs/`.
+`grep -r "load_session\|session_save" lib/ spec/` returns nothing.
+
+**Risk:** Medium. Touches workflow recovery code. Keep state-rotation tests intact.
+
+---
+
+### PR 3 · `feat!: noun-verb CLI consistency`
+
+Today four commands break the noun-verb pattern: `snapshot`, `screenshot`,
+`record`, `trace`. Every other verb pairs with a noun (`page open`, `cookie list`,
+`storage set`, `state save`, `workflow run`).
+
+**Renames (direct, no aliases):**
+
+| Before | After |
+|---|---|
+| `browserctl snapshot <page> [...]` | `browserctl page snapshot <name> [...]` |
+| `browserctl screenshot <page> [...]` | `browserctl page screenshot <name> [...]` |
+| `browserctl record start <name>` | `browserctl recording start <name>` |
+| `browserctl record stop` | `browserctl recording stop` |
+| `browserctl record status` | `browserctl recording status` |
+| `browserctl trace [<name>]` | unchanged — debug-time top-level read |
+
+**Wire protocol unchanged.** The JSON-RPC commands `snapshot` and `screenshot`
+on the Unix socket stay exactly as documented — only the CLI grammar changes.
+This keeps the Fixed zone intact.
+
+**Files:**
+- `bin/browserctl` — update top-level dispatcher.
+- `lib/browserctl/commands/snapshot.rb` → move under a `Page` namespace dispatch.
+- `lib/browserctl/commands/screenshot.rb` → ditto.
+- `lib/browserctl/commands/record.rb` → rename file to `recording.rb`; class
+  `Browserctl::Commands::Record` → `Browserctl::Commands::Recording`.
+- `lib/browserctl/commands/page.rb` — register `snapshot` and `screenshot` subcommands.
+- `docs/reference/commands.md` — rewrite the Interaction and Capture sections.
+- `examples/**` — update every script that uses the old verbs.
+- `rakelib/smoke/**` — update smoke-task command lines.
+- Integration specs under `spec/integration/` — update CLI invocations.
+
+**Acceptance:** `rspec` green. `examples/test_automation_practices` and
+`examples/the_internet` run end-to-end. `rake smoke:all` green.
+
+**Risk:** Medium. Wide touch but mechanical.
+
+---
+
+### PR 4 · `feat!: narrow Fixed zone — store/fetch and known overlaps`
+
+Docs-only edit. The `store`/`fetch` daemon KV is currently in the Fixed zone but
+has no TTL, no scoping, and minimal documentation. Locking it as Fixed at 1.0
+forecloses post-1.0 evolution. Cookies and storage have overlapping wire commands
+(`set_cookie`/`import_cookies`/`export_cookies`/`delete_cookies` mirror
+`storage_*`) — this is real but the consolidation cost is too high pre-1.0.
+
+**Files:**
+- `docs/reference/api-stability.md` —
+  - Move `store` / `fetch` from Fixed → Extension. Document limits explicitly:
+    no TTL, no scoping, per-daemon (not per-session) lifetime.
+  - Add a "Known overlapping surfaces — consolidation deferred to v2.0" section
+    naming the cookie/storage parallel APIs and committing to addressing them
+    only at the next major.
+
+**Acceptance:** stability doc reviewed by the maintainer; CHANGELOG entry notes
+the zone narrowing.
+
+**Risk:** None — pure stability-promise edit.
+
+---
+
+### PR 5 · `feat!: unified --output {json,text,silent} on every CLI command`
+
+The README claims "AI-friendly," but most commands have ad-hoc text output and
+structured JSON only on errors. v0.12 WS-2 makes errors structured; v0.13 makes
+the rest of the surface match.
+
+**Implementation:**
+- New module `lib/browserctl/commands/output_format.rb` exposing
+  `OutputFormat.from(flag, env)` and `OutputFormat#emit(payload, text_block)`.
+- Every command in `lib/browserctl/commands/*.rb` accepts `--output`. Default
+  resolution order: explicit flag → `BROWSERCTL_OUTPUT` env var → `text`.
+- `text` output stays byte-identical to today's output where possible — this
+  PR does not redesign user-facing prose, only adds the JSON path.
+- `silent` suppresses stdout entirely, exit codes still carry the result.
+
+**Files:**
+- New: `lib/browserctl/commands/output_format.rb` + spec.
+- Edit: every file under `lib/browserctl/commands/*.rb`.
+- Edit: `lib/browserctl/commands/cli_output.rb` — wire the formatter in.
+- Edit: `docs/reference/commands.md` — document the flag and env var once,
+  then reference from each command section.
+- Edit: `docs/guides/agents.md` (or create) — agent recipe using
+  `BROWSERCTL_OUTPUT=json`.
+
+**Acceptance:**
+- `BROWSERCTL_OUTPUT=json browserctl page list` returns valid JSON.
+- `browserctl page list` (no flag) produces unchanged text output — verified by
+  golden-file test.
+- New integration spec covers all three modes for at least one command per
+  domain (page, cookie, storage, state, workflow).
+
+**Risk:** Wide touch but mechanical. Pairs with v0.12 WS-2 — this PR completes
+the agent-friendly contract by making structured output reachable from every
+command, not only error paths.
+
+---
+
+## WS-2 · Internal refactors (NO wire change, NO breaking change)
+
+These touch internals only. They can land in any order and in parallel after WS-1
+stabilizes. No `BREAKING CHANGE:` footer needed. Public method signatures of
+`Browserctl::Client` and `PageProxy` stay stable.
+
+### PR 6 · `refactor: split Recording into focused objects`
+
+`lib/browserctl/recording.rb` is 27 methods / ~390 LOC. It owns recording I/O,
+redaction, log formatting, JSON parsing, timestamp inference, secret-field
+detection, and dispatch to workflow generation.
+
+**Carve out:**
+- `Browserctl::Recording::Redactor` — secret-aware redaction.
+- `Browserctl::Recording::State` — singleton over `STATE_FILE` marker.
+- `Browserctl::Recording::LogWriter` — log file I/O and JSONL formatting.
+
+`Recording` becomes a thin facade. Keep its public interface stable for any
+plugin consumers.
+
+**Acceptance:** `recording.rb` < 150 LOC; each extracted object has its own spec
+file; existing integration specs unchanged.
+
+---
+
+### PR 7 · `refactor: extract CallableDefinition base for Flow/Workflow`
+
+`lib/browserctl/workflow.rb` (559 LOC) and `lib/browserctl/flow.rb` (215 LOC)
+share param/step/retry/timeout DSL via duplication. `WorkflowContext` and
+`FlowContext` are near-twins. The doctrinal distinction (flows return state,
+workflows share state via `store`/`fetch`) is enforced by whitelisting at
+runtime, not by structure — easy to break in code review.
+
+**Refactor:**
+- New `lib/browserctl/callable_definition.rb` holding shared DSL.
+- `Flow` and `Workflow` inherit from `CallableDefinition`.
+- `WorkflowContext` mixes a new `ContextualPersistence` module that `FlowContext`
+  does not — the persistence whitelist becomes structural.
+- Cross-type calls (e.g. flow invoking a workflow) raise at definition time, not
+  at runtime.
+
+**Acceptance:** existing flow + workflow specs pass unchanged; new spec asserts
+cross-type calls raise at definition time.
+
+---
+
+### PR 8 · `refactor: extract SessionRecoveryManager from WorkflowContext`
+
+After PR 2 there is no session path, but WorkflowContext still owns
+`recover_auth_required_state` and `load_after_fallback`
+(currently `lib/browserctl/workflow.rb:236–320`). This is multi-step recovery
+logic that doesn't belong to the context object.
+
+**Refactor:**
+- New `lib/browserctl/workflow/recovery_manager.rb` (or
+  `state_recovery_manager.rb`).
+- WorkflowContext delegates the recovery flow to it.
+
+**Acceptance:** `workflow.rb` drops below ~450 LOC; recovery has its own
+dedicated spec file.
+
+---
+
+### PR 9 · `refactor: value object for State.save`
+
+`Browserctl::State.save` takes 5+ keyword args (cookies, storage, metadata,
+origins, encrypt, ...). Order-sensitive in callers, brittle to extend.
+
+**Refactor:**
+- New `Browserctl::State::Payload` struct (or `Data.define`) bundling the
+  fields.
+- `State.save(name, payload)` becomes the only signature. No shim — internal
+  refactor, callers updated in the same PR.
+
+**Acceptance:** all `State.save` call sites updated; existing state specs pass
+unchanged.
+
+---
+
+### PR 10 · `refactor: PageProxy delegate_unwrap macro`
+
+`lib/browserctl/workflow.rb:366–417` has ~15 one-liner `unwrap @client.METHOD(@name, ...)`
+methods. Boilerplate that's easy to get wrong (forgetting `unwrap`, wrong arg
+order). Each new page method requires more boilerplate.
+
+**Refactor:**
+- Add `delegate_unwrap` class macro to PageProxy.
+- Replace the 15 explicit methods with one declarative line per signature shape.
+
+**Acceptance:** PageProxy LOC drops ~40%; public method surface byte-identical
+(checked via `PageProxy.public_instance_methods - Object.public_instance_methods`
+diff in a spec).
+
+---
+
+### PR 11 · `refactor: EncryptionService consolidates keychain + cipher`
+
+After PR 2 (session removal), encryption logic lives in `State::Bundle` plus
+private helpers. Pull it together so the contract is explicit and testable.
+
+**Files:**
+- New `lib/browserctl/encryption_service.rb` owning keychain interaction and
+  cipher setup.
+- `State::Bundle` delegates encrypt/decrypt to it.
+
+**Depends on:** PR 2 must land first (so the Session encryption path is gone
+and we're consolidating only one caller).
+
+**Acceptance:** every encryption test passes via the new service. `State::Bundle`
+no longer references `OpenSSL::Cipher` directly.
+
+---
+
+### PR 12 · `refactor: split CommandDispatcher#dispatch into builtin/plugin paths`
+
+`lib/browserctl/server/command_dispatcher.rb:101–114` mixes builtin command
+routing with plugin fallback; logging is duplicated, plugin session lookup is
+manual.
+
+**Refactor:**
+- Extract `dispatch_builtin` and `dispatch_plugin` private methods.
+- Pull plugin logging + session lookup into a small `PluginDispatcher` helper
+  if it cleans up the call site (judgment call — don't over-extract).
+
+**Acceptance:** main `dispatch` method drops to ~5 lines; plugin handler
+integration spec unchanged.
+
+---
+
+## Sequencing
+
+```
+v0.12 ships (WS-1..5 from v0.12-solid.md)
+         │
+         ▼
+v0.13 opens
+         │
+         ├── PR 1 (driver delete — zero-risk warmup)
+         ├── PR 4 (docs-only zone narrowing)
+         │
+         ├── PR 2 (remove session)        ─┐
+         ├── PR 3 (CLI noun-verb)          ├── breaking changes, bunched
+         ├── PR 5 (--output flag)         ─┘
+         │
+         └── PRs 6, 7, 8, 9, 10, 12 in parallel (internal refactors)
+             PR 11 waits on PR 2.
+
+v0.13 ships → 2-month soak → 1.0
+```
+
+## Acceptance for the milestone
+
+- All breaking changes shipped in one window; no deprecation aliases linger.
+- `state` is the only persistence command; `session` removed.
+- Every CLI command obeys noun-verb grammar (modulo `trace` as a documented exception).
+- `--output {json,text,silent}` works on every command.
+- Fixed zone in `api-stability.md` is narrower than at v0.12; `store`/`fetch`
+  are explicitly Extension.
+- `lib/browserctl/workflow.rb` < 450 LOC; `lib/browserctl/recording.rb` < 150 LOC.
+- Driver abstraction removed; ADR-0012 superseded.
+- All v0.12 acceptance criteria still hold (formats versioned, errors typed,
+  observability intact).
+
+## Open routing decision (resolve before PR 3)
+
+PR 3 chose **`page snapshot` / `page screenshot` / `recording …`** with `trace`
+remaining top-level. Alternative considered: `capture snapshot|screenshot` /
+`observation trace` umbrellas. The `page`-prefixed form was chosen because every
+existing capture command already takes a page name as its first argument —
+nesting under `page` matches existing grammar without inventing new umbrellas.
+Flip to umbrellas if you'd rather keep page commands purely about lifecycle
+and interaction.

--- a/docs/plans/v0.14-polish.md
+++ b/docs/plans/v0.14-polish.md
@@ -1,0 +1,348 @@
+# v0.14 — Polish: execution plan
+
+> Companion to v0.12 ("Solid") and v0.13 ("Lean"). v0.12 hardened, v0.13 cut.
+> v0.14 polishes the internals so the 1.0 surface earns its lock.
+
+## Goal
+
+Close the remaining hygiene gaps before 1.0: complete the typed-error sweep
+the v0.12 cop only partially enforces, decouple the few internal boundaries
+that still leak, and finish the command-layer extractions v0.13 didn't have
+budget for. **No new user-facing surface. No breaking changes.** Public method
+signatures of `Browserctl::Client` and `PageProxy` stay byte-identical.
+
+## Non-goals
+
+- New commands, flows, or workflow features.
+- Wire-protocol changes (Fixed zone is frozen — that's the whole point of 1.0).
+- Breaking changes to the Stable zone. CLI grammar from v0.13 is the 1.0 grammar.
+- Deprecation aliases — there's nothing left to deprecate after v0.13.
+- 1.0 itself. v0.14 ships, the two-month soak resumes from the v0.14 release date.
+
+## Dependencies
+
+- v0.13 must ship first. All v0.13 PRs (session removal, noun-verb CLI,
+  unified `--output`, `store`/`fetch` zone narrowing) must be merged before
+  any v0.14 work begins — v0.14 assumes the v0.13 surface as its baseline.
+- Anyone executing this plan should re-read `docs/reference/api-stability.md`
+  before opening a PR. v0.14 does not move any boundary; it only tidies the
+  inside.
+
+## Conventions for every PR in this plan
+
+- Branch off `main`, open a PR, never push to `main`.
+- Conventional Commits: `refactor:` / `chore:` / `test:` / `docs:`. No `feat!:`
+  in this milestone — anything that wants to be breaking belongs in a future
+  major.
+- No `Co-Authored-By` lines. No "Generated with Claude Code" or AI attribution
+  anywhere project-facing.
+- New error paths get table-driven integration tests via the v0.12 error code
+  enum.
+- Public surface diff check: every PR runs
+  `Browserctl::Client.public_instance_methods - Object.public_instance_methods`
+  against `main` and asserts no drift.
+
+---
+
+## WS-1 · Typed-error completion
+
+**Outcome:** The `Browserctl/TypedError` cop covers every raise in `lib/`. Agents
+can branch on error codes for validation failures, not only runtime failures.
+
+The v0.12 sweep typed all runtime errors but left validation guards on public
+APIs raising bare `ArgumentError`. Confirmed gaps:
+
+- `lib/browserctl/client.rb:51, 64, 246, 258, 270` — selector/ref guards on
+  `click`, `fill`, `hover`, `upload`, `select`.
+- `lib/browserctl/state.rb:86` — state name validation.
+- `lib/browserctl/flow.rb:66, 72, 78, 90, 96, 116, 169` — DSL validation guards.
+- `lib/browserctl/callable_definition.rb:51` — step block presence.
+- `lib/browserctl/migrations.rb:45` — upgrade block presence.
+- `lib/browserctl/format_version.rb:32` — version integer guard.
+
+### PR 1 · `feat: validation error codes`
+
+Add a new family of codes to `Browserctl::Error::Codes`: `VALIDATION_FAILED`
+as the parent, plus `INVALID_SELECTOR_REF`, `INVALID_STATE_NAME`,
+`INVALID_DSL_USAGE`, `INVALID_FORMAT_VERSION`. Map each to exit code `8`
+("validation error") in `docs/reference/exit-codes.md` and `lib/browserctl/error/exit_codes.rb`.
+
+**Files:**
+- Edit `lib/browserctl/error/codes.rb`.
+- Edit `lib/browserctl/error/exit_codes.rb` and `lib/browserctl/error/suggested_actions.rb`.
+- Edit `docs/reference/errors.md` and `docs/reference/exit-codes.md`.
+
+**Acceptance:** new codes appear in the error reference doc; exit-code map
+includes `8`; existing exit codes unchanged.
+
+**Risk:** None. Pure additive.
+
+### PR 2 · `refactor: typed errors on Client validation guards`
+
+Replace the five `ArgumentError` raises in `client.rb` with
+`Browserctl::Error.new(code: Codes::INVALID_SELECTOR_REF, ...)`. Keep the
+human message identical so CLI output is unchanged.
+
+**Files:**
+- Edit `lib/browserctl/client.rb`.
+- Add table-driven spec for each of the five methods covering the missing-arg
+  path.
+
+**Acceptance:** `bundle exec rubocop` green (the cop now passes on `client.rb`
+without inline disables); `rspec` green; CLI stderr for a missing-selector call
+now includes `"code": "INVALID_SELECTOR_REF"` in JSON mode and unchanged prose
+in text mode.
+
+**Risk:** Low. Adds a JSON field to an error path; no caller can rely on its
+absence.
+
+### PR 3 · `refactor: typed errors on State name validation`
+
+Convert `state.rb:86` to `INVALID_STATE_NAME`. Mirror PR 2's pattern.
+
+**Files:** `lib/browserctl/state.rb`, matching spec.
+
+**Acceptance:** invalid name rejected with code; valid names accepted.
+
+**Risk:** None.
+
+### PR 4 · `refactor: typed errors on DSL guards`
+
+Convert the eight validation raises in `flow.rb`, `callable_definition.rb`,
+`migrations.rb`, `format_version.rb` to `INVALID_DSL_USAGE` or
+`INVALID_FORMAT_VERSION`.
+
+**Files:** the four library files above and their specs.
+
+**Acceptance:** definition-time errors carry codes; specs assert codes, not
+prose. `grep -rn "raise ArgumentError" lib/` returns nothing.
+
+**Risk:** Low. These raise at DSL definition time — broken usage fails fast
+either way.
+
+### PR 5 · `chore: remove TypedError cop disables`
+
+After PRs 2–4 the cop should run without any inline `# rubocop:disable
+Browserctl/TypedError` comments. Sweep and remove. Tighten the cop config to
+fail CI on new violations.
+
+**Files:** `lib/`, `.rubocop.yml`.
+
+**Acceptance:** `git grep TypedError` returns only the cop definition and its
+spec.
+
+**Risk:** None.
+
+---
+
+## WS-2 · Internal boundary cleanup
+
+**Outcome:** Two leaky internal couplings are removed. Recording is no longer
+hard-wired into `Client`; the daemon-side and CLI-side `State` modules are
+namespaced distinctly so the file tree reads at a glance.
+
+### PR 6 · `refactor: extract RecordingInterceptor from Client`
+
+`lib/browserctl/client.rb` couples every `call()` to `Recording.append` at
+line 18, and inlines `Recording.active ? true : nil` at lines 54 and 67 for
+post-snapshot capture. Move this into a `Client::RecordingInterceptor` that
+wraps `call`, so `Client` stays a pure IPC shim.
+
+**Files:**
+- New `lib/browserctl/client/recording_interceptor.rb`.
+- Edit `lib/browserctl/client.rb` — `call` becomes `interceptors.reduce(...)`
+  or a simpler explicit wrapping; drop the `Recording.active` literal at
+  `click` / `fill` call sites in favour of the interceptor reading state.
+- Add spec covering: recording-off path (interceptor no-op), recording-on
+  path (append happens exactly once per successful call).
+
+**Acceptance:** `Client.public_instance_methods` diff against `main` is empty;
+`grep -n Recording lib/browserctl/client.rb` returns nothing; existing
+recording integration specs unchanged.
+
+**Risk:** Medium. Recording is hot-path. Add a smoke spec that records a real
+workflow end-to-end and replays it.
+
+### PR 7 · `refactor: rename Handlers::State to Handlers::StateRpc`
+
+`lib/browserctl/commands/state.rb` (CLI) and `lib/browserctl/server/handlers/state.rb`
+(JSON-RPC) both export a class called `State`. The directory disambiguates,
+but the symbol does not. Rename the handler module to `StateRpc` (or move all
+handler modules under `Browserctl::Server::JsonRpc::*` — pick one and apply
+consistently).
+
+**Files:**
+- Edit `lib/browserctl/server/handlers/state.rb` and every handler file under
+  `lib/browserctl/server/handlers/`.
+- Edit `lib/browserctl/server/command_dispatcher.rb` for the include list.
+
+**Acceptance:** No two top-level modules in `lib/` share a class name. Specs
+unchanged.
+
+**Risk:** Low. Internal-only.
+
+### PR 8 · `refactor: narrow bare rescues in navigation and logger`
+
+Two bare `rescue StandardError` clauses swallow more than they should:
+
+- `lib/browserctl/server/handlers/navigation.rb:78` —
+  `capture_post_snapshot_digest` silently discards snapshot failures. Narrow
+  to `JSON::ParserError, Timeout::Error, Browserctl::Error` and log discarded
+  exceptions at `debug` level.
+- `lib/browserctl/logger.rb:135` — `build_jsonl_logger` returns `nil` on any
+  error during log device construction. Narrow to `Errno::*` and `IOError`;
+  re-raise anything else.
+
+**Files:** the two library files above; matching specs covering the rescue
+branches.
+
+**Acceptance:** specs assert that unexpected exceptions propagate; expected
+exceptions are still handled. No behaviour change on the happy path.
+
+**Risk:** Low. The change makes failures louder, which is the goal.
+
+---
+
+## WS-3 · Command-layer extractions
+
+**Outcome:** The two largest command files (`trace.rb` 216 LOC, `state.rb` 194
+LOC) get their rendering and business logic carved out so the command file
+itself is a thin CLI parser.
+
+### PR 9 · `refactor: extract TraceRenderer from commands/trace`
+
+`lib/browserctl/commands/trace.rb` mixes JSONL parsing, event categorisation,
+colorisation, timeline rendering, and redaction. Extract:
+
+- `Browserctl::Trace::Renderer` — owns timeline formatting and colour.
+- `Browserctl::Trace::EventStream` — owns JSONL parsing and event grouping.
+
+`Commands::Trace` becomes a thin CLI dispatcher reading flags and handing the
+stream to the renderer. Reuse `Browserctl::Redactor` (no new redaction
+implementation).
+
+**Files:**
+- New `lib/browserctl/trace/renderer.rb`, `lib/browserctl/trace/event_stream.rb`.
+- Edit `lib/browserctl/commands/trace.rb` — drop to <80 LOC.
+- New specs for the extracted classes; existing trace integration spec
+  unchanged.
+
+**Acceptance:** `commands/trace.rb` < 80 LOC; `trace --redact` output
+byte-identical to `main` on a golden-file fixture.
+
+**Risk:** Low. Output is verified by golden file.
+
+### PR 10 · `refactor: extract StateMutator from commands/state`
+
+`lib/browserctl/commands/state.rb` mixes CLI parsing with `run_rotate`,
+`parse_origins`, `prompt_passphrase`, and `state_needs_passphrase?`. Extract
+a `Browserctl::State::Mutator` that owns rotation (flow lookup, param merge,
+re-save) so the logic is reusable from `Workflow` and testable without
+spawning a CLI.
+
+**Files:**
+- New `lib/browserctl/state/mutator.rb`.
+- Edit `lib/browserctl/commands/state.rb` — drop to <120 LOC.
+- New spec for `State::Mutator` covering rotation success and failure paths.
+
+**Acceptance:** `state rotate` CLI behaviour unchanged (covered by existing
+integration spec); `State::Mutator` callable directly from Ruby code without
+touching `Commands::State`.
+
+**Risk:** Low. Pure internal extraction.
+
+---
+
+## WS-4 · Public surface guard
+
+**Outcome:** A CI check prevents accidental drift in the Stable zone.
+
+### PR 11 · `test: public surface lock-file`
+
+Add a spec that dumps `Browserctl::Client.public_instance_methods`,
+`Browserctl::Workflow::PageProxy.public_instance_methods`, and the CLI
+command list to a fixture file, and fails CI if the live surface diverges
+from the fixture. Updating the fixture is an explicit step in any PR that
+intentionally changes the Stable zone.
+
+**Files:**
+- New `spec/public_surface_spec.rb`.
+- New fixture `spec/fixtures/public_surface.yml`.
+- Document the update workflow in `docs/reference/api-stability.md`.
+
+**Acceptance:** spec passes on `main` post-v0.13; deliberate surface changes
+require a fixture update in the same PR.
+
+**Risk:** None. Test-only.
+
+---
+
+## Sequencing
+
+```
+v0.13 ships
+         │
+         ▼
+v0.14 opens
+         │
+         ├── PR 1  (validation codes — additive warmup)
+         │      │
+         │      ▼
+         ├── PR 2, 3, 4 in parallel (typed-error sweeps)
+         │      │
+         │      ▼
+         ├── PR 5  (remove cop disables, tighten cop)
+         │
+         ├── PR 6  (Recording interceptor — medium risk, do early)
+         ├── PR 7  (Handlers rename — mechanical, any time)
+         ├── PR 8  (rescue narrowing — any time)
+         │
+         ├── PR 9  (TraceRenderer)
+         ├── PR 10 (StateMutator)
+         │
+         └── PR 11 (public surface lock)
+```
+
+WS-1 is sequenced (PR 1 must land before 2–4; 5 must come last). WS-2, WS-3,
+WS-4 are independent and can land in any order once WS-1 PR 1 is in.
+
+## Acceptance for the milestone
+
+- `git grep "raise ArgumentError\|raise RuntimeError\|raise StandardError" lib/`
+  returns nothing.
+- No `# rubocop:disable Browserctl/TypedError` comments remain in `lib/`.
+- `grep -n Recording lib/browserctl/client.rb` returns nothing.
+- `lib/browserctl/commands/trace.rb` < 80 LOC.
+- `lib/browserctl/commands/state.rb` < 120 LOC.
+- Public surface lock-file spec is green on `main`.
+- `bundle exec rspec` and `bundle exec rubocop` both green.
+- All v0.12 + v0.13 acceptance criteria still hold (formats versioned, errors
+  typed, observability intact, surface narrow).
+
+## What v0.14 deliberately does NOT do
+
+These came up during the v0.13 self-review and were considered for v0.14;
+recording the decisions here so they don't get rediscovered.
+
+- **`migrations.rb` rework** — ships empty by design, kept for the first
+  post-1.0 format change. No work needed.
+- **`Driver::CDP` namespace flatten to `Browserctl::CDP`** — v0.13 PR 1 left
+  the question open. Pick one in v0.14 if energy permits; otherwise defer to
+  1.0-prerelease cleanup. Not on the critical path.
+- **Snapshot/Replay namespace consolidation** — flagged as v2.0 work in
+  `api-stability.md`. Don't touch.
+- **`CommandDispatcher` plugin-route extraction beyond v0.13 PR 12** — if
+  v0.13 PR 12 landed cleanly, no further work. If it shipped partial, the
+  remaining slice belongs here as an extra PR rather than a new milestone.
+- **`method_missing` on `PageProxy` to auto-delegate any `Client` method** —
+  considered, rejected. `delegate_unwrap` (v0.13 PR 10) is explicit and
+  greppable; `method_missing` would hide the public surface from the lock
+  file in WS-4.
+
+## Open routing decision (resolve before PR 7)
+
+WS-2 PR 7 chose `Handlers::StateRpc` as the rename target. Alternative:
+move every handler under `Browserctl::Server::JsonRpc::*` (a deeper namespace
+that disambiguates by directory rather than suffix). The suffix form is
+cheaper; the namespace form scales better if more wire protocols are ever
+added. Decide before opening the PR.


### PR DESCRIPTION
## Summary

- Backfills `docs/plans/v0.13-lean.md` — the milestone plan that drove the 0.13.x releases (driver delete, session removal, noun-verb CLI, unified `--output`, recording/workflow refactors). v0.13.1 has already shipped; this just lands the plan into the same directory as the other v0.10–v0.12 plans for historical continuity.
- Adds `docs/plans/v0.14-polish.md` — the companion "Polish" plan covering the remaining internal hygiene before 1.0:
  - **WS-1 Typed-error completion** — close the ~15 validation guards still raising `ArgumentError` and tighten the `Browserctl/TypedError` cop.
  - **WS-2 Internal boundary cleanup** — extract `Client::RecordingInterceptor`, rename `Handlers::State` → `Handlers::StateRpc`, narrow bare rescues in `navigation.rb` / `logger.rb`.
  - **WS-3 Command-layer extractions** — `TraceRenderer` out of `commands/trace.rb`; `State::Mutator` out of `commands/state.rb`.
  - **WS-4 Public surface guard** — lock-file spec preventing accidental Stable-zone drift before 1.0.

Per-PR breakdown, files, acceptance criteria, risk, and sequencing diagram all match the conventions of `v0.12-solid.md`.

No code changes. Plan files only.

## Test plan
- [x] No code changes — no test impact.
- [ ] Maintainer reads the v0.14 plan and confirms the workstream split before any v0.14 PR opens.