### PR TITLE
refactor: extract TraceRenderer and EventStream (v0.14 WS-3 PR 9)

### DIFF
--- a/lib/browserctl/commands/trace.rb
+++ b/lib/browserctl/commands/trace.rb
@@ -1,112 +1,67 @@
 # frozen_string_literal: true
 
 require "json"
-require "time"
 require_relative "../logger"
 require_relative "../redactor"
 require_relative "../secret_resolver_registry"
+require_relative "../trace/event_stream"
+require_relative "../trace/renderer"
 require_relative "output_format"
 
 module Browserctl
   module Commands
     # `browserctl trace [<session>] [--no-redact]` — pretty timeline of
-    # structured log events across cli.log + daemon.log. Defaults to most
-    # recent session.
-    #
-    # Loose categorisation by inspecting common keys (event/snapshot/request/
-    # error). No schema is enforced — this command is tolerant of any JSONL
-    # produced by Browserctl::JsonlFormatter.
-    #
-    # Redaction: ON by default. Secret values are sourced from current ENV
-    # patterns (`*_TOKEN`, `*_KEY`, `*_SECRET`, `*_PASSWORD`) and any values
-    # captured by `SecretResolverRegistry` during this process. Pass
-    # `--no-redact` to disable (local debugging only). Note: when replaying
-    # historical traces from a previous process, registry-captured values are
-    # gone — only current ENV patterns apply.
+    # structured log events across cli.log + daemon.log. Thin CLI dispatcher;
+    # parsing lives in `Browserctl::Trace::EventStream`, rendering in
+    # `Browserctl::Trace::Renderer`, redaction in `Browserctl::Redactor`.
     module Trace
       USAGE = "Usage: browserctl trace [<session>] [--no-redact]"
       NO_REDACT_WARNING = "[browserctl] traces include unredacted secret values; " \
                           "do not paste this output publicly."
-
-      LEVEL_COLORS = {
-        "DEBUG" => "\e[2;37m", # dim grey
-        "INFO" => "\e[36m",    # cyan
-        "WARN" => "\e[33m",    # yellow
-        "ERROR" => "\e[31m" # red
-      }.freeze
-      RESET = "\e[0m"
-
-      CATEGORY_ICONS = {
-        error: "!",
-        snapshot: "S",
-        network: "N",
-        event: "."
-      }.freeze
-
-      OMIT_KEYS = %w[ts level component event msg].freeze
 
       def self.run(args, log_dir: Browserctl.log_dir, out: $stdout, err: $stderr)
         abort USAGE if args.include?("-h") || args.include?("--help")
         args = args.dup
         redact = !args.delete("--no-redact")
         session_filter = args.shift
-        redactor = resolve_redactor(redact, err)
-        records = collect_records(log_dir, session_filter, out)
-        emit_records(records, redactor, out) if records
-      end
+        redactor = redact ? build_redactor : (warn_no_redact(err) || nil)
 
-      def self.resolve_redactor(redact, err)
-        return nil unless redact
-
-        build_redactor
-      ensure
-        warn_no_redact(err) unless redact
-      end
-
-      def self.collect_records(log_dir, session_filter, out)
-        records = load_records(log_dir)
-        if records.empty?
-          emit_empty("No log entries found in #{log_dir}", out)
-          return nil
+        stream = Browserctl::Trace::EventStream.new(log_dir, session_filter: session_filter)
+        if stream.empty?
+          emit_empty(empty_message(log_dir, session_filter), out)
+          return
         end
 
-        records = filter_session(records, session_filter)
-        if records.empty?
-          emit_empty("No entries match session=#{session_filter}", out)
-          return nil
-        end
+        emit(stream, redactor, out)
+      end
 
-        records
+      def self.emit(stream, redactor, out)
+        fmt = OutputFormat.current
+        if fmt.json?
+          fmt.emit({ records: stream.records.map { |r| redact_record(r, redactor) } }, io: out)
+        elsif !fmt.silent?
+          Browserctl::Trace::Renderer.new(io: out, redactor: redactor).render(stream)
+        end
+      end
+
+      def self.empty_message(log_dir, session_filter)
+        session_filter ? "No entries match session=#{session_filter}" : "No log entries found in #{log_dir}"
       end
 
       def self.emit_empty(message, out)
         OutputFormat.current.emit({ records: [], message: message }, message, io: out)
       end
 
