### PR TITLE
refactor: typed errors on surprise raise sites (v0.14 WS-1 PR 4b)

### DIFF
--- a/lib/browserctl/driver/cdp.rb
+++ b/lib/browserctl/driver/cdp.rb
@@ -80,7 +80,11 @@ module Browserctl
         when "brave"
           resolve_brave_path
         else
-          raise ArgumentError, "Unknown browser: #{@browser.inspect}"
+          raise Browserctl::Error.new(
+            "Unknown browser: #{@browser.inspect}",
+            code: Browserctl::Error::Codes::VALIDATION_FAILED,
+            context: { browser: @browser }
+          )
         end
       end
 

--- a/lib/browserctl/flow_registry.rb
+++ b/lib/browserctl/flow_registry.rb
@@ -60,7 +60,11 @@ module Browserctl
     def self.validate_name!(name)
       return if SAFE_NAME.match?(name.to_s)
 
-      raise ArgumentError, "invalid flow name: #{name.inspect} — use letters, digits, _ and - only"
+      raise Browserctl::Error.new(
+        "invalid flow name: #{name.inspect} — use letters, digits, _ and - only",
+        code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+        context: { name: name.to_s }
+      )
     end
   end
 end

--- a/lib/browserctl/flows/stdlib/totp_2fa.rb
+++ b/lib/browserctl/flows/stdlib/totp_2fa.rb
@@ -31,7 +31,11 @@ module Browserctl
 
       def char_to_bits(char)
         idx = BASE32_ALPHABET.index(char) or
-          raise ArgumentError, "invalid base32 char #{char.inspect}"
+          raise Browserctl::Error.new(
+            "invalid base32 char #{char.inspect}",
+            code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+            context: { char: char }
+          )
         idx.to_s(2).rjust(5, "0")
       end
     end

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -320,9 +320,12 @@ module Browserctl
     def compose(workflow_name)
       name = workflow_name.to_s
       if Browserctl.lookup_flow(name)
-        raise ArgumentError,
-              "workflow '#{@name}' cannot compose flow '#{name}': flows return state, " \
-              "workflows share state — composition across kinds is not supported"
+        raise Browserctl::Error.new(
+          "workflow '#{@name}' cannot compose flow '#{name}': flows return state, " \
+          "workflows share state — composition across kinds is not supported",
+          code: Browserctl::Error::Codes::INVALID_DSL_USAGE,
+          context: { workflow: @name, flow: name, kind: :cross_kind_compose }
+        )
       end
 
       source = Browserctl.lookup_workflow(name)

--- a/spec/unit/callable_definition_spec.rb
+++ b/spec/unit/callable_definition_spec.rb
@@ -44,7 +44,10 @@ RSpec.describe Browserctl::CallableDefinition do
         Browserctl.workflow("composing_wf") do
           compose :my_flow
         end
-      end.to raise_error(ArgumentError, /cannot compose flow/)
+      end.to raise_error(Browserctl::Error) { |err|
+        expect(err.message).to match(/cannot compose flow/)
+        expect(err.code).to eq(Browserctl::Error::Codes::INVALID_DSL_USAGE)
+      }
     end
 
     it "rejects a flow composing a workflow" do

--- a/spec/unit/flow_registry_spec.rb
+++ b/spec/unit/flow_registry_spec.rb
@@ -72,7 +72,10 @@ RSpec.describe Browserctl::FlowRegistry do
 
     it "rejects unsafe flow names" do
       expect { described_class.resolve("../etc/passwd") }
-        .to raise_error(ArgumentError, /invalid flow name/)
+        .to raise_error(Browserctl::Error) { |err|
+          expect(err.message).to match(/invalid flow name/)
+          expect(err.code).to eq(Browserctl::Error::Codes::INVALID_DSL_USAGE)
+        }
     end
 
     it "prefers the project file when both project and stdlib define the same name" do


### PR DESCRIPTION
## Summary

PR 4 (#185) closed the DSL guards in `flow.rb`, `callable_definition.rb`, `migrations.rb`, and `format_version.rb`, but the grep sweep surfaced four additional bare `raise ArgumentError` sites that weren't in the original plan. This PR closes them out so WS-1 PR 5 (cop disable removal) can land cleanly.

| File | Code |
|------|------|
| `lib/browserctl/flow_registry.rb` (`validate_name!`) | `INVALID_DSL_USAGE` |
| `lib/browserctl/workflow.rb` (`WorkflowDefinition#compose`) | `INVALID_DSL_USAGE` |
| `lib/browserctl/driver/cdp.rb` (`resolve_browser_path`) | `VALIDATION_FAILED` — defensive guard on internal `@browser` value, not user input |
| `lib/browserctl/flows/stdlib/totp_2fa.rb` (`char_to_bits`) | `INVALID_DSL_USAGE` — base32 input validation; cop config does not exempt `lib/browserctl/flows/stdlib/**` |

Prose messages unchanged; the only diff is the typed-error wrapper. All four map to exit code 8 (`VALIDATION_FAILED`).

The CLI error matrix already has cells for `INVALID_DSL_USAGE` and `VALIDATION_FAILED` (PR 4 / #185 and PR 1 enum reservation); no new cells needed — these are additional reachable paths for the existing cells. Unblocks WS-1 PR 5.

### Cop exemption check

`.rubocop.yml` excludes only the cop's own source tree:

```yaml
Browserctl/TypedError:
  Enabled: true
  Include:
    - "lib/**/*.rb"
  Exclude:
    - "lib/browserctl/rubocop/**/*"
```

So `totp_2fa.rb` is not exempt and was converted.

### Post-conversion grep

```
$ git grep -nE 'raise ArgumentError' lib/
(no output)
```

## Test plan

- [x] `bundle exec rspec spec/unit/flow_registry_spec.rb spec/unit/workflow_spec.rb spec/unit/callable_definition_spec.rb spec/unit/driver_cdp_spec.rb spec/unit/flows/stdlib/totp_2fa_spec.rb spec/unit/error_codes_spec.rb spec/integration/cli_error_matrix_spec.rb` passes
- [x] `bundle exec rubocop` on touched files clean
- [x] Pre-push full rspec: 966 examples, 0 failures, 54 pending
- [x] `git grep "raise ArgumentError" lib/` returns nothing