### PR TITLE
refactor: rename Handlers::State to Handlers::StateRpc (v0.14 WS-2 PR 7)

### DIFF
--- a/lib/browserctl/server/command_dispatcher.rb
+++ b/lib/browserctl/server/command_dispatcher.rb
@@ -29,7 +29,7 @@ module Browserctl
     include Handlers::DevTools
     include Handlers::DaemonControl
     include Handlers::Storage
-    include Handlers::State
+    include Handlers::StateRpc
     include Handlers::Interaction
 
     COMMAND_MAP = {

--- a/lib/browserctl/server/handlers/state.rb
+++ b/lib/browserctl/server/handlers/state.rb
@@ -8,7 +8,7 @@ module Browserctl
     module Handlers
       # Top-level state management — collapses cookies + localStorage +
       # sessionStorage into a single `.bctl` bundle. See lib/browserctl/state.rb.
-      module State
+      module StateRpc
         private
 
         def cmd_state_save(req)


### PR DESCRIPTION
## Summary

Renames `Browserctl::CommandDispatcher::Handlers::State` to `Handlers::StateRpc` so it no longer collides at the symbol level with `Browserctl::Commands::State` (the CLI command dispatcher). Both modules previously presented as a bare `State`, forcing greps and code review to rely on the directory path to tell them apart.

Per the plan's "open routing decision" (WS-2 PR 7), the suffix form was chosen over a deeper `Server::JsonRpc::*` namespace move — much smaller diff, no churn in unrelated handlers.

- Module declaration in `lib/browserctl/server/handlers/state.rb` renamed `State` -> `StateRpc`.
- `include Handlers::State` in `lib/browserctl/server/command_dispatcher.rb` updated to `include Handlers::StateRpc`.
- Filename left as `state.rb` for consistency with sibling handlers (`navigation.rb`, `cookies.rb`, etc.) — directory `server/handlers/` already conveys the "RPC handler" role.

No behaviour change. Public API and JSON-RPC wire protocol untouched (the handler module name is implementation detail).

## Verification

Clean rename — no stale references to the old name:

```
$ git grep -nE "Handlers::State\b" lib/ spec/
(no output)

$ git grep -n "Handlers::StateRpc" lib/ spec/
lib/browserctl/server/command_dispatcher.rb:32:    include Handlers::StateRpc
```

## Test plan

- [x] `bundle exec rspec spec/integration/ spec/unit/server*` — 79 examples, 0 failures, 55 pending (browser-required skips)
- [x] Full suite via pre-push hook — 925 examples, 0 failures, 55 pending
- [x] `bundle exec rubocop` on touched files — no offenses

Refs: `docs/plans/v0.14-polish.md` WS-2 PR 7.