### PR TITLE
refactor: typed errors on DSL guards (v0.14 WS-1 PR 4)

### DIFF
--- a/lib/browserctl/callable_definition.rb
+++ b/lib/browserctl/callable_definition.rb
@@ -48,7 +48,13 @@ module Browserctl
     end
 
     def step(label, retry_count: 0, timeout: nil, &block)
-      raise ArgumentError, "#{callable_kind} step '#{label}' requires a block" unless block
+      unless block
+        raise Browserctl::Error.new(
+          "#{callable_kind} step '#{label}' requires a block",
+          code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+          context: { dsl: callable_kind, action: :step, label: label }
+        )
+      end
 
       @steps << StepDef.new(label: label, block: block, retry_count: retry_count, timeout: timeout)
     end

--- a/lib/browserctl/flow.rb
+++ b/lib/browserctl/flow.rb
@@ -63,19 +63,37 @@ module Browserctl
     end
 
     def precondition(label = "precondition", &block)
-      raise ArgumentError, "precondition '#{label}' requires a block" unless block
+      unless block
+        raise Browserctl::Error.new(
+          "precondition '#{label}' requires a block",
+          code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+          context: { dsl: :flow, action: :precondition, label: label }
+        )
+      end
 
       @preconditions << FlowConditionDef.new(kind: :precondition, label: label, block: block)
     end
 
     def postcondition(label = "postcondition", &block)
-      raise ArgumentError, "postcondition '#{label}' requires a block" unless block
+      unless block
+        raise Browserctl::Error.new(
+          "postcondition '#{label}' requires a block",
+          code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+          context: { dsl: :flow, action: :postcondition, label: label }
+        )
+      end
 
       @postconditions << FlowConditionDef.new(kind: :postcondition, label: label, block: block)
     end
 
     def produces_state(&block)
-      raise ArgumentError, "produces_state requires a block" unless block
+      unless block
+        raise Browserctl::Error.new(
+          "produces_state requires a block",
+          code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+          context: { dsl: :flow, action: :produces_state }
+        )
+      end
 
       @produces_state_block = block
     end
@@ -87,13 +105,22 @@ module Browserctl
     def compose(target_name)
       name = target_name.to_s
       if Browserctl.respond_to?(:lookup_workflow) && Browserctl.lookup_workflow(name)
-        raise ArgumentError,
-              "flow '#{@name}' cannot compose workflow '#{name}': flows return state, " \
-              "workflows share state — composition across kinds is not supported"
+        raise Browserctl::Error.new(
+          "flow '#{@name}' cannot compose workflow '#{name}': flows return state, " \
+          "workflows share state — composition across kinds is not supported",
+          code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+          context: { dsl: :flow, action: :compose, source: @name, target: name, reason: :cross_kind }
+        )
       end
 
       source = Browserctl.lookup_flow(name)
-      raise ArgumentError, "flow '#{name}' not found for composition" unless source
+      unless source
+        raise Browserctl::Error.new(
+          "flow '#{name}' not found for composition",
+          code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+          context: { dsl: :flow, action: :compose, source: @name, target: name, reason: :not_found }
+        )
+      end
 
       @steps.concat(source.steps)
     end
@@ -113,7 +140,11 @@ module Browserctl
     def validate_semver!(value, label:)
       return if value.to_s.match?(SEMVER_RE)
 
-      raise ArgumentError, "#{label} must be MAJOR.MINOR.PATCH (got #{value.inspect})"
+      raise Browserctl::Error.new(
+        "#{label} must be MAJOR.MINOR.PATCH (got #{value.inspect})",
+        code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+        context: { dsl: :flow, action: :validate_semver, label: label, value: value.to_s }
+      )
     end
 
     def missing_param_error(name)
@@ -166,7 +197,13 @@ module Browserctl
   @flow_registry       = {}
 
   def self.flow(name, &block)
-    raise ArgumentError, "Browserctl.flow requires a block" unless block
+    unless block
+      raise Browserctl::Error.new(
+        "Browserctl.flow requires a block",
+        code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+        context: { dsl: :flow, action: :define, name: name.to_s }
+      )
+    end
 
     flow = Flow.new(name).tap { |f| f.instance_exec(&block) }
     register_flow(flow)