-      def self.emit_records(records, redactor, out)
-        fmt = OutputFormat.current
-        if fmt.json?
-          fmt.emit({ records: records.map { |r| redact_record(r, redactor) } }, io: out)
-        elsif !fmt.silent?
-          render(records, out: out, redactor: redactor)
-        end
-      end
-
       def self.redact_record(record, redactor)
         return record unless redactor
 
-        line = JSON.generate(record)
-        JSON.parse(redactor.redact(line))
+        JSON.parse(redactor.redact(JSON.generate(record)))
       rescue JSON::ParserError
         record
       end
 
       def self.build_redactor
-        extra = if defined?(Browserctl::SecretResolverRegistry)
-                  Browserctl::SecretResolverRegistry.resolved_values
-                else
-                  []
-                end
+        extra = defined?(Browserctl::SecretResolverRegistry) ? Browserctl::SecretResolverRegistry.resolved_values : []
         Browserctl::Redactor.from_env(extra: extra)
       rescue StandardError
         Browserctl::Redactor.new(secrets: [])
@@ -114,102 +69,7 @@ module Browserctl
 
       def self.warn_no_redact(err)
         err&.puts NO_REDACT_WARNING
-      end
-
-      def self.load_records(log_dir)
-        paths = Dir.glob(File.join(log_dir, "{cli,daemon}.log"))
-        records = paths.flat_map do |path|
-          File.foreach(path).filter_map { |line| parse_line(line) }
-        end
-        records.sort_by { |r| r["ts"].to_s }
-      end
-
-      def self.parse_line(line)
-        line = line.strip
-        return nil if line.empty?
-
-        JSON.parse(line)
-      rescue JSON::ParserError
         nil
-      end
-
-      # Session resolution. When session_id is stamped on records (future PR),
-      # filter/select by it. Otherwise, treat the entire merged stream as one
-      # session — caller can scope by tailing/rotating logs.
-      # TODO: stamp session_id on every log line so this scopes correctly.
-      def self.filter_session(records, session_filter)
-        if session_filter
-          records.select { |r| r["session_id"].to_s == session_filter }
-        else
-          ids = records.map { |r| r["session_id"] }.compact.uniq
-          if ids.empty?
-            records
-          else
-            recent = ids.last
-            records.select { |r| r["session_id"] == recent }
-          end
-        end
-      end
-
-      def self.render(records, out:, redactor: nil)
-        tty = out.respond_to?(:tty?) && out.tty?
-        records.each { |r| out.puts(format_line(r, tty: tty, redactor: redactor)) }
-      end
-
-      def self.format_line(record, tty:, redactor: nil)
-        level = (record["level"] || "INFO").to_s
-        line  = format("%-12<ts>s %<icon>s %-5<level>s %-7<comp>s %-22<label>s %<ctx>s",
-                       ts: format_ts(record["ts"]),
-                       icon: CATEGORY_ICONS.fetch(categorise(record), "."),
-                       level: level,
-                       comp: (record["component"] || "?").to_s,
-                       label: event_label(record),
-                       ctx: context_snippet(record)).rstrip
-
-        line = redactor.redact(line) if redactor
-        tty ? colourise(line, level) : line
-      end
-
-      def self.format_ts(timestamp)
-        Time.iso8601(timestamp.to_s).strftime("%H:%M:%S.%L")
-      rescue ArgumentError, TypeError
-        "??:??:??.???"
-      end
-
-      def self.categorise(record)
-        return :error    if record["level"] == "ERROR" || record["error"]
-        return :snapshot if record["snapshot"]
-        return :network  if record["request"] || record["response"] || record["url"]
-
-        :event
-      end
-
-      def self.event_label(record)
-        (record["event"] || record["snapshot"] || record["request"] ||
-          record["msg"] || "-").to_s.slice(0, 22)
-      end
-
-      # Compact "k=v k=v" snippet of remaining structured keys, capped to keep
-      # the timeline scannable. Skips fields already shown in fixed columns.
-      def self.context_snippet(record)
-        pairs = record.except(*OMIT_KEYS)
-        return "" if pairs.empty?
-
-        pairs.map { |k, v| "#{k}=#{format_value(v)}" }.join(" ").slice(0, 120)
-      end
-
-      def self.format_value(value)
-        case value
-        when String  then value.length > 40 ? "#{value[0, 37]}..." : value
-        when Array   then "[#{value.length}]"
-        when Hash    then "{#{value.keys.length}}"
-        else value.to_s
-        end
-      end
-
-      def self.colourise(line, level)
-        colour = LEVEL_COLORS[level] || ""
-        "#{colour}#{line}#{RESET}"
       end
     end
   end

