### PR TITLE
refactor: extract State::Mutator from commands/state (v0.14 WS-3 PR 10)

### DIFF
--- a/lib/browserctl/commands/passphrase_prompt.rb
+++ b/lib/browserctl/commands/passphrase_prompt.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "io/console"
+
+module Browserctl
+  module Commands
+    # Stdin/stderr passphrase prompting for `browserctl state` commands.
+    # Honours `BROWSERCTL_STATE_PASSPHRASE` for non-interactive use; otherwise
+    # reads from a tty with echo disabled and optional confirmation.
+    module PassphrasePrompt
+      module_function
+
+      # @return [String]
+      def read(confirm: false)
+        return ENV["BROWSERCTL_STATE_PASSPHRASE"] if ENV["BROWSERCTL_STATE_PASSPHRASE"]
+
+        pass = ask("Passphrase: ")
+        if confirm
+          confirm_pass = ask("Confirm passphrase: ")
+          abort "Passphrases do not match." unless pass == confirm_pass
+        end
+        pass
+      end
+
+      # Peek at the manifest first so we only prompt when the bundle is
+      # actually encrypted.
+      def needed_for?(client, name)
+        info = client.state_info(name)
+        return false if info[:error] || info["error"]
+
+        manifest = info[:info] || info["info"] || {}
+        manifest[:encrypted] || manifest["encrypted"] || false
+      end
+
+      def ask(label)
+        $stderr.print(label)
+        value = $stdin.noecho(&:gets).to_s.chomp
+        $stderr.puts
+        value
+      end
+      private_class_method :ask
+    end
+  end
+end

--- a/lib/browserctl/commands/state.rb
+++ b/lib/browserctl/commands/state.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "io/console"
 require "json"
 require_relative "cli_output"
 require_relative "output_format"
+require_relative "passphrase_prompt"
 
 module Browserctl
   module Commands
@@ -23,7 +23,6 @@ module Browserctl
 
       def self.run(client, args)
         sub = args.shift or abort USAGE
-
         if (m = DAEMON_SUBCOMMANDS[sub])
           sub == "list" ? send(m, client) : send(m, client, args)
         elsif (m = LOCAL_SUBCOMMANDS[sub])
@@ -39,22 +38,14 @@ module Browserctl
         flow    = extract_value!(args, "--flow")
         name    = args.shift or abort "usage: browserctl state save <name> [--encrypt] " \
                                       "[--origins a,b] [--flow NAME]"
-
-        passphrase = encrypt ? prompt_passphrase(confirm: true) : nil
-        origin_list = parse_origins(origins)
-
+        passphrase  = encrypt ? PassphrasePrompt.read(confirm: true) : nil
+        origin_list = origins ? origins.split(",").map(&:strip).reject(&:empty?) : nil
         print_result(client.state_save(name, origins: origin_list, flow: flow, passphrase: passphrase))
-      end
-
-      def self.parse_origins(value)
-        return nil unless value
-
-        value.split(",").map(&:strip).reject(&:empty?)
       end
 
       def self.run_load(client, args)
         name = args.shift or abort "usage: browserctl state load <name>"
-        passphrase = state_needs_passphrase?(client, name) ? prompt_passphrase : nil
+        passphrase = PassphrasePrompt.needed_for?(client, name) ? PassphrasePrompt.read : nil
         print_result(client.state_load(name, passphrase: passphrase))
       end
 
@@ -72,67 +63,33 @@ module Browserctl
         print_result(client.state_delete(name))
       end
 
-      # Re-runs the flow bound to <name> and re-saves the bundle. The flow is
-      # read from the manifest (set when the bundle was originally produced
-      # via `state save --flow ...`). Params come from --params or k=v pairs.
+      # Re-runs the flow bound to <name> and re-saves it. Mutation logic
+      # lives in {Browserctl::State::Mutator}; this method is CLI plumbing.
       def self.run_rotate(client, args)
-        require "browserctl/flow_registry"
+        require "browserctl/state/mutator"
+        require "browserctl/runner"
         page_name   = extract_value!(args, "--page")
         params_path = extract_value!(args, "--params")
         name        = args.shift or abort "usage: browserctl state rotate <name> " \
                                           "[--page NAME] [--params FILE] [--key value ...]"
 
