### PR TITLE
refactor: typed errors on Client validation guards (v0.14 WS-1 PR 2)

### DIFF
--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -48,7 +48,13 @@ module Browserctl
     # @param ref [String, nil] snapshot ref (e.g. "e3")
     # @return [Hash] `{ ok: true }` or `{ error: }`
     def click(name, selector = nil, ref: nil)
-      raise ArgumentError, "click: provide selector or ref:" unless selector || ref
+      unless selector || ref
+        raise Browserctl::Error.new(
+          "click: provide selector or ref",
+          code: Browserctl::Error::Codes::INVALID_SELECTOR_REF,
+          context: { method: :click, name: name }
+        )
+      end
 
       call("click", name: name, selector: selector, ref: ref,
                     capture_post_snapshot: Recording.active ? true : nil)
@@ -61,7 +67,13 @@ module Browserctl
     # @param ref [String, nil] snapshot ref
     # @return [Hash] `{ ok: true }` or `{ error: }`
     def fill(name, selector = nil, value = nil, ref: nil)
-      raise ArgumentError, "fill: provide selector or ref:" unless selector || ref
+      unless selector || ref
+        raise Browserctl::Error.new(
+          "fill: provide selector or ref",
+          code: Browserctl::Error::Codes::INVALID_SELECTOR_REF,
+          context: { method: :fill, name: name }
+        )
+      end
 
       call("fill", name: name, selector: selector, ref: ref, value: value,
                    capture_post_snapshot: Recording.active ? true : nil)
@@ -243,7 +255,13 @@ module Browserctl
     # @param selector [String] CSS selector
     # @return [Hash] `{ ok: true }` or `{ error: }`
     def hover(name, selector = nil, ref: nil)
-      raise ArgumentError, "hover: provide selector or ref:" unless selector || ref
+      unless selector || ref
+        raise Browserctl::Error.new(
+          "hover: provide selector or ref",
+          code: Browserctl::Error::Codes::INVALID_SELECTOR_REF,
+          context: { method: :hover, name: name }
+        )
+      end
 
       call("hover", name: name, selector: selector, ref: ref)
     end
@@ -255,7 +273,13 @@ module Browserctl
     # @param ref [String, nil] element ref from a prior snapshot
     # @return [Hash] `{ ok: true }` or `{ error: }`
     def upload(name, selector = nil, path = nil, ref: nil)
-      raise ArgumentError, "upload: provide selector or ref:" unless selector || ref
+      unless selector || ref
+        raise Browserctl::Error.new(
+          "upload: provide selector or ref",
+          code: Browserctl::Error::Codes::INVALID_SELECTOR_REF,
+          context: { method: :upload, name: name }
+        )
+      end
 
       call("upload", name: name, selector: selector, ref: ref, path: path)
     end
@@ -267,7 +291,13 @@ module Browserctl
     # @param ref [String, nil] element ref from a prior snapshot
     # @return [Hash] `{ ok: true }` or `{ error: }`
     def select(name, selector = nil, value = nil, ref: nil)
-      raise ArgumentError, "select: provide selector or ref:" unless selector || ref
+      unless selector || ref
+        raise Browserctl::Error.new(
+          "select: provide selector or ref",
+          code: Browserctl::Error::Codes::INVALID_SELECTOR_REF,
+          context: { method: :select, name: name }
+        )
+      end
 
       call("select", name: name, selector: selector, ref: ref, value: value)
     end

