### PR TITLE
refactor: extract Client::RecordingInterceptor (v0.14 WS-2 PR 6)

### DIFF
--- a/lib/browserctl/client.rb
+++ b/lib/browserctl/client.rb
@@ -4,18 +4,19 @@ require "fileutils"
 require "socket"
 require "json"
 require_relative "constants"
-require_relative "recording"
+require_relative "client/recording_interceptor"
 
 module Browserctl
   # Thin IPC client that wraps each browserd command as a Ruby method call.
   class Client
-    def initialize(socket_path = nil)
+    def initialize(socket_path = nil, recording_interceptor: nil)
       @socket_path = socket_path || auto_discover_socket
+      @recording_interceptor = recording_interceptor
     end
 
     def call(cmd, **params)
       result = communicate(JSON.generate({ cmd: cmd }.merge(params)))
-      Recording.append(cmd, response: result, **params) if result[:ok]
+      recording_interceptor.append(cmd, response: result, params: params)
       result
     rescue Errno::ENOENT, Errno::ECONNREFUSED
       raise DaemonUnavailableError, "browserd is not running — start it with: browserd"
@@ -57,7 +58,7 @@ module Browserctl
       end
 
       call("click", name: name, selector: selector, ref: ref,
-                    capture_post_snapshot: Recording.active ? true : nil)
+                    capture_post_snapshot: recording_interceptor.capture_post_snapshot_flag)
     end
 
     # Fills an input element with a value.
@@ -76,7 +77,7 @@ module Browserctl
       end
 
       call("fill", name: name, selector: selector, ref: ref, value: value,
-                   capture_post_snapshot: Recording.active ? true : nil)
+                   capture_post_snapshot: recording_interceptor.capture_post_snapshot_flag)
     end
 
     # Takes a screenshot of a named page.
@@ -356,6 +357,10 @@ module Browserctl
     end
 
     private
+
+    def recording_interceptor
+      @recording_interceptor ||= RecordingInterceptor.new
+    end
 
     def auto_discover_socket
       default = Browserctl.socket_path

--- a/lib/browserctl/client/recording_interceptor.rb
+++ b/lib/browserctl/client/recording_interceptor.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../recording"
+
+module Browserctl
+  class Client
+    # Bridges Client#call to the Recording subsystem. Keeps Client itself a
+    # pure IPC shim — Recording is pluggable via constructor injection.
+    class RecordingInterceptor
+      def initialize(recording: Browserctl::Recording)
+        @recording = recording
+      end
+
+      # Whether recording is currently active. Call sites that need to vary
+      # their request shape (e.g. click/fill passing capture_post_snapshot:)
+      # can ask without touching Recording directly.
+      def active?
+        @recording.active
+      end
+
+      # Returns `true` when active, `nil` otherwise. Matches the shape that
+      # click/fill historically passed as the `capture_post_snapshot` param.
+      def capture_post_snapshot_flag
+        return true if active?
+
+        nil
+      end
+
+      # Called after a successful Client#call to append the command and
+      # response to the active recording log. No-op if the response was
+      # not ok (recording only captures successful interactions).
+      def append(cmd, response:, params: {})
+        return unless response[:ok]
+
+        @recording.append(cmd, response: response, **params)
+      end
+    end
+  end
+end

