### PR TITLE
docs: fix stale session save/load references (v0.15 WS-6 PR 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ browserctl url main
 browserctl page snapshot main --diff       # only what changed
 
 # Session persistence: save now, pick up later
-browserctl session save my-session
-# On a fresh daemon tomorrow: `browserctl session load my-session`
+browserctl state save my-session
+# On a fresh daemon tomorrow: `browserctl state load my-session`
 # → tabs restored, cookies intact, no re-login needed
 
 # 7. Done

--- a/docs/concepts/sessions-and-pages.md
+++ b/docs/concepts/sessions-and-pages.md
@@ -65,28 +65,24 @@ No re-authentication. No cookie injection. The session is just alive.
 
 ## Saving and restoring sessions
 
-In-memory state is lost when the daemon stops. `session save` captures everything — open pages, cookies, and localStorage — to disk. `session load` restores it into a running daemon, including re-opening every saved page at its saved URL.
+In-memory state is lost when the daemon stops. `state save` captures everything — open pages, cookies, and localStorage — to disk. `state load` restores it into a running daemon, including re-opening every saved page at its saved URL.
 
 ```bash
 # After logging in and navigating to the right state:
-browserctl session save github_work           # plaintext (0o600 perms)
-browserctl session save github_work --encrypt # AES-256-GCM, key in macOS Keychain
+browserctl state save github_work           # plaintext (0o600 perms)
+browserctl state save github_work --encrypt # AES-256-GCM, key in macOS Keychain
 
 # Next time, on a fresh daemon:
 browserd &
-browserctl session load github_work
+browserctl state load github_work
 # → pages are back, cookies are restored, localStorage is seeded
 ```
 
-Plaintext sessions live in `~/.browserctl/sessions/<name>/` as `0o600` JSON files. Encrypted sessions store `.enc` blobs instead — the decryption key is kept in macOS Keychain and retrieved transparently on load:
+State bundles live as single `.bctl` files under `~/.browserctl/state/` with `0o600` perms. When `--encrypt` is used, the bundle body is AES-256-GCM encrypted and the decryption key is kept in macOS Keychain, retrieved transparently on load:
 
 ```
-~/.browserctl/sessions/github_work/
-  metadata.json            # page names + URLs + timestamps (always plaintext)
-  cookies.json             # plaintext, or…
-  cookies.json.enc         # …AES-256-GCM blob when --encrypt was used
-  local_storage.json(.enc)
-  session_storage.json(.enc)
+~/.browserctl/state/
+  github_work.bctl         # one bundle per name — plaintext or encrypted
 ```
 
 To share a session or move it to another machine, export it as a zip. Add `--encrypt` to protect the archive with a passphrase (prompted on export; detected automatically on import):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,14 +156,14 @@ browserctl page snapshot main --diff
 If you want to pick up exactly where you left off next time — same tabs, same cookies, same auth — save your session before stopping:
 
 ```bash
-browserctl session save my-first-session
+browserctl state save my-first-session
 ```
 
 Restore it on a fresh daemon:
 
 ```bash
 browserd &
-browserctl session load my-first-session
+browserctl state load my-first-session
 # → pages re-opened, cookies restored, localStorage seeded
 ```
 

--- a/docs/guides/agent-integration.md
+++ b/docs/guides/agent-integration.md
@@ -136,12 +136,12 @@ Save state at the end of a run so the next run picks up authenticated:
 
 ```bash
 # End of run 1
-browserctl session save my-agent-session
+browserctl state save my-agent-session
 browserctl daemon stop
 
 # Start of run 2 — no re-login needed
 browserd &
-browserctl session load my-agent-session
+browserctl state load my-agent-session
 # → cookies restored, localStorage seeded, pages reopened
 ```
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -113,7 +113,7 @@ It is the difference between a browser **you restart** and a browser **you steer
 ### v0.6 — CLI Redesign & Storage ✓ _(shipped)_
 **Goal:** A consistent noun-verb CLI surface with first-class web storage control.
 
-- [x] Noun-verb command structure — `browserctl page open`, `browserctl session save`, `browserctl workflow run`
+- [x] Noun-verb command structure — `browserctl page open`, `browserctl state save` (the `state` verb was named `session` until v0.13), `browserctl workflow run`
 - [x] `storage get/set/export/import/delete` — direct Web Storage access without custom scripts
 - [x] Daemon auto-index — second unnamed daemon auto-picks next available slot
 - [x] `page focus` command
@@ -136,7 +136,7 @@ It is the difference between a browser **you restart** and a browser **you steer
 - [x] Built-in resolvers: `env://`, `keychain://` (macOS), `op://` (1Password CLI)
 - [x] User-defined resolvers via `~/.browserctl/resolvers.rb`
 - [x] `load_session` with `fallback:` — automatic session expiry recovery
-- [x] Session encryption at rest — `browserctl session save --encrypt`
+- [x] Session encryption at rest — `browserctl state save --encrypt` (the `state` verb was named `session` until v0.13)
 - [x] Export encryption — `browserctl session export --encrypt` with passphrase
 
 ### v0.8.3 — Session Durability (patch)


### PR DESCRIPTION
## Summary

v0.13 renamed `browserctl session save` / `session load` to `browserctl state save` / `state load`, but several user-facing docs still showed the old verbs. This PR brings them in line with the shipped CLI.

## Files changed

- `README.md` — quickstart block
- `docs/getting-started.md` — section "6. Save your session"
- `docs/concepts/sessions-and-pages.md` — "Saving and restoring sessions" prose, code samples, and the on-disk layout (now `~/.browserctl/state/<name>.bctl`, a single bundle file per name, matching `lib/browserctl/state.rb`)
- `docs/guides/agent-integration.md` — "Session persistence across agent runs"
- `docs/vision.md` — v0.6 and v0.8 shipped-checklist items, with a parenthetical preserving the historical rename

## Out of scope

`docs/plans/**` and `docs/superpowers/plans/**` are intentionally preserved as historical planning records — they reference the original `session save` / `session load` verbs by design. The plan's grep-clean acceptance criterion is scoped to user-facing docs (`README.md`, `docs/getting-started.md`, `docs/concepts/`, `docs/guides/`, `docs/vision.md`), all of which are now clean.

## Acceptance checklist

- [x] `grep -rn "session save\|session load" README.md docs/getting-started.md docs/concepts/ docs/guides/ docs/vision.md` returns nothing
- [x] `state save` / `state load` verified to exist in `lib/browserctl/commands/state.rb`
- [x] On-disk path in `docs/concepts/sessions-and-pages.md` matches `lib/browserctl/state.rb` (`~/.browserctl/state/<name>.bctl`)
- [x] README quickstart commands map to real CLI verbs