--- a/lib/browserctl/trace/event_stream.rb
+++ b/lib/browserctl/trace/event_stream.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Browserctl
+  module Trace
+    # Reads `cli.log` + `daemon.log` JSONL files from a log directory and yields
+    # records sorted by timestamp. Malformed lines are skipped silently — this
+    # matches the tolerant behaviour expected of `browserctl trace`.
+    #
+    # Session filtering: when `session_filter` is provided, only records whose
+    # `session_id` matches are emitted. When nil, records are scoped to the most
+    # recent `session_id` observed in the merged stream (or all records if none
+    # carry a session id yet — backwards compatible with older logs).
+    class EventStream
+      include Enumerable
+
+      LOG_GLOB = "{cli,daemon}.log"
+
+      def initialize(log_dir, session_filter: nil)
+        @log_dir = log_dir
+        @session_filter = session_filter
+      end
+
+      def each(&block)
+        return enum_for(:each) unless block
+
+        records.each(&block)
+      end
+
+      def empty?
+        records.empty?
+      end
+
+      def records
+        @records ||= filter_session(load_records)
+      end
+
+      private
+
+      def load_records
+        paths = Dir.glob(File.join(@log_dir, LOG_GLOB))
+        rows = paths.flat_map do |path|
+          File.foreach(path).filter_map { |line| parse_line(line) }
+        end
+        rows.sort_by { |r| r["ts"].to_s }
+      end
+
+      def parse_line(line)
+        stripped = line.strip
+        return nil if stripped.empty?
+
+        JSON.parse(stripped)
+      rescue JSON::ParserError
+        nil
+      end
+
+      # Session resolution. When session_id is stamped on records (future PR),
+      # filter/select by it. Otherwise, treat the entire merged stream as one
+      # session — caller can scope by tailing/rotating logs.
+      # TODO: stamp session_id on every log line so this scopes correctly.
+      def filter_session(rows)
+        if @session_filter
+          rows.select { |r| r["session_id"].to_s == @session_filter }
+        else
+          ids = rows.map { |r| r["session_id"] }.compact.uniq
+          return rows if ids.empty?
+
+          recent = ids.last
+          rows.select { |r| r["session_id"] == recent }
+        end
+      end
+    end
+  end
+end

