### PR TITLE
refactor: typed error on State name validation (v0.14 WS-1 PR 3)

### DIFF
--- a/lib/browserctl/state.rb
+++ b/lib/browserctl/state.rb
@@ -83,7 +83,11 @@ module Browserctl
     def self.validate_name!(name)
       return if SAFE_NAME.match?(name.to_s)
 
-      raise ArgumentError, "invalid state name #{name.inspect} — use letters, digits, _ or - (max 64 chars)"
+      raise Browserctl::Error.new(
+        "invalid state name #{name.inspect} — use letters, digits, _ or - (max 64 chars)",
+        code: Browserctl::Error::Codes::INVALID_STATE_NAME,
+        context: { name: name }
+      )
     end
 
     # Persist a bundle. `payload` is a `State::Payload` value object carrying

--- a/spec/integration/cli_error_matrix_spec.rb
+++ b/spec/integration/cli_error_matrix_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe "CLI error code matrix" do
     CliErrorMatrix::Cell.new(
       command: "state save / load / etc.", code: "INVALID_STATE_NAME",
       scenario: "name fails [A-Za-z0-9_-]{1,64}",
-      skip_reason: "wired by v0.14 WS-1 PR 3 (State name validation)",
+      skip_reason: "covered by unit spec — CLI state path connects to daemon before validation",
       runner: ->(_) { [+"", +"", 0] }
     ),
     CliErrorMatrix::Cell.new(

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -33,9 +33,18 @@ RSpec.describe Browserctl::State do
       expect { described_class.validate_name!("github_prod-1") }.not_to raise_error
     end
 
-    it "rejects unsafe names" do
-      expect { described_class.validate_name!("../oops") }.to raise_error(ArgumentError)
-      expect { described_class.validate_name!("with space") }.to raise_error(ArgumentError)
+    it "rejects unsafe names with a typed INVALID_STATE_NAME error" do
+      [
+        "../oops",
+        "with space",
+        "bang!",
+        "slash/in/name",
+        ("x" * 65)
+      ].each do |bad|
+        expect { described_class.validate_name!(bad) }.to raise_error(Browserctl::Error) { |err|
+          expect(err.code).to eq(Browserctl::Error::Codes::INVALID_STATE_NAME)
+        }
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Replaces the `ArgumentError` in `Browserctl::State.validate_name!` with `Browserctl::Error` carrying `Codes::INVALID_STATE_NAME` and a `{ name: }` context. Prose message unchanged.
- Maps to exit code 8 (`VALIDATION_FAILED` family) per the v0.12 error model — see `docs/reference/errors.md` and `docs/reference/exit-codes.md`.
- Promotes the unit coverage for `validate_name!` to assert the typed error + canonical code across spaces, punctuation, path traversal, and >64-char names.
- Updates the `INVALID_STATE_NAME` cell in the CLI error matrix to a documented skip: the state CLI commands route through `Client#state_save` (et al.), which hits the daemon socket before validation runs, so the typed error is not reachable from a black-box CLI invocation without Chrome. Unit spec is the canonical coverage.

Tracks `docs/plans/v0.14-polish.md` WS-1 PR 3.

## Test plan

- [x] `bundle exec rspec spec/unit/state_spec.rb spec/unit/error_codes_spec.rb spec/integration/cli_error_matrix_spec.rb`
- [x] `bundle exec rubocop lib/browserctl/state.rb spec/unit/state_spec.rb spec/integration/cli_error_matrix_spec.rb`
- [x] Full `bundle exec rspec` via pre-push hook: 925 examples, 0 failures, 55 pending.