### PR TITLE
fix: dialog handlers use with_page mutex pattern (v0.15 WS-2 PR 4)

### DIFF
--- a/lib/browserctl/server/handlers/interaction.rb
+++ b/lib/browserctl/server/handlers/interaction.rb
@@ -85,28 +85,26 @@ module Browserctl
         end
 
         def cmd_dialog_accept(req)
-          session = @global_mutex.synchronize { @pages[req[:name]] }
-          return { error: "no page named '#{req[:name]}'" } unless session
-
-          text = req[:text]
-          id   = nil
-          id = session.page.on(:dialog) do |dialog|
-            session.page.off(:dialog, id)
-            dialog.accept(text)
+          with_page(req[:name]) do |session|
+            text = req[:text]
+            id   = nil
+            id = session.page.on(:dialog) do |dialog|
+              session.page.off(:dialog, id)
+              dialog.accept(text)
+            end
+            { ok: true }
           end
-          { ok: true }
         end
 
         def cmd_dialog_dismiss(req)
-          session = @global_mutex.synchronize { @pages[req[:name]] }
-          return { error: "no page named '#{req[:name]}'" } unless session
-
-          id = nil
-          id = session.page.on(:dialog) do |dialog|
-            session.page.off(:dialog, id)
-            dialog.dismiss
+          with_page(req[:name]) do |session|
+            id = nil
+            id = session.page.on(:dialog) do |dialog|
+              session.page.off(:dialog, id)
+              dialog.dismiss
+            end
+            { ok: true }
           end
-          { ok: true }
         end
       end
     end

--- a/spec/integration/dialog_race_spec.rb
+++ b/spec/integration/dialog_race_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "webrick"
+
+# Regression test for the v0.15 WS-2 PR 4 fix. Prior to that PR,
+# `dialog_accept` / `dialog_dismiss` reached into `@pages` under
+# `@global_mutex` directly and skipped `with_page()`, so a concurrent
+# `pause` could land between the lookup and the handler body — opening
+# a race where the dialog handler would register against a page that
+# had just been paused for HITL inspection.
+#
+# After the fix both handlers route through `with_page`, which holds
+# the per-page mutex and waits on `pause_cv` while the page is paused.
+# This spec proves the wait is in effect: a `dialog_accept` issued
+# against a paused page must block until `resume` is called, instead
+# of returning `{ ok: true }` immediately and racing.
+RSpec.describe "dialog handler pause race", :integration do
+  def start_html_server
+    log    = WEBrick::Log.new(File::NULL)
+    server = WEBrick::HTTPServer.new(Port: 0, Logger: log, AccessLog: [])
+    server.mount_proc("/") do |_, res|
+      res.body = <<~HTML
+        <html><body>
+          <button id="confirm-btn" onclick="window.confirmed=confirm('sure?')">Confirm</button>
+        </body></html>
+      HTML
+      res["Content-Type"] = "text/html"
+    end
+    Thread.new { server.start }
+    [server, server.config[:Port]]
+  end
+
+  before(:all) do
+    @client = start_daemon
+    @server, @port = start_html_server
+    @client.page_open("p", url: "http://localhost:#{@port}/")
+  end
+
+  after(:all) do
+    stop_daemon
+    @server.shutdown
+  end
+
+  it "blocks dialog_accept while the page is paused, then completes on resume" do
+    pause_res = @client.pause("p", message: "inspect")
+    expect(pause_res[:paused]).to be true
+
+    queue = Queue.new
+    worker = Thread.new do
+      queue << @client.dialog_accept("p")
+    end
+
+    # Give the worker enough time to reach with_page; it must NOT have
+    # returned yet because the page is paused.
+    sleep 0.5
+    expect(worker.alive?).to be true
+    expect(queue.empty?).to be true
+
+    resume_res = @client.resume("p")
+    expect(resume_res[:paused]).to be false
+
+    result = nil
+    Timeout.timeout(5) { result = queue.pop }
+    worker.join(5)
+
+    expect(result[:ok]).to be true
+  end
+
+  it "blocks dialog_dismiss while the page is paused, then completes on resume" do
+    pause_res = @client.pause("p", message: "inspect")
+    expect(pause_res[:paused]).to be true
+
+    queue = Queue.new
+    worker = Thread.new do
+      queue << @client.dialog_dismiss("p")
+    end
+
+    sleep 0.5
+    expect(worker.alive?).to be true
+    expect(queue.empty?).to be true
+
+    resume_res = @client.resume("p")
+    expect(resume_res[:paused]).to be false
+
+    result = nil
+    Timeout.timeout(5) { result = queue.pop }
+    worker.join(5)
+
+    expect(result[:ok]).to be true
+  end
+
+  it "returns the no-page error when the page does not exist" do
+    res = @client.dialog_accept("ghost")
+    expect(res[:error]).to match(/no page named/)
+  end
+end


### PR DESCRIPTION
## Summary

`dialog_accept` and `dialog_dismiss` in `lib/browserctl/server/handlers/interaction.rb` previously read `@pages[name]` under `@global_mutex` and then called `session.page.on(:dialog)` outside any per-page lock. A concurrent `pause` could slip between the lookup and the listener registration, leaving the dialog handler attached to a page that had just been paused for HITL inspection.

This PR routes both handlers through `with_page()` so they hold the per-page mutex for the entire registration and wait on `pause_cv` while the page is paused — the same pattern every other named-page handler already uses.

## Race window closed

Before: `lookup → (race here, pause lands) → page.on(:dialog)`
After: `with_page { page.on(:dialog) }` — the per-page mutex is held continuously and the body sleeps on `pause_cv` if the page is paused.

## Acceptance

- `lib/browserctl/server/handlers/interaction.rb` dialog handlers go through `with_page()`.
- New `spec/integration/dialog_race_spec.rb` pauses the page, fires `dialog_accept` / `dialog_dismiss` from a worker thread, asserts the call blocks, then resumes and confirms the call completes with `{ ok: true }`. Also covers the no-such-page error path.
- `bundle exec rspec spec/integration/dialog_race_spec.rb` — 3 examples, 0 failures.
- `bundle exec rspec spec/integration/interaction_spec.rb -e dialog` — 4 examples, 0 failures (no regression).
- `bundle exec rubocop` on touched files — 0 offenses.