--- a/spec/integration/cli_error_matrix_spec.rb
+++ b/spec/integration/cli_error_matrix_spec.rb
@@ -268,7 +268,8 @@ RSpec.describe "CLI error code matrix" do
     CliErrorMatrix::Cell.new(
       command: "click / fill / hover / upload / select", code: "INVALID_SELECTOR_REF",
       scenario: "neither selector nor ref provided",
-      skip_reason: "wired by v0.14 WS-1 PR 2 (Client validation guards)",
+      skip_reason: "covered by unit spec (spec/unit/client_validation_guards_spec.rb) — " \
+                   "CLI subcommands abort with usage text before reaching the Client guard",
       runner: ->(_) { [+"", +"", 0] }
     ),
     CliErrorMatrix::Cell.new(

--- a/spec/unit/client_validation_guards_spec.rb
+++ b/spec/unit/client_validation_guards_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/client"
+require "browserctl/errors"
+
+# Unit coverage for the five "provide selector or ref" guards in
+# Browserctl::Client. The guards raise Browserctl::Error with the canonical
+# INVALID_SELECTOR_REF code so agents can branch on the structured payload
+# instead of string-matching ArgumentError prose.
+#
+# These guards execute before any UNIX-socket connection, so we can drive
+# them with a Client pointed at a non-existent socket path — the guard
+# raises before `call` ever runs.
+RSpec.describe Browserctl::Client, "selector-or-ref guards" do
+  subject(:client) { described_class.new("/tmp/browserctl-nonexistent-#{Process.pid}.sock") }
+
+  # method_name, args (positional + kwargs as a proc, since fill/upload/select
+  # take more positional args)
+  cases = [
+    [:click,  ->(c, name) { c.click(name) }],
+    [:fill,   ->(c, name) { c.fill(name) }],
+    [:hover,  ->(c, name) { c.hover(name) }],
+    [:upload, ->(c, name) { c.upload(name) }],
+    [:select, ->(c, name) { c.select(name) }]
+  ]
+
+  cases.each do |method_name, invoker|
+    describe "##{method_name}" do
+      it "raises Browserctl::Error with INVALID_SELECTOR_REF when neither selector nor ref is provided" do
+        expect { invoker.call(client, "somepage") }
+          .to raise_error(Browserctl::Error) do |err|
+            expect(err.code).to eq(Browserctl::Error::Codes::INVALID_SELECTOR_REF)
+            expect(err.message).to include("provide selector or ref")
+            expect(err.context).to include(method: method_name, name: "somepage")
+          end
+      end
+
+      it "is not an ArgumentError" do
+        expect { invoker.call(client, "somepage") }.not_to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Rewrites the five `raise ArgumentError, "<method>: provide selector or ref:"` guards in `Browserctl::Client` (`click`, `fill`, `hover`, `upload`, `select`) to raise `Browserctl::Error` with `Codes::INVALID_SELECTOR_REF` and a structured `context: { method:, name: }` payload, per the typed-error contract introduced in v0.12 and the validation-code family added in PR #179.
- Drops the trailing colon from the human prose (it was an artefact of the old `ArgumentError` sentence shape).
- Adds `spec/unit/client_validation_guards_spec.rb` — table-driven coverage of all five methods asserting `Browserctl::Error`, `code`, message, and `context`, plus a negative `ArgumentError` check.
- Updates the `INVALID_SELECTOR_REF` cell in `spec/integration/cli_error_matrix_spec.rb`: re-worded skip note pointing at the new unit spec. The CLI subcommands `abort` with usage text when the positional selector arg is missing, so the Client guard is not reachable via the CLI surface — unit coverage is the right home.

Exit code for this code is 8 (`VALIDATION_FAILED`) per the family wired in PR #179. See `docs/plans/v0.14-polish.md` WS-1 PR 2.

## Test plan

- [x] `bundle exec rspec spec/unit/client_validation_guards_spec.rb spec/unit/error_codes_spec.rb spec/unit/exit_codes_spec.rb spec/integration/cli_error_matrix_spec.rb` — green
- [x] `bundle exec rubocop lib/browserctl/client.rb spec/unit/client_validation_guards_spec.rb spec/integration/cli_error_matrix_spec.rb` — no offenses
- [x] Pre-push hook full `bundle exec rspec` — 935 examples, 0 failures, 55 pending