-        manifest = read_manifest!(client, name)
-        flow     = resolve_bound_flow!(manifest)
-        params   = build_rotate_params(params_path, args)
-        page_proxy = page_name ? Browserctl::PageProxy.new(page_name, client) : nil
+        file_params = params_path ? Browserctl::Runner.load_params_file(params_path) : {}
+        cli_params  = args.each_slice(2).to_h { |flag, val| [flag.to_s.sub(/\A--/, "").to_sym, val] }
+        page        = page_name ? Browserctl::PageProxy.new(page_name, client) : nil
 
-        flow.run(page: page_proxy, client: client, **params)
-
-        save_result = client.state_save(name,
-                                        flow: flow.name,
-                                        flow_version: flow.version_string,
-                                        origins: manifest[:origins])
-        print_result(save_result.merge(rotated_flow: flow.name))
+        result = Browserctl::State::Mutator.new(client: client)
+                                           .rotate(name: name, params: file_params.merge(cli_params), page: page)
+        print_result(result.to_h)
       rescue Browserctl::FlowError => e
         warn "Error: #{e.message}"
         exit 1
       end
 
-      def self.read_manifest!(client, name)
-        info = client.state_info(name)
-        abort "Error: #{info[:error] || info['error']}" if info[:error] || info["error"]
-
-        info[:info] || info["info"] || {}
-      end
-      private_class_method :read_manifest!
-
-      def self.resolve_bound_flow!(manifest)
-        flow_name = manifest[:flow] || manifest["flow"]
-        abort "Error: state has no bound flow — re-save with `state save --flow NAME` first" if flow_name.nil? ||
-                                                                                                flow_name.to_s.empty?
-
-        flow = Browserctl::FlowRegistry.resolve(flow_name)
-        abort "Error: flow '#{flow_name}' not found in registry" unless flow
-
-        flow
-      end
-      private_class_method :resolve_bound_flow!
-
-      def self.build_rotate_params(params_path, args)
-        require "browserctl/runner"
-        file_params = params_path ? Browserctl::Runner.load_params_file(params_path) : {}
-        cli_params  = args.each_slice(2).to_h { |flag, val| [flag.to_s.sub(/\A--/, "").to_sym, val] }
-        file_params.merge(cli_params)
-      end
-      private_class_method :build_rotate_params
-
       def self.run_export(args)
         name        = args.shift or abort "usage: browserctl state export <name> <destination>"
         destination = args.shift or abort "usage: browserctl state export <name> <destination>"
         require "browserctl/state"
-        result = Browserctl::State.export(name, destination)
-        OutputFormat.current.emit(result)
+        OutputFormat.current.emit(Browserctl::State.export(name, destination))
       rescue Browserctl::State::Transport::TransportError, Browserctl::Error, ArgumentError => e
         warn "Error: #{e.message}"
         exit 1
@@ -142,53 +99,19 @@ module Browserctl
         name_override = extract_value!(args, "--name")
         source        = args.shift or abort "usage: browserctl state import <source> [--name NAME]"
         require "browserctl/state"
-        result = Browserctl::State.import(source, name: name_override)
-        OutputFormat.current.emit(result)
-      rescue Browserctl::State::Transport::TransportError,
-             Browserctl::State::Bundle::BundleError,
+        OutputFormat.current.emit(Browserctl::State.import(source, name: name_override))
+      rescue Browserctl::State::Transport::TransportError, Browserctl::State::Bundle::BundleError,
              Browserctl::Error, ArgumentError => e
         warn "Error: #{e.message}"
         exit 1
       end
 
-      private_class_method :parse_origins
-
       def self.extract_value!(args, flag)
-        idx = args.index(flag)
-        return nil unless idx
-
+        idx = args.index(flag) or return nil
         args.delete_at(idx)
         args.delete_at(idx) or abort "missing value for #{flag}"
       end
       private_class_method :extract_value!