--- a/lib/browserctl/format_version.rb
+++ b/lib/browserctl/format_version.rb
@@ -29,7 +29,13 @@ module Browserctl
 
     # Returns the canonical header string for a given integer version.
     def stamp(version:)
-      raise ArgumentError, "version must be a non-negative Integer" unless version.is_a?(Integer) && version >= 0
+      unless version.is_a?(Integer) && version >= 0
+        raise Browserctl::Error.new(
+          "version must be a non-negative Integer",
+          code: Browserctl::Error::Codes::INVALID_FORMAT_VERSION,
+          context: { value: version }
+        )
+      end
 
       "version: #{version}\n"
     end

--- a/lib/browserctl/migrations.rb
+++ b/lib/browserctl/migrations.rb
@@ -42,7 +42,14 @@ module Browserctl
       # block receives the file path as a keyword argument and must rewrite
       # the file in place to the new version.
       def register(format:, from_version:, to_version:, &upgrade)
-        raise ArgumentError, "upgrade block required" unless upgrade
+        unless upgrade
+          raise Browserctl::Error.new(
+            "upgrade block required",
+            code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+            context: { dsl: :migrations, action: :register, format: format,
+                       from_version: from_version, to_version: to_version }
+          )
+        end
 
         @mutex.synchronize do
           @registry << Migration.new(format: format, from_version: from_version,

--- a/spec/integration/cli_error_matrix_spec.rb
+++ b/spec/integration/cli_error_matrix_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe "CLI error code matrix" do
     path
   end
 
+  # Build a workflow .rb file whose body trips a DSL guard at load
+  # time — `step` declared without a block. `workflow run <file>`
+  # `load`s the file before any params are inspected, so the typed
+  # INVALID_DSL_USAGE error surfaces through the CLI's top-level
+  # Browserctl::Error rescue with exit 8.
+  def write_dsl_violation_workflow(dir)
+    path = File.join(dir, "bad_dsl.rb")
+    File.write(path, <<~RUBY)
+      # frozen_string_literal: true
+      # format_version: 1
+      Browserctl.workflow "bad_dsl" do
+        step "no-block-here"
+      end
+    RUBY
+    path
+  end
+
   # Each cell: [command_label, code, scenario, skip_reason_or_nil, runner_proc]
   # The runner_proc returns [out, err, status] for that scenario.
   matrix = [
@@ -278,15 +295,20 @@ RSpec.describe "CLI error code matrix" do
       runner: ->(_) { [+"", +"", 0] }
     ),
     CliErrorMatrix::Cell.new(
-      command: "workflow / flow DSL", code: "INVALID_DSL_USAGE",
-      scenario: "missing block or invalid name on a DSL call",
-      skip_reason: "wired by v0.14 WS-1 PR 4 (DSL guards)",
-      runner: ->(_) { [+"", +"", 0] }
+      command: "workflow run (DSL)", code: "INVALID_DSL_USAGE",
+      scenario: "missing block on a step DSL call",
+      runner: lambda do |ctx|
+        Dir.mktmpdir do |dir|
+          path = ctx.write_dsl_violation_workflow(dir)
+          ctx.run_cli(["workflow", "run", path])
+        end
+      end
     ),
     CliErrorMatrix::Cell.new(
       command: "(internal) format_version", code: "INVALID_FORMAT_VERSION",
       scenario: "version header is not a non-negative Integer",
-      skip_reason: "wired by v0.14 WS-1 PR 4 (FormatVersion guard)",
+      skip_reason: "covered by unit spec — FormatVersion.stamp is an internal " \
+                   "writer; no CLI surface accepts a user-supplied version int",
       runner: ->(_) { [+"", +"", 0] }
     ),
 

--- a/spec/unit/callable_definition_spec.rb
+++ b/spec/unit/callable_definition_spec.rb
@@ -52,11 +52,10 @@ RSpec.describe Browserctl::CallableDefinition do
         step("noop") { :ok }
       end
 
-      expect do
-        Browserctl.flow(:composing_flow) do
-          compose :my_wf
-        end
-      end.to raise_error(ArgumentError, /cannot compose workflow/)
+      define = -> { Browserctl.flow(:composing_flow) { compose :my_wf } }
+      expect(&define).to raise_error(Browserctl::Error, /cannot compose workflow/) do |e|
+        expect(e.code).to eq(Browserctl::Error::Codes::INVALID_DSL_USAGE)
+      end
     end
 
     it "allows a workflow to compose another workflow" do

--- a/spec/unit/flow_spec.rb
+++ b/spec/unit/flow_spec.rb
@@ -25,35 +25,36 @@ RSpec.describe Browserctl::Flow do
 
     it "rejects non-semver versions" do
       expect { Browserctl.flow("x") { version "1.2" } }
-        .to raise_error(ArgumentError, /MAJOR\.MINOR\.PATCH/)
+        .to raise_error(Browserctl::Error, /MAJOR\.MINOR\.PATCH/) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::INVALID_DSL_USAGE)
+        end
     end
 
     it "rejects non-semver requires_browserctl" do
       expect { Browserctl.flow("x") { requires_browserctl "v1" } }
