### PR TITLE
refactor: tighten TypedError cop (v0.14 WS-1 PR 5)

### DIFF
--- a/docs/plans/v0.14-polish.md
+++ b/docs/plans/v0.14-polish.md
@@ -120,18 +120,41 @@ prose. `grep -rn "raise ArgumentError" lib/` returns nothing.
 **Risk:** Low. These raise at DSL definition time — broken usage fails fast
 either way.
 
-### PR 5 · `chore: remove TypedError cop disables`
+### PR 5 · `refactor: tighten TypedError cop`
 
-After PRs 2–4 the cop should run without any inline `# rubocop:disable
-Browserctl/TypedError` comments. Sweep and remove. Tighten the cop config to
-fail CI on new violations.
+The "remove inline disables" half of this PR turned out to be a no-op:
+PRs 2/3/4/4b converted every bare `ArgumentError` to a typed `Browserctl::Error`
+with a `Codes::*` constant, so no `# rubocop:disable Browserctl/TypedError`
+comments ever needed to land in `lib/`. The grep is already clean.
 
-**Files:** `lib/`, `.rubocop.yml`.
+The "tighten" half is real and is what this PR ships:
 
-**Acceptance:** `git grep TypedError` returns only the cop definition and its
-spec.
+- Remove the `VALID_CODES` whitelist baked into the cop. The whitelist was
+  stale (frozen at six of the v0.12 codes; missing the three remaining v0.12
+  codes and the entire v0.14 `VALIDATION_FAILED` family) and contradicted
+  the cop's stated intent — any string literal in `code:` is wrong even
+  when it happens to spell a canonical code, because renames in
+  `Browserctl::Error::Codes` must propagate through constant references,
+  not via a hand-maintained list inside the cop.
+- Add a second matcher for `raise Browserctl::Error.new(..., code: ...)`.
+  The previous pattern only matched the comma-arg form
+  `raise Browserctl::Error, msg, code: ...`, which is not how the
+  codebase calls it today — every typed raise wired by WS-1 uses `.new`.
 
-**Risk:** None.
+**Files:** `lib/browserctl/rubocop/cops/typed_error.rb`, `spec/rubocop/typed_error_spec.rb`.
+
+**Acceptance:**
+- `bundle exec rubocop --only Browserctl/TypedError` returns no offences
+  across all 233 lib files.
+- `git grep "raise ArgumentError" lib/` returns nothing (verified across
+  PRs 2/3/4/4b).
+- `git grep TypedError` returns only the cop definition, its spec, and
+  this plan doc.
+- Spec covers both `raise Klass, msg, code:` and `raise Klass.new(msg, code:)`
+  shapes; flags ANY string literal in `code:`, even canonical ones.
+
+**Risk:** None. The cop only newly flags shapes that don't exist in the
+codebase.
 
 ---
 

--- a/lib/browserctl/rubocop/cops/typed_error.rb
+++ b/lib/browserctl/rubocop/cops/typed_error.rb
@@ -12,12 +12,13 @@ module RuboCop
       # Subclasses with their own `default_code` are trusted (the cop does not
       # try to statically resolve `default_code` across files); the contract
       # is enforced by the unit test suite. This cop's job is to catch the
-      # specific failure mode of inlining a stale snake_case code at the
-      # raise site and bypassing the canonical enum.
+      # specific failure mode of inlining a stale code string at the raise
+      # site and bypassing the canonical enum.
       #
       # @example
-      #   # bad — string literal that isn't a Codes constant
-      #   raise Browserctl::Error, "state expired", code: "state_expired"
+      #   # bad — any string literal, even one that happens to match a
+      #   # canonical code today, drifts when the enum is renamed
+      #   raise Browserctl::Error, "state expired", code: "STATE_EXPIRED"
       #
       #   # good — Codes constant reference
       #   raise Browserctl::Error, "state expired",
@@ -29,18 +30,15 @@ module RuboCop
       # The pattern is intentionally narrow. The full default_code-vs-Codes
       # reconciliation lives in `lib/browserctl/errors.rb` and is covered by
       # `spec/unit/errors_spec.rb`.
+      #
+      # The cop was tightened in v0.14 WS-1 PR 5 to remove the previous
+      # "canonical SCREAMING_SNAKE string literals are also fine" escape
+      # hatch — every `code:` must now be a constant reference so renames in
+      # `Codes` propagate through the codebase via the constant, not via a
+      # stale whitelist baked into this cop.
       class TypedError < RuboCop::Cop::Base
         MSG = "Browserctl raise: `code:` must reference Browserctl::Error::Codes::* — " \
               "got string literal %<value>p. See lib/browserctl/error/codes.rb."
-
-        VALID_CODES = %w[
-          AUTH_REQUIRED
-          SELECTOR_NOT_FOUND
-          STATE_EXPIRED
-          SECRET_RESOLUTION_FAILED
-          DAEMON_UNREACHABLE
-          PROTOCOL_MISMATCH
-        ].freeze
 
         # Matches `raise Browserctl::Foo, ..., code: <value>` and yields the
         # `code:` value node.
@@ -51,16 +49,27 @@ module RuboCop
             (hash <(pair (sym :code) $_) ...>))
         PATTERN
 
+        # Matches `raise Browserctl::Foo.new(..., code: <value>, ...)` and
+        # yields the `code:` value node. The base error initializer is
+        # routinely called via `.new` (see `Browserctl::Error#initialize`),
+        # so the cop needs to inspect both shapes.
+        def_node_matcher :browserctl_raise_new_with_code, <<~PATTERN
+          (send nil? :raise
+            (send (const (const nil? :Browserctl) _) :new
+              ...
+              (hash <(pair (sym :code) $_) ...>)))
+        PATTERN
+
         def on_send(node)
           return unless node.method?(:raise)
 