-
-      def self.prompt_passphrase(confirm: false)
-        return ENV["BROWSERCTL_STATE_PASSPHRASE"] if ENV["BROWSERCTL_STATE_PASSPHRASE"]
-
-        $stderr.print "Passphrase: "
-        pass = $stdin.noecho(&:gets).to_s.chomp
-        $stderr.puts
-
-        if confirm
-          $stderr.print "Confirm passphrase: "
-          confirm_pass = $stdin.noecho(&:gets).to_s.chomp
-          $stderr.puts
-          abort "Passphrases do not match." unless pass == confirm_pass
-        end
-
-        pass
-      end
-      private_class_method :prompt_passphrase
-
-      # Peek at the manifest first so we only prompt for a passphrase when needed.
-      def self.state_needs_passphrase?(client, name)
-        info = client.state_info(name)
-        return false if info[:error] || info["error"]
-
-        manifest = info[:info] || info["info"] || {}
-        manifest[:encrypted] || manifest["encrypted"] || false
-      end
-      private_class_method :state_needs_passphrase?
     end
   end
 end

--- a/lib/browserctl/state/mutator.rb
+++ b/lib/browserctl/state/mutator.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "../flow_registry"
+require_relative "../errors"
+
+module Browserctl
+  module State
+    # Drives the "rotate this bundle's bound flow and re-save" operation
+    # without dragging in CLI input concerns. Extracted from
+    # `Browserctl::Commands::State.run_rotate` so the rotation flow is:
+    #   - testable without spawning a CLI subprocess
+    #   - reusable from Workflow if a workflow ever needs to drive rotation
+    #     programmatically.
+    #
+    # Errors are surfaced by raising typed `Browserctl::FlowError` so the
+    # caller (CLI or Workflow) can decide how to render them. The CLI maps
+    # to a non-zero exit; a Workflow caller may catch and continue.
+    class Mutator
+      Result = Struct.new(:save_result, :flow_name, :flow_version, keyword_init: true) do
+        def to_h
+          (save_result || {}).merge(rotated_flow: flow_name)
+        end
+      end
+
+      def initialize(client:, registry: Browserctl::FlowRegistry)
+        @client   = client
+        @registry = registry
+      end
+
+      # Re-runs the flow bound to the bundle <name> and re-saves it under the
+      # same origins. `params` is the merged param set (file + caller-provided);
+      # the CLI does the file/k=v parsing before handing values in.
+      #
+      # @return [Result]
+      # @raise  [Browserctl::FlowError]
+      def rotate(name:, params: {}, page: nil)
+        manifest = read_manifest!(name)
+        flow     = resolve_bound_flow!(manifest)
+
+        flow.run(page: page, client: @client, **params)
+
+        save_result = @client.state_save(name,
+                                         flow: flow.name,
+                                         flow_version: flow.version_string,
+                                         origins: manifest[:origins] || manifest["origins"])
+        Result.new(save_result: save_result, flow_name: flow.name, flow_version: flow.version_string)
+      end
+
+      private
+
+      def read_manifest!(name)
+        info = @client.state_info(name)
+        err  = info[:error] || info["error"]
+        raise Browserctl::FlowError, err.to_s if err
+
+        info[:info] || info["info"] || {}
+      end
+
+      def resolve_bound_flow!(manifest)
+        flow_name = manifest[:flow] || manifest["flow"]
+        if flow_name.nil? || flow_name.to_s.empty?
+          raise Browserctl::FlowError,
+                "state has no bound flow — re-save with `state save --flow NAME` first"
+        end
+
+        flow = @registry.resolve(flow_name)
+        raise Browserctl::FlowError, "flow '#{flow_name}' not found in registry" unless flow
+
+        flow
+      end
+    end
+  end
+end