-        .to raise_error(ArgumentError, /MAJOR\.MINOR\.PATCH/)
+        .to raise_error(Browserctl::Error, /MAJOR\.MINOR\.PATCH/) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::INVALID_DSL_USAGE)
+        end
     end
 
     it "requires a block at the top level" do
-      expect { Browserctl.flow("x") }.to raise_error(ArgumentError, /requires a block/)
+      expect { Browserctl.flow("x") }
+        .to raise_error(Browserctl::Error, /requires a block/) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::INVALID_DSL_USAGE)
+        end
     end
 
     it "requires blocks for step, precondition, postcondition, produces_state" do
-      expect { Browserctl.flow("x") { step("s") } }.to raise_error(ArgumentError, /step.*requires a block/)
-      expect do
-        Browserctl.flow("x") do
-          precondition("p")
-        end
-      end.to raise_error(ArgumentError, /precondition.*requires a block/)
-      expect do
-        Browserctl.flow("x") do
-          postcondition("p")
-        end
-      end.to raise_error(ArgumentError, /postcondition.*requires a block/)
-      expect do
-        Browserctl.flow("x") do
-          produces_state
-        end
-      end.to raise_error(ArgumentError, /produces_state.*requires a block/)
+      expect_dsl_block_required { Browserctl.flow("x") { step("s") } }
+      expect_dsl_block_required { Browserctl.flow("x") { precondition("p") } }
+      expect_dsl_block_required { Browserctl.flow("x") { postcondition("p") } }
+      expect_dsl_block_required { Browserctl.flow("x") { produces_state } }
+    end
+
+    def expect_dsl_block_required(&block)
+      expect(&block).to raise_error(Browserctl::Error, /requires a block/) do |e|
+        expect(e.code).to eq(Browserctl::Error::Codes::INVALID_DSL_USAGE)
+      end
     end
 
     it "coerces secret_ref params to secret: true" do

--- a/spec/unit/format_version_spec.rb
+++ b/spec/unit/format_version_spec.rb
@@ -13,12 +13,21 @@ RSpec.describe Browserctl::FormatVersion do
     end
 
     it "rejects non-integer versions" do
-      expect { described_class.stamp(version: "1") }.to raise_error(ArgumentError)
-      expect { described_class.stamp(version: 1.0) }.to raise_error(ArgumentError)
+      expect { described_class.stamp(version: "1") }
+        .to raise_error(Browserctl::Error) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::INVALID_FORMAT_VERSION)
+        end
+      expect { described_class.stamp(version: 1.0) }
+        .to raise_error(Browserctl::Error) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::INVALID_FORMAT_VERSION)
+        end
     end
 
     it "rejects negative versions" do
-      expect { described_class.stamp(version: -1) }.to raise_error(ArgumentError)
+      expect { described_class.stamp(version: -1) }
+        .to raise_error(Browserctl::Error) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::INVALID_FORMAT_VERSION)
+        end
     end
   end
 