--- a/spec/unit/client/recording_interceptor_spec.rb
+++ b/spec/unit/client/recording_interceptor_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/client/recording_interceptor"
+
+RSpec.describe Browserctl::Client::RecordingInterceptor do
+  let(:recording) { double("Recording", active: false, append: nil) }
+  subject(:interceptor) { described_class.new(recording: recording) }
+
+  describe "#active?" do
+    it "delegates to the injected recording module" do
+      allow(recording).to receive(:active).and_return("flow-name")
+      expect(interceptor.active?).to eq("flow-name")
+    end
+
+    it "returns nil/false when recording is off" do
+      allow(recording).to receive(:active).and_return(nil)
+      expect(interceptor.active?).to be_falsey
+    end
+  end
+
+  describe "#capture_post_snapshot_flag" do
+    it "returns true when active" do
+      allow(recording).to receive(:active).and_return("flow")
+      expect(interceptor.capture_post_snapshot_flag).to be(true)
+    end
+
+    it "returns nil when inactive" do
+      allow(recording).to receive(:active).and_return(nil)
+      expect(interceptor.capture_post_snapshot_flag).to be_nil
+    end
+  end
+
+  describe "#append" do
+    it "is a no-op when response is not ok" do
+      expect(recording).not_to receive(:append)
+      interceptor.append("click", response: { ok: false, error: "boom" }, params: { name: "x" })
+    end
+
+    it "calls Recording.append with cmd, response: and spreads params:" do
+      response = { ok: true, value: 1 }
+      expect(recording).to receive(:append)
+        .with("fill", response: response, name: "main", selector: "input", value: "hi")
+      interceptor.append("fill",
+                         response: response,
+                         params: { name: "main", selector: "input", value: "hi" })
+    end
+
+    it "handles missing params (empty hash)" do
+      response = { ok: true }
+      expect(recording).to receive(:append).with("ping", response: response)
+      interceptor.append("ping", response: response)
+    end
+  end
+
+  describe "default constructor" do
+    it "defaults to the Browserctl::Recording module" do
+      default = described_class.new
+      expect(default.instance_variable_get(:@recording)).to eq(Browserctl::Recording)
+    end
+  end
+end

--- a/spec/unit/workflow_spec.rb
+++ b/spec/unit/workflow_spec.rb
@@ -105,8 +105,14 @@ RSpec.describe Browserctl::WorkflowDefinition do
 end
 
 RSpec.describe "compose" do
-  before { Browserctl.instance_variable_set(:@registry, {}) }
-  after  { Browserctl.instance_variable_set(:@registry, {}) }
+  before do
+    Browserctl.instance_variable_set(:@registry, {})
+    Browserctl.flow_registry_reset!
+  end
+  after do
+    Browserctl.instance_variable_set(:@registry, {})
+    Browserctl.flow_registry_reset!
+  end
 
   it "inlines steps from another workflow" do
     Browserctl.workflow "shared" do


### PR DESCRIPTION
## Summary

Decouples `Browserctl::Client` from `Browserctl::Recording`.

Before this PR `Client#call` inlined `Recording.append(...)` after every IPC roundtrip, and `Client#click` / `Client#fill` consulted `Recording.active` directly to decide whether to ask the daemon for a post-snapshot. After this PR the client only depends on a single `RecordingInterceptor` collaborator; the Recording module is pluggable via constructor injection (`Client.new(recording_interceptor: <double>)`).

- New `Browserctl::Client::RecordingInterceptor` at `lib/browserctl/client/recording_interceptor.rb`
  - `#active?` — delegates to the injected recording module
  - `#capture_post_snapshot_flag` — returns `true` when active, `nil` otherwise (preserves the historical wire shape used by click/fill)
  - `#append(cmd, response:, params:)` — no-op when `response[:ok]` is falsey
- `Client#call`, `#click`, `#fill` updated to route through the interceptor
- New unit spec `spec/unit/client/recording_interceptor_spec.rb`

## Surface lock

Zero public surface change. `Browserctl::Client.public_instance_methods` matches `spec/fixtures/public_surface.yml` byte-identically; the lock-file spec (added in #187) passes unmodified.

`grep -nw Recording lib/browserctl/client.rb` returns no matches — only the new `RecordingInterceptor` class name remains as a substring.

## Test plan

- [x] `bundle exec rspec spec/unit/client/recording_interceptor_spec.rb` — 8 new examples pass
- [x] `bundle exec rspec spec/public_surface_spec.rb` — green, lock-file fixture unchanged
- [x] `bundle exec rspec spec/integration/ -e recording` — hot-path replayable recording integration spec passes unmodified (Risk: Medium per plan)
- [x] `bundle exec rspec` (full pre-push hook) — 974 examples, 0 failures, 54 pending
- [x] `bundle exec rubocop lib/browserctl/client.rb lib/browserctl/client/ spec/unit/client/` — clean

Refs: `docs/plans/v0.14-polish.md` WS-2 PR 6.