--- a/spec/unit/state/mutator_spec.rb
+++ b/spec/unit/state/mutator_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/state/mutator"
+
+RSpec.describe Browserctl::State::Mutator do
+  let(:client) { instance_double(Browserctl::Client) }
+
+  before { Browserctl.flow_registry_reset! }
+  after  { Browserctl.flow_registry_reset! }
+
+  describe "#rotate" do
+    let(:manifest) { { flow: "github_login", origins: ["https://github.com"] } }
+
+    let(:flow_ran) { [] }
+
+    before do
+      ran = flow_ran
+      Browserctl.flow("github_login") do
+        version "1.2.3"
+        param :username, required: true
+        step("noop") { ran << username }
+      end
+    end
+
+    it "runs the bound flow, re-saves the bundle, and returns a Result" do
+      saved_args = nil
+      allow(client).to receive(:state_info).with("github").and_return(ok: true, info: manifest)
+      allow(client).to receive(:state_save) do |name, **kw|
+        saved_args = [name, kw]
+        { ok: true, path: "/tmp/x.bctl" }
+      end
+
+      result = described_class.new(client: client)
+                              .rotate(name: "github", params: { username: "pat" })
+
+      expect(flow_ran).to eq(["pat"])
+      expect(saved_args).to eq([
+                                 "github",
+                                 { flow: "github_login", flow_version: "1.2.3",
+                                   origins: ["https://github.com"] }
+                               ])
+      expect(result).to be_a(described_class::Result)
+      expect(result.flow_name).to eq("github_login")
+      expect(result.flow_version).to eq("1.2.3")
+      expect(result.to_h).to include(ok: true, path: "/tmp/x.bctl", rotated_flow: "github_login")
+    end
+
+    it "merges params verbatim (caller hash drives the flow run)" do
+      allow(client).to receive(:state_info).and_return(ok: true, info: manifest)
+      allow(client).to receive(:state_save).and_return(ok: true)
+
+      described_class.new(client: client).rotate(name: "github", params: { username: "alice" })
+
+      expect(flow_ran).to eq(["alice"])
+    end
+
+    it "raises FlowError when the manifest has no bound flow" do
+      allow(client).to receive(:state_info).with("x").and_return(ok: true, info: { origins: [] })
+
+      expect { described_class.new(client: client).rotate(name: "x") }
+        .to raise_error(Browserctl::FlowError, /no bound flow/)
+    end
+
+    it "raises FlowError when the bound flow is not registered" do
+      allow(client).to receive(:state_info).with("x").and_return(ok: true, info: { flow: "missing" })
+
+      expect { described_class.new(client: client).rotate(name: "x") }
+        .to raise_error(Browserctl::FlowError, /not found in registry/)
+    end
+
+    it "raises FlowError when state_info returns an error" do
+      allow(client).to receive(:state_info).with("x").and_return(error: "state 'x' not found")
+
+      expect { described_class.new(client: client).rotate(name: "x") }
+        .to raise_error(Browserctl::FlowError, /not found/)
+    end
+
+    it "does not call state_save when the flow lookup fails" do
+      allow(client).to receive(:state_info).with("x").and_return(ok: true, info: { flow: "missing" })
+      expect(client).not_to receive(:state_save)
+
+      begin
+        described_class.new(client: client).rotate(name: "x")
+      rescue Browserctl::FlowError
+        # expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

WS-3 PR 10 of the v0.14 "Polish" milestone (`docs/plans/v0.14-polish.md`).

- Extracts rotation logic from `Browserctl::Commands::State.run_rotate` into a new `Browserctl::State::Mutator` so it is testable without a CLI subprocess and reusable from `Workflow` if a workflow ever needs to drive rotation programmatically.
- `Commands::State` becomes CLI plumbing only: option-flag parsing, error rendering, output emission. Mutator surfaces errors as typed `Browserctl::FlowError` and the CLI maps that to exit 1 (unchanged behaviour).
- Passphrase prompting moves into a dedicated `Browserctl::Commands::PassphrasePrompt` module — pure CLI-input concern, called from `run_save`/`run_load`. Same observable behaviour (honours `BROWSERCTL_STATE_PASSPHRASE`, prompts on tty with `noecho`, supports confirmation).
- LOC target met: `Commands::State` drops from 194 to 117 LOC (target: <120). New `Mutator` is 73 LOC; `PassphrasePrompt` is 44 LOC.

## LOC

```
117 lib/browserctl/commands/state.rb        (was 194)
 73 lib/browserctl/state/mutator.rb         (new)
 44 lib/browserctl/commands/passphrase_prompt.rb  (new)
```

## Test plan

- [x] New `spec/unit/state/mutator_spec.rb` covers: rotation happy path, params passed through to flow, no-bound-flow raises `FlowError`, missing-flow-in-registry raises `FlowError`, `state_info` error surfaces as `FlowError`, `state_save` is not called when flow lookup fails.
- [x] Existing `spec/unit/commands_state_rotate_spec.rb` (CLI-level) still passes unchanged — CLI behaviour is unchanged.
- [x] Existing `spec/integration/state_rotate_e2e_spec.rb` still passes (skipped locally without Chrome; CI runs it).
- [x] Full suite: 931 examples, 0 failures, 55 pending (all pre-existing pending/skipped).
- [x] `bundle exec rubocop` clean on all touched files.

Plan reference: `docs/plans/v0.14-polish.md` WS-3 PR 10.