--- a/spec/unit/migrations_spec.rb
+++ b/spec/unit/migrations_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe Browserctl::Migrations do
 
     it "rejects registration without an upgrade block" do
       expect { described_class.register(format: :bundle, from_version: 1, to_version: 2) }
-        .to raise_error(ArgumentError, /upgrade block required/)
+        .to raise_error(Browserctl::Error, /upgrade block required/) do |e|
+          expect(e.code).to eq(Browserctl::Error::Codes::INVALID_DSL_USAGE)
+        end
     end
   end
 


### PR DESCRIPTION
## Summary

Wires the remaining DSL / format-version validation guards to the typed-error contract — `INVALID_DSL_USAGE` for the DSL family, `INVALID_FORMAT_VERSION` for the integer-version guard. Both map to exit code 8 via `VALIDATION_FAILED`.

Files touched:
- `lib/browserctl/flow.rb` — `precondition`, `postcondition`, `produces_state`, `compose` (cross-kind + not-found), `validate_semver!`, and the top-level `Browserctl.flow` block guard.
- `lib/browserctl/callable_definition.rb` — `step` block guard.
- `lib/browserctl/migrations.rb` — `Migrations.register` block guard.
- `lib/browserctl/format_version.rb` — `FormatVersion.stamp` integer guard.

Existing prose is preserved; structured `context:` carries the minimal useful keys (`dsl`, `action`, `label`, `value`, etc.).

## Plan reference

`docs/plans/v0.14-polish.md` — WS-1 PR 4 (DSL guards).

## CLI matrix resolution

- `INVALID_DSL_USAGE` cell promoted from placeholder skip to a real runner: `workflow run <file>` against a workflow whose `step` declaration is missing a block. The DSL guard fires inside `load`, surfaces through the top-level `Browserctl::Error` rescue, exits 8 with the JSON payload.
- `INVALID_FORMAT_VERSION` cell remains a skip with a corrected reason — `FormatVersion.stamp` is an internal writer; no CLI surface accepts a user-supplied version int. Unit coverage in `spec/unit/format_version_spec.rb` exercises every branch of the guard.

## Verification

After this PR, `git grep "raise ArgumentError" lib/` returns:

```
lib/browserctl/client.rb:51:      raise ArgumentError, "click: provide selector or ref:" unless selector || ref
lib/browserctl/client.rb:64:      raise ArgumentError, "fill: provide selector or ref:" unless selector || ref
lib/browserctl/client.rb:246:      raise ArgumentError, "hover: provide selector or ref:" unless selector || ref
lib/browserctl/client.rb:258:      raise ArgumentError, "upload: provide selector or ref:" unless selector || ref
lib/browserctl/client.rb:270:      raise ArgumentError, "select: provide selector or ref:" unless selector || ref
lib/browserctl/driver/cdp.rb:83:          raise ArgumentError, "Unknown browser: #{@browser.inspect}"
lib/browserctl/flow_registry.rb:63:      raise ArgumentError, "invalid flow name: #{name.inspect} — use letters, digits, _ and - only"
lib/browserctl/flows/stdlib/totp_2fa.rb:34:          raise ArgumentError, "invalid base32 char #{char.inspect}"
lib/browserctl/state.rb:86:      raise ArgumentError, "invalid state name #{name.inspect} — use letters, digits, _ or - (max 64 chars)"
lib/browserctl/workflow.rb:323:        raise ArgumentError,
```

All remaining raises sit in paths already rewired by other WS-1 PRs (client.rb → PR 2, state.rb / flow_registry.rb → PR 3, workflow.rb compose / driver / stdlib → covered by PRs 5+ or exempt). PR 5 of WS-1 removes the inline cop disables once the sweep is fully complete.

## Test plan

- [x] `bundle exec rspec` — 925 examples, 0 failures, 54 pending (Chrome-only).
- [x] `bundle exec rubocop` — 220 files, no offenses.
- [x] CLI matrix `INVALID_DSL_USAGE` cell exercises the full CLI surface end-to-end (exit 8, canonical JSON payload).
- [x] Unit specs assert `Browserctl::Error` with the right `code` for every newly-typed raise site.