--- a/lib/browserctl/trace/renderer.rb
+++ b/lib/browserctl/trace/renderer.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "time"
+
+module Browserctl
+  module Trace
+    # Renders structured log records as a human-scannable timeline. Output
+    # format is intentionally compact:
+    #
+    #   HH:MM:SS.mmm I LEVEL COMPONENT LABEL                  k=v k=v
+    #
+    # Colour is enabled when the target IO is a TTY (or when `color: true` is
+    # forced). Redaction is optional and injected as a dependency so callers
+    # can substitute a stricter `Browserctl::Redactor` or pass `nil` to
+    # disable.
+    class Renderer
+      LEVEL_COLORS = {
+        "DEBUG" => "\e[2;37m", # dim grey
+        "INFO" => "\e[36m",    # cyan
+        "WARN" => "\e[33m",    # yellow
+        "ERROR" => "\e[31m" # red
+      }.freeze
+      RESET = "\e[0m"
+
+      CATEGORY_ICONS = {
+        error: "!",
+        snapshot: "S",
+        network: "N",
+        event: "."
+      }.freeze
+
+      OMIT_KEYS = %w[ts level component event msg].freeze
+
+      def initialize(io:, color: nil, redactor: nil)
+        @io = io
+        @color = color.nil? ? tty?(io) : color
+        @redactor = redactor
+      end
+
+      def render(stream)
+        stream.each { |record| @io.puts(format_line(record)) }
+      end
+
+      private
+
+      def tty?(io)
+        io.respond_to?(:tty?) && io.tty?
+      end
+
+      def format_line(record)
+        level = (record["level"] || "INFO").to_s
+        line  = format("%-12<ts>s %<icon>s %-5<level>s %-7<comp>s %-22<label>s %<ctx>s",
+                       ts: format_ts(record["ts"]),
+                       icon: CATEGORY_ICONS.fetch(categorise(record), "."),
+                       level: level,
+                       comp: (record["component"] || "?").to_s,
+                       label: event_label(record),
+                       ctx: context_snippet(record)).rstrip
+
+        line = @redactor.redact(line) if @redactor
+        @color ? colourise(line, level) : line
+      end
+
+      def format_ts(timestamp)
+        Time.iso8601(timestamp.to_s).strftime("%H:%M:%S.%L")
+      rescue ArgumentError, TypeError
+        "??:??:??.???"
+      end
+
+      def categorise(record)
+        return :error    if record["level"] == "ERROR" || record["error"]
+        return :snapshot if record["snapshot"]
+        return :network  if record["request"] || record["response"] || record["url"]
+
+        :event
+      end
+
+      def event_label(record)
+        (record["event"] || record["snapshot"] || record["request"] ||
+          record["msg"] || "-").to_s.slice(0, 22)
+      end
+
+      # Compact "k=v k=v" snippet of remaining structured keys, capped to keep
+      # the timeline scannable. Skips fields already shown in fixed columns.
+      def context_snippet(record)
+        pairs = record.except(*OMIT_KEYS)
+        return "" if pairs.empty?
+
+        pairs.map { |k, v| "#{k}=#{format_value(v)}" }.join(" ").slice(0, 120)
+      end
+
+      def format_value(value)
+        case value
+        when String  then value.length > 40 ? "#{value[0, 37]}..." : value
+        when Array   then "[#{value.length}]"
+        when Hash    then "{#{value.keys.length}}"
+        else value.to_s
+        end
+      end
+
+      def colourise(line, level)
+        colour = LEVEL_COLORS[level] || ""
+        "#{colour}#{line}#{RESET}"
+      end
+    end
+  end
+end

--- a/spec/fixtures/trace/sample.golden.txt
+++ b/spec/fixtures/trace/sample.golden.txt
@@ -1,0 +1,4 @@
+06:21:48.500 . INFO  daemon  ready                  port=1234
+06:21:49.000 . INFO  cli     click                  selector=#submit
+06:21:49.500 S INFO  cli     snap_a                 snapshot=snap_a url=https://example.com/page
+06:21:50.000 ! ERROR daemon  kaboom                 code=E_BOOM

--- a/spec/fixtures/trace/sample.log
+++ b/spec/fixtures/trace/sample.log
@@ -1,0 +1,4 @@
+{"ts":"2026-05-10T06:21:48.500Z","level":"INFO","component":"daemon","event":"ready","port":1234}
+{"ts":"2026-05-10T06:21:49.000Z","level":"INFO","component":"cli","event":"click","selector":"#submit"}
+{"ts":"2026-05-10T06:21:49.500Z","level":"INFO","component":"cli","snapshot":"snap_a","url":"https://example.com/page"}
+{"ts":"2026-05-10T06:21:50.000Z","level":"ERROR","component":"daemon","msg":"kaboom","code":"E_BOOM"}

--- a/spec/integration/trace_golden_spec.rb
+++ b/spec/integration/trace_golden_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/commands/trace"
+require "fileutils"
+require "stringio"
+require "tmpdir"
+
+# Pins the rendered timeline output to a checked-in golden file so the
+# extraction refactor (v0.14 WS-3 PR 9) is provably byte-identical to the
+# pre-extraction implementation.
+RSpec.describe "browserctl trace golden output" do
+  let(:fixture)   { File.expand_path("../fixtures/trace/sample.log", __dir__) }
+  let(:golden)    { File.expand_path("../fixtures/trace/sample.golden.txt", __dir__) }
+  let(:tmp_dir)   { Dir.mktmpdir("browserctl-trace-golden") }
+
+  after { FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir) }
+
+  it "matches the golden file byte-for-byte" do
+    FileUtils.cp(fixture, File.join(tmp_dir, "daemon.log"))
+    out = StringIO.new
+    err = StringIO.new
+    Browserctl::Commands::Trace.run([], log_dir: tmp_dir, out: out, err: err)
+
+    expect(out.string).to eq(File.read(golden))
+  end
+end