-          browserctl_raise_with_code(node) do |code_value|
+          [
+            browserctl_raise_with_code(node),
+            browserctl_raise_new_with_code(node)
+          ].compact.each do |code_value|
             next unless code_value.str_type?
 
-            value = code_value.value
-            next if VALID_CODES.include?(value)
-
-            add_offense(code_value, message: format(MSG, value: value))
+            add_offense(code_value, message: format(MSG, value: code_value.value))
           end
         end
       end

--- a/spec/rubocop/typed_error_spec.rb
+++ b/spec/rubocop/typed_error_spec.rb
@@ -25,18 +25,39 @@ RSpec.describe RuboCop::Cop::Browserctl::TypedError do
     RUBY
   end
 
-  it "accepts a raise with code: matching a canonical SCREAMING_SNAKE string" do
+  it "accepts a raise Browserctl::Error.new(..., code: Codes::...) form" do
     expect(offenses_for(<<~RUBY)).to be_empty
-      raise Browserctl::Error, "auth", code: "AUTH_REQUIRED"
+      raise Browserctl::Error.new(
+        "expired",
+        code: Browserctl::Error::Codes::STATE_EXPIRED
+      )
     RUBY
   end
 
-  it "flags a raise whose explicit code: is a non-canonical string literal" do
+  it "flags ANY string literal passed as code:, even a canonical SCREAMING_SNAKE one" do
+    # Tightened in v0.14 WS-1 PR 5: every `code:` must be a Codes constant so
+    # renames in the enum propagate. No stale whitelist of allowed strings.
+    offenses = offenses_for(<<~RUBY)
+      raise Browserctl::Error, "auth", code: "AUTH_REQUIRED"
+    RUBY
+    expect(offenses.size).to eq(1)
+    expect(offenses.first.message).to include("string literal \"AUTH_REQUIRED\"")
+  end
+
+  it "flags a non-canonical string literal in code:" do
     offenses = offenses_for(<<~RUBY)
       raise Browserctl::Error, "boom", code: "state_expired"
     RUBY
     expect(offenses.size).to eq(1)
     expect(offenses.first.message).to include("string literal \"state_expired\"")
+  end
+
+  it "flags a string literal in the .new(..., code:) shape too" do
+    offenses = offenses_for(<<~RUBY)
+      raise Browserctl::Error.new("boom", code: "STATE_EXPIRED")
+    RUBY
+    expect(offenses.size).to eq(1)
+    expect(offenses.first.message).to include("string literal \"STATE_EXPIRED\"")
   end
 
   it "ignores plain Ruby raises that are not Browserctl errors" do


### PR DESCRIPTION
## Summary

Closes WS-1 of v0.14 (typed-error completion).

The plan called for **two** things in PR 5:
1. Remove inline `# rubocop:disable Browserctl/TypedError` comments from `lib/`.
2. Tighten the cop config to fail CI on new violations.

(1) turned out to be a no-op — PRs 2/3/4/4b converted every bare `ArgumentError` to a typed `Browserctl::Error` with a `Codes::*` constant, so no inline disables ever needed to land. `git grep "rubocop:disable.*TypedError" lib/` returns nothing pre-PR.

(2) is what this PR ships — and there was a real bug to fix.

### The tightening

**Removed the `VALID_CODES` whitelist baked into the cop.** It was stale (frozen at six of the v0.12 codes; missing `DOMAIN_NOT_ALLOWED`, `KEY_NOT_FOUND`, `GENERIC`, plus the entire v0.14 `VALIDATION_FAILED` family added in #179) and contradicted the cop's intent — any string literal in `code:` is wrong even when it happens to spell a canonical code, because renames in `Browserctl::Error::Codes` must propagate via the constant reference, not via a hand-maintained list inside the cop.

**Added a second matcher** for `raise Browserctl::Error.new(..., code: ...)`. The previous pattern only matched the comma-arg form `raise Klass, msg, code: ...`, which is not how the codebase calls it today — every typed raise wired by WS-1 uses `.new`. The cop was effectively silent on the dominant call shape.

### Acceptance evidence

- `bundle exec rubocop --only Browserctl/TypedError` — **233 files inspected, no offences detected.**
- `git grep "raise ArgumentError" lib/` — empty.
- `git grep TypedError` — only the cop definition, this PR's spec, and `docs/plans/v0.14-polish.md` (which documents the cop).
- Cop spec covers both `raise Klass, msg, code:` and `raise Klass.new(msg, code:)` shapes; flags ANY string literal in `code:`, even canonical SCREAMING_SNAKE ones.

## Test plan

- [x] `bundle exec rspec spec/rubocop/typed_error_spec.rb` — 7 examples, 0 failures.
- [x] `bundle exec rubocop` — clean across all touched files.
- [x] Pre-push hook (full rspec) — green.

## v0.14 milestone status after this PR

WS-1 (typed-error completion): ✓ closes here.
WS-2 (boundary cleanup): ✓ all three PRs (#183 rename, #184 rescues, #190 RecordingInterceptor) merged.
WS-3 (command-layer extractions): ✓ #186 (TraceRenderer) and #188 (StateMutator) merged.
WS-4 (public surface guard): ✓ #187 merged.

v0.14 is functionally complete after this lands. release-please's #180 will regenerate to capture the full milestone.

Refs: `docs/plans/v0.14-polish.md` WS-1 PR 5.