### PR TITLE
refactor: narrow bare rescues in navigation and logger (v0.14 WS-2 PR 8)

### DIFF
--- a/lib/browserctl/logger.rb
+++ b/lib/browserctl/logger.rb
@@ -132,7 +132,8 @@ module Browserctl
     log.progname  = component
     log.formatter = JsonlFormatter.new(component: component)
     log
-  rescue StandardError
+  rescue Errno::EACCES, Errno::ENOENT, Errno::EISDIR, Errno::ENOSPC, Errno::EROFS, IOError => e
+    warn "browserctl: failed to build jsonl logger (#{e.class}: #{e.message})"
     nil
   end
 

--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "json"
+require "timeout"
+
 module Browserctl
   class CommandDispatcher
     module Handlers
@@ -75,7 +78,8 @@ module Browserctl
         def capture_post_snapshot_digest(session)
           snapshot = @snapshot_builder.call(session.page)
           Browserctl::Replay::SnapshotDiff.digest(snapshot)
-        rescue StandardError
+        rescue JSON::ParserError, Timeout::Error, Browserctl::Error => e
+          Browserctl.logger.debug("post-snapshot digest skipped: #{e.class}: #{e.message}")
           nil
         end
 

--- a/spec/unit/handlers_navigation_spec.rb
+++ b/spec/unit/handlers_navigation_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/server/command_dispatcher"
+
+# Targets the narrowed rescue in
+# Browserctl::CommandDispatcher::Handlers::Navigation#capture_post_snapshot_digest.
+RSpec.describe Browserctl::CommandDispatcher::Handlers::Navigation do
+  # Minimal harness exposing the private method without booting the full
+  # dispatcher (which would require a live Ferrum browser).
+  let(:harness_class) do
+    Class.new do
+      include Browserctl::CommandDispatcher::Handlers::Navigation
+
+      def initialize(snapshot_builder)
+        @snapshot_builder = snapshot_builder
+      end
+
+      public :capture_post_snapshot_digest
+    end
+  end
+
+  let(:session) { instance_double("Browserctl::PageSession", page: :fake_page) }
+
+  context "expected exceptions are swallowed and logged at debug" do
+    [
+      JSON::ParserError.new("bad json"),
+      Timeout::Error.new("snapshot timeout"),
+      Browserctl::Error.new("typed failure")
+    ].each do |err|
+      it "returns nil and logs at debug when snapshot raises #{err.class}" do
+        builder = ->(_page) { raise err }
+        harness = harness_class.new(builder)
+        debug_messages = []
+        allow(Browserctl).to receive(:logger).and_return(
+          instance_double("Logger").tap do |l|
+            allow(l).to receive(:debug) { |msg| debug_messages << msg }
+          end
+        )
+
+        expect(harness.capture_post_snapshot_digest(session)).to be_nil
+        expect(debug_messages.last).to include("post-snapshot digest skipped", err.class.to_s)
+      end
+    end
+  end
+
+  it "propagates unexpected exceptions (rescue is no longer too wide)" do
+    builder = ->(_page) { raise "unexpected" }
+    harness = harness_class.new(builder)
+
+    expect { harness.capture_post_snapshot_digest(session) }
+      .to raise_error(RuntimeError, "unexpected")
+  end
+
+  it "propagates ArgumentError (proves StandardError-wide rescue is gone)" do
+    builder = ->(_page) { raise ArgumentError, "bad arg" }
+    harness = harness_class.new(builder)
+
+    expect { harness.capture_post_snapshot_digest(session) }
+      .to raise_error(ArgumentError)
+  end
+end

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -128,4 +128,32 @@ RSpec.describe "Browserctl logger (structured JSONL)" do
       expect(File).not_to exist(File.join(Browserctl.log_dir, "daemon.log"))
     end
   end
+
+  describe ".build_jsonl_logger" do
+    it "returns nil and warns when filesystem errors occur (Errno::EACCES)" do
+      allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES, "permission denied")
+
+      expect do
+        result = Browserctl.build_jsonl_logger(Logger::INFO, "daemon")
+        expect(result).to be_nil
+      end.to output(/failed to build jsonl logger.*EACCES/).to_stderr
+    end
+
+    it "returns nil and warns when an IOError is raised" do
+      allow(Browserctl::HeaderlessLogDevice).to receive(:new).and_raise(IOError, "device closed")
+
+      expect do
+        result = Browserctl.build_jsonl_logger(Logger::INFO, "daemon")
+        expect(result).to be_nil
+      end.to output(/failed to build jsonl logger.*IOError/).to_stderr
+    end
+
+    it "propagates unexpected exceptions (no longer rescued by bare StandardError)" do
+      allow(FileUtils).to receive(:mkdir_p).and_raise(RuntimeError, "unexpected")
+
+      expect do
+        Browserctl.build_jsonl_logger(Logger::INFO, "daemon")
+      end.to raise_error(RuntimeError, "unexpected")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Two `rescue StandardError` clauses were silently swallowing any failure. Narrowed both to the expected exception classes so unexpected exceptions now propagate to the caller. Happy path behaviour is unchanged.

- `lib/browserctl/server/handlers/navigation.rb#capture_post_snapshot_digest` now rescues only `JSON::ParserError`, `Timeout::Error`, and `Browserctl::Error`, logging the discard at `debug` level via `Browserctl.logger`.
- `lib/browserctl/logger.rb#build_jsonl_logger` now rescues only `Errno::EACCES`, `Errno::ENOENT`, `Errno::EISDIR`, `Errno::ENOSPC`, `Errno::EROFS`, and `IOError`, emitting a `warn` so silent log loss is at least visible before returning `nil`.

Refs plan `docs/plans/v0.14-polish.md` WS-2 PR 8.

## Test plan

- [x] New unit specs assert that expected exceptions are still handled (returns `nil` plus debug log / stderr warning).
- [x] New unit specs assert that unexpected exceptions (`RuntimeError`, `ArgumentError`) now propagate.
- [x] `bundle exec rspec` — 933 examples, 0 failures, 55 pending (browser-required integration specs skipped on CI-less host).
- [x] `bundle exec rubocop` on touched files — clean.