--- a/spec/unit/trace/event_stream_spec.rb
+++ b/spec/unit/trace/event_stream_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/trace/event_stream"
+require "json"
+require "tmpdir"
+
+RSpec.describe Browserctl::Trace::EventStream do
+  let(:tmp_dir) { Dir.mktmpdir("browserctl-event-stream") }
+
+  after { FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir) }
+
+  def write_log(name, records)
+    File.open(File.join(tmp_dir, name), "w") do |f|
+      records.each { |r| f.puts(JSON.generate(r)) }
+    end
+  end
+
+  it "returns no records when log directory is empty" do
+    stream = described_class.new(tmp_dir)
+    expect(stream.empty?).to be true
+    expect(stream.to_a).to eq([])
+  end
+
+  it "parses JSONL lines from cli.log + daemon.log and sorts by ts" do
+    write_log("daemon.log", [
+                { ts: "2026-05-10T06:00:02.000Z", event: "b" },
+                { ts: "2026-05-10T06:00:00.000Z", event: "a" }
+              ])
+    write_log("cli.log", [
+                { ts: "2026-05-10T06:00:01.000Z", event: "mid" }
+              ])
+
+    events = described_class.new(tmp_dir).to_a
+    expect(events.map { |r| r["event"] }).to eq(%w[a mid b])
+  end
+
+  it "skips malformed JSON lines and blank lines" do
+    File.open(File.join(tmp_dir, "daemon.log"), "w") do |f|
+      f.puts("not json")
+      f.puts("")
+      f.puts(JSON.generate(ts: "2026-05-10T06:00:00.000Z", event: "ok"))
+    end
+
+    events = described_class.new(tmp_dir).to_a
+    expect(events.length).to eq(1)
+    expect(events.first["event"]).to eq("ok")
+  end
+
+  it "filters to a specific session when session_filter is provided" do
+    write_log("daemon.log", [
+                { ts: "2026-05-10T06:00:00.000Z", event: "a", session_id: "s1" },
+                { ts: "2026-05-10T06:00:01.000Z", event: "b", session_id: "s2" }
+              ])
+
+    events = described_class.new(tmp_dir, session_filter: "s2").to_a
+    expect(events.map { |r| r["event"] }).to eq(["b"])
+  end
+
+  it "scopes to the most recent session_id when none is specified" do
+    write_log("daemon.log", [
+                { ts: "2026-05-10T06:00:00.000Z", event: "a", session_id: "old" },
+                { ts: "2026-05-10T06:00:01.000Z", event: "b", session_id: "recent" }
+              ])
+
+    events = described_class.new(tmp_dir).to_a
+    expect(events.map { |r| r["event"] }).to eq(["b"])
+  end
+
+  it "returns all records when no record carries a session_id" do
+    write_log("daemon.log", [
+                { ts: "2026-05-10T06:00:00.000Z", event: "a" },
+                { ts: "2026-05-10T06:00:01.000Z", event: "b" }
+              ])
+
+    events = described_class.new(tmp_dir).to_a
+    expect(events.map { |r| r["event"] }).to eq(%w[a b])
+  end
+end

--- a/spec/unit/trace/renderer_spec.rb
+++ b/spec/unit/trace/renderer_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/trace/renderer"
+require "browserctl/redactor"
+require "stringio"
+
+RSpec.describe Browserctl::Trace::Renderer do
+  let(:out) { StringIO.new }
+
+  let(:records) do
+    [
+      { "ts" => "2026-05-10T06:21:48.500Z", "level" => "INFO",
+        "component" => "daemon", "event" => "ready", "port" => 1234 },
+      { "ts" => "2026-05-10T06:21:50.000Z", "level" => "ERROR",
+        "component" => "daemon", "msg" => "kaboom" }
+    ]
+  end
+
+  it "renders a fixed event sequence as a timeline" do
+    described_class.new(io: out, color: false).render(records)
+    lines = out.string.lines.map(&:rstrip)
+    expect(lines.length).to eq(2)
+    expect(lines[0]).to include("06:21:48.500", "INFO", "daemon", "ready", "port=1234")
+    expect(lines[1]).to include("06:21:50.000", "!", "ERROR", "kaboom")
+  end
+
+  it "omits ANSI colour codes when color: false" do
+    described_class.new(io: out, color: false).render(records)
+    expect(out.string).not_to include("\e[")
+  end
+
+  it "emits ANSI colour codes when color: true" do
+    described_class.new(io: out, color: true).render(records)
+    expect(out.string).to include("\e[")
+  end
+
+  it "defaults color to TTY-detection of the target IO" do
+    allow(out).to receive_messages(tty?: false)
+    described_class.new(io: out).render(records)
+    expect(out.string).not_to include("\e[")
+  end
+
+  it "applies the injected redactor to formatted lines" do
+    redactor = Browserctl::Redactor.new(secrets: ["kaboom"])
+    described_class.new(io: out, color: false, redactor: redactor).render(records)
+    expect(out.string).not_to include("kaboom")
+    expect(out.string).to include("[REDACTED]")
+  end
+
+  it "renders a fallback timestamp for malformed ts values" do
+    described_class.new(io: out, color: false).render([{ "ts" => "garbage", "level" => "INFO" }])
+    expect(out.string).to include("??:??:??.???")
+  end
+
+  it "categorises snapshot, network, and event records with distinct icons" do
+    snap = { "ts" => "2026-05-10T06:00:00.000Z", "snapshot" => "snap1", "component" => "cli" }
+    net  = { "ts" => "2026-05-10T06:00:01.000Z", "url" => "https://example.com", "component" => "cli" }
+    ev   = { "ts" => "2026-05-10T06:00:02.000Z", "event" => "click", "component" => "cli" }
+
+    described_class.new(io: out, color: false).render([snap, net, ev])
+    lines = out.string.lines.map(&:rstrip)
+    expect(lines[0]).to match(/06:00:00\.000\s+S\s/)
+    expect(lines[1]).to match(/06:00:01\.000\s+N\s/)
+    expect(lines[2]).to match(/06:00:02\.000\s+\.\s/)
+  end
+end


### PR DESCRIPTION
## Summary

Splits `lib/browserctl/commands/trace.rb` (216 LOC) into three focused objects so the command file becomes a thin CLI dispatcher and the rendering / parsing logic is testable without spawning the CLI.

- `Browserctl::Trace::EventStream` — JSONL parsing, malformed-line tolerance, session filtering
- `Browserctl::Trace::Renderer` — timeline formatting, colour, optional injected redactor
- `Browserctl::Commands::Trace` — CLI parser only, wires the two together and reuses `Browserctl::Redactor` for `--no-redact`

Output is byte-identical to the pre-refactor CLI behaviour — pinned by a golden-file spec (`spec/integration/trace_golden_spec.rb`) that diffs `browserctl trace` output against a checked-in fixture. No public CLI surface change.

### LOC

```
$ wc -l lib/browserctl/commands/trace.rb
      76 lib/browserctl/commands/trace.rb
```

Under the plan's <80 LOC target. Companion files:

```
      75 lib/browserctl/trace/event_stream.rb
     107 lib/browserctl/trace/renderer.rb
```

## Test plan

- [x] `bundle exec rspec spec/unit/trace_spec.rb spec/unit/trace/ spec/integration/trace_golden_spec.rb` — 22 examples, 0 failures
- [x] Full suite via pre-push hook — 939 examples, 0 failures, 55 pending (chrome-required)
- [x] `bundle exec rubocop lib/browserctl/commands/trace.rb lib/browserctl/trace/ spec/unit/trace/` — clean
- [x] Golden-file spec asserts byte-identical CLI output against a fixture

Refs `docs/plans/v0.14-polish.md` WS-3 PR 9.