### PR TITLE
docs: status badges on plan files (v0.15 WS-6 PR 11)

### DIFF
--- a/docs/plans/v0.10-flows.md
+++ b/docs/plans/v0.10-flows.md
@@ -1,5 +1,7 @@
 # v0.10 — Flows: execution plan
 
+**Status:** SHIPPED 2026-05-09
+
 > Companion to the v0.10 entry in `../vision.md`. This file is the per-PR breakdown.
 
 ## Goal

--- a/docs/plans/v0.11-replayable.md
+++ b/docs/plans/v0.11-replayable.md
@@ -1,5 +1,7 @@
 # v0.11 — Replayable: execution plan
 
+**Status:** SHIPPED 2026-05-10
+
 > Companion to the v0.11 entry in `../vision.md`. Per-PR breakdown.
 
 ## Goal

--- a/docs/plans/v0.12-solid.md
+++ b/docs/plans/v0.12-solid.md
@@ -1,5 +1,7 @@
 # v0.12 — Solid: execution plan
 
+**Status:** SHIPPED 2026-05-10
+
 > Companion to the v0.12 entry in `../vision.md`. Per-PR breakdown.
 
 ## Goal

--- a/docs/plans/v0.13-lean.md
+++ b/docs/plans/v0.13-lean.md
@@ -1,5 +1,7 @@
 # v0.13 — Lean: execution plan
 
+**Status:** SHIPPED 2026-05-11
+
 > Companion to v0.12 ("Solid"). v0.12 hardens what exists; v0.13 cuts what shouldn't.
 > Per-PR breakdown intended to be picked up by any contributor (human or agent) cold,
 > without prior session context.

--- a/docs/plans/v0.14-polish.md
+++ b/docs/plans/v0.14-polish.md
@@ -1,5 +1,7 @@
 # v0.14 — Polish: execution plan
 
+**Status:** SHIPPED 2026-05-12
+
 > Companion to v0.12 ("Solid") and v0.13 ("Lean"). v0.12 hardened, v0.13 cut.
 > v0.14 polishes the internals so the 1.0 surface earns its lock.
 

--- a/docs/plans/v0.15-lock.md
+++ b/docs/plans/v0.15-lock.md
@@ -1,0 +1,472 @@
+# v0.15 — Lock: execution plan
+
+**Status:** IN-PROGRESS
+
+> Companion to v0.12 ("Solid"), v0.13 ("Lean"), and v0.14 ("Polish").
+> v0.12 hardened, v0.13 cut, v0.14 tidied the inside. v0.15 is the last
+> milestone where the 1.0 surface can still move — anything that doesn't
+> land here is frozen for the duration of v1.x.
+
+## Goal
+
+Earn the 1.0 lock by closing the four pre-lock gaps a parallel review
+surfaced in the v0.14 cycle: (1) consolidate the duplicated cookie /
+storage APIs in the Fixed zone, (2) close the daemon's remaining
+concurrency and plugin-isolation foot-guns, (3) extend the public surface
+lock-file to cover the wire protocol's response shapes, (4) install a
+minimum-viable observability and testability seam so operators have a
+timeline and contributors can unit-test handlers without a real Chrome.
+
+Everything else from the review (docs alignment, idiomatic Ruby hygiene,
+small extractions) rides along as cheap workstreams so the lock isn't
+held up by paper cuts.
+
+## Non-goals
+
+- New user-facing commands, flows, or workflow features.
+- Reworking the workflow DSL or recording format — both already lock-eligible.
+- Plugin authoring API expansion. v0.15 isolates plugins; it does not
+  give them more capability.
+- A second driver. The `PageDriver` extraction in WS-5 is a seam for
+  testing, not an invitation to ship a non-Ferrum backend before 1.0.
+- 1.0 itself. v0.15 ships, then the two-month soak resumes from the
+  v0.15 release date — same shape as the v0.14 soak.
+
+## Dependencies
+
+- v0.14 must ship first. All WS-1..WS-4 PRs from `v0.14-polish.md` must
+  be merged before any v0.15 work begins. v0.15 assumes the v0.14
+  internals (typed-error completion, RecordingInterceptor, State::Mutator,
+  TraceRenderer / EventStream, public-surface lock-file) as its baseline.
+- Re-read `docs/reference/api-stability.md` before opening any WS-1 or
+  WS-3 PR. v0.15 is the only milestone in this run that intentionally
+  moves a boundary (WS-1 consolidates two Fixed-zone command families);
+  every other workstream stays inside existing zones.
+- Anyone executing WS-2 should re-read `docs/architecture/decisions/`
+  for the daemon concurrency ADRs before touching the page mutex
+  protocol.
+
+## Conventions for every PR in this plan
+
+- Branch off `main`, open a PR, never push to `main`.
+- Conventional Commits: `refactor:` / `chore:` / `test:` / `docs:` /
+  `fix:`. Exactly **one** `feat!:` is allowed in this milestone — WS-1
+  PR 2 (cookie / storage consolidation). Tag it with a `BREAKING CHANGE:`
+  footer and an explicit `Release-As: 0.15.0` so release-please doesn't
+  bump to 1.0 prematurely.
+- No `Co-Authored-By` lines. No "Generated with Claude Code" or AI
+  attribution anywhere project-facing.
+- New error paths get table-driven integration tests via the v0.12
+  error code enum.
+- Public surface diff check: every PR runs the v0.14 public-surface
+  spec and asserts no unintended drift. WS-1 PR 2 updates the lock-file
+  in the same commit and is the only PR allowed to do so.
+
+---
+
+## WS-1 · Fixed-zone consolidation (the one breaking change)
+
+**Outcome:** Cookie and storage operations live under a single verb
+family on the wire. The 1.0 Fixed zone documents one way to read or
+mutate browser-side persistent data, not two.
+
+The v0.13 narrowing pass moved `store` / `fetch` out of Fixed; it
+did not touch the `cookie *` vs `storage *` duplication, which
+api-stability.md (lines 158-175) explicitly defers to v2.0. Deferring
+that to v2.0 means committing to maintain both shapes for the entire
+v1.x line. v0.15 is the last chance to retire one.
+
+### PR 1 · `docs: cookie/storage consolidation RFC`
+
+Write the consolidation proposal as an ADR in
+`docs/architecture/decisions/`. Cover: target verb (`data` vs
+`resource` — recommend `data`), `--scope {cookies|localStorage|sessionStorage}`
+flag, response-shape unification, and the deprecation window for the
+old verbs (one minor release, removed at 1.0).
+
+**Files:** `docs/architecture/decisions/00NN-data-verb-consolidation.md`.
+
+**Acceptance:** ADR merged. No code change. Patrick signs off on verb
+name before PR 2 opens.
+
+**Risk:** None. Discussion-only.
+
+### PR 2 · `feat!: data verb consolidates cookie and storage commands`
+
+Add a new `data` command family on the wire and CLI: `data get`,
+`data set`, `data delete`, `data list`, with a required
+`--scope {cookies|localStorage|sessionStorage}` flag. Keep the old
+`cookie *` and `storage *` verbs as aliases that emit a one-line
+deprecation warning to stderr (suppressed under `--output json`).
+
+**Files:**
+- New `lib/browserctl/commands/data.rb`.
+- Edit `lib/browserctl/server/handlers/cookies.rb` and
+  `lib/browserctl/server/handlers/storage.rb` to dispatch from a
+  shared `Handlers::Data` mixin; keep their existing entry points
+  delegating to it.
+- Edit `lib/browserctl/client.rb` to add `data_get`, `data_set`,
+  `data_delete`, `data_list`.
+- Edit `docs/reference/commands.md` and `docs/reference/api-stability.md`
+  to document the new verb as Fixed and the old verbs as
+  deprecated-for-removal-at-1.0.
+- Edit `spec/fixtures/public_surface.yml` to include the new methods.
+- New `spec/integration/data_command_spec.rb` covering all three scopes.
+
+**Acceptance:**
+- Every test that previously exercised `cookie *` or `storage *` has
+  a matching test under `data --scope ...`.
+- Deprecation warning appears exactly once per CLI invocation that
+  uses an old verb, and never under `--output json`.
+- `docs/reference/api-stability.md` lists the old verbs in a "Removed
+  at 1.0" section with the deprecation timeline.
+
+**Risk:** Medium. The only breaking change in this plan; release-please
+must be pinned with `Release-As: 0.15.0`.
+
+### PR 3 · `chore: drop deprecated cookie and storage verbs`
+
+Lands on the 1.0 release branch, not in v0.15 itself. Listed here so
+the timeline is visible: at 1.0 cut, remove the alias path and the
+deprecation warnings. v0.15 ships with the aliases; 1.0 ships without.
+
+**Files:** (deferred to 1.0 branch.)
+
+**Acceptance:** (tracked in `docs/plans/v1.0-cut.md` when that opens.)
+
+**Risk:** Low. Purely deletion once aliases have shipped for the
+v0.15 soak.
+
+---
+
+## WS-2 · Daemon concurrency and plugin isolation
+
+**Outcome:** The daemon does not have a known race in any command
+handler, and a buggy third-party plugin cannot deadlock or crash
+`browserd`.
+
+### PR 4 · `fix: dialog handlers use with_page mutex pattern`
+
+`lib/browserctl/server/handlers/interaction.rb:88-110`
+(`dialog_accept` and `dialog_dismiss`) takes only `@global_mutex` and
+skips `with_page()`, opening a window where the page can be paused or
+closed mid-handler. Every other handler uses `with_page()`; standardise.
+
+**Files:**
+- Edit `lib/browserctl/server/handlers/interaction.rb`.
+- New `spec/integration/dialog_race_spec.rb` that pauses a page
+  immediately before `dialog_accept` and asserts the handler returns
+  a typed `PAGE_PAUSED` error rather than racing.
+
+**Acceptance:** No handler in `lib/browserctl/server/handlers/` accesses
+`@pages` without going through `with_page()`. Grep for `@pages[` and
+`@global_mutex.synchronize` outside the dispatcher base class returns
+nothing.
+
+**Risk:** Low. Strictly tightens an existing seam.
+
+### PR 5 · `feat: plugin command timeout and error isolation`
+
+Plugins registered via `Browserctl.register_command` (see
+`lib/browserctl.rb:15-25`) currently run inline on the daemon thread
+with no timeout. Wrap the dispatch in a per-plugin timeout (default
+30s, configurable via the registration block) and a rescue boundary
+that converts any uncaught exception into a typed
+`PLUGIN_FAILED` error response without taking down the daemon.
+
+**Files:**
+- New `lib/browserctl/server/plugin_dispatcher.rb` (extracts plugin
+  invocation from `command_dispatcher.rb`).
+- Edit `lib/browserctl.rb` to accept `timeout:` on
+  `register_command`.
+- Edit `lib/browserctl/error/codes.rb` to add `PLUGIN_FAILED` and
+  `PLUGIN_TIMED_OUT`.
+- Edit `docs/reference/errors.md` and `docs/reference/exit-codes.md`.
+- New `spec/integration/plugin_isolation_spec.rb` covering: plugin
+  that raises, plugin that hangs past timeout, plugin that returns
+  malformed JSON.
+
+**Acceptance:** A plugin that sleeps for 60s returns
+`PLUGIN_TIMED_OUT` after 30s and the daemon answers a follow-up
+`page list` call in < 1s. A plugin that raises returns
+`PLUGIN_FAILED` with the plugin name in the payload.
+
+**Risk:** Low-Medium. New error codes are additive; the timeout is a
+hard cap so plugins relying on indefinite wait will need an explicit
+opt-out via `timeout: nil`, which is documented.
+
+---
+
+## WS-3 · Public surface lock-file extension
+
+**Outcome:** The CI lock-file covers the Fixed zone's response shapes,
+not just the Stable zone's method names. A new optional field cannot
+slip into a Fixed response without explicit lock-file update.
+
+### PR 6 · `test: wire-protocol response shape lock`
+
+Extend `spec/fixtures/public_surface.yml` (introduced in v0.14 WS-4)
+to record, per Fixed-zone command, the full set of response field
+names and their declared optionality. Extend
+`spec/public_surface_spec.rb` to fail CI if any handler returns a
+field not in the lock-file or omits a required field.
+
+**Files:**
+- Edit `spec/fixtures/public_surface.yml` — add `fixed_zone:` section
+  keyed by command name.
+- Edit `spec/public_surface_spec.rb` — add the response-shape
+  assertion.
+- Edit `docs/reference/api-stability.md` to point at the extended
+  lock-file as the canonical Fixed-zone contract.
+
+**Acceptance:** Every command in `COMMAND_MAP` has an entry in
+`fixed_zone:`. Adding a field to any handler response without
+updating the lock-file fails CI. Removing the lock-file entry for a
+required field fails CI.
+
+**Risk:** Low. Test-only.
+
+---
+
+## WS-4 · Observability seam
+
+**Outcome:** Operators can wire `browserd` into an external tracing
+backend without forking the gem. A 30-second workflow produces a
+timeline.
+
+### PR 7 · `feat: pluggable tracing hook`
+
+Add a minimum-viable tracing seam shaped like OpenTelemetry's span
+API (without taking an OpenTelemetry dependency). Each command
+dispatch wraps its handler in a span; `Browserctl::Tracing.backend = ...`
+lets users plug in an OTel exporter, a JSONL writer, or a no-op
+(default).
+
+**Files:**
+- New `lib/browserctl/tracing.rb` defining the `Backend` protocol
+  (`start_span(name, attributes:)`, `end_span(span, status:)`).
+- Edit `lib/browserctl/server/command_dispatcher.rb` to wrap dispatch
+  in a span.
+- New `examples/tracing_otel.rb` demonstrating the OTel wiring as
+  a doc-only example (no dependency added).
+- New `spec/unit/tracing_spec.rb` covering the no-op default and a
+  test backend that records spans.
+- Edit `docs/reference/api-stability.md` to mark `Browserctl::Tracing`
+  as Extension zone.
+
+**Acceptance:** Default backend is no-op; existing benchmarks show no
+regression > 2% (run `rake bench:all` against `main`). A test backend
+records one span per command with `command:`, `page:`, and
+`duration_ms:` attributes.
+
+**Risk:** Low. Default no-op means zero behaviour change unless a
+backend is wired.
+
+---
+
+## WS-5 · Testability seam (PageDriver extraction)
+
+**Outcome:** Handlers can be unit-tested without a real Chrome.
+`PageSession` no longer leaks Ferrum's API surface into handler code.
+
+### PR 8 · `refactor: extract PageDriver interface from PageSession`
+
+Today `lib/browserctl/server/page_session.rb` exposes `session.page`
+directly and handlers call `session.page.evaluate(...)`,
+`session.page.at_css(...)`, etc. Extract a `PageDriver` interface
+with the dozen methods handlers actually use; provide a
+`FerrumPageDriver` implementation; rewrite handlers against the
+interface.
+
+**Files:**
+- New `lib/browserctl/driver/page_driver.rb` (interface module).
+- New `lib/browserctl/driver/ferrum_page_driver.rb` (the only
+  implementation v0.15 ships).
+- Edit `lib/browserctl/server/page_session.rb` to hold a
+  `PageDriver` instead of a raw Ferrum page.
+- Edit every handler in `lib/browserctl/server/handlers/*.rb` to
+  call `session.driver.<method>` instead of `session.page.<method>`.
+- New `spec/support/fake_page_driver.rb` — an in-memory test double.
+- New `spec/unit/handlers/` covering at least three handler families
+  (interaction, observation, cookies) without Chrome.
+
+**Acceptance:** `grep -rn "session.page\." lib/` returns nothing
+outside `lib/browserctl/driver/`. `spec/unit/handlers/` runs in < 1s
+without spawning a browser.
+
+**Risk:** Medium. Large diff but mechanical; the interface stays in
+the Extension zone, so it does not move any lock boundary.
+
+---
+
+## WS-6 · Docs alignment
+
+**Outcome:** A first-touch user does not hit a stale command. A
+contributor knows which zone they're touching before they touch it.
+
+### PR 9 · `docs: fix stale session save/load references`
+
+The README quickstart and `docs/getting-started.md` still teach
+`browserctl session save` / `session load`. v0.13 replaced these
+with `state save` / `state load`. Update both files.
+
+**Files:**
+- Edit `README.md` (quickstart block around lines 58-59).
+- Edit `docs/getting-started.md` (lines 159, 166 and surrounding
+  prose).
+- Grep `docs/ README.md` for any other `session save|load` and fix.
+
+**Acceptance:** `grep -rn "session save\|session load" README.md docs/`
+returns nothing. The README quickstart, copy-pasted into a shell,
+runs end-to-end against a fresh daemon.
+
+**Risk:** None.
+
+### PR 10 · `docs: align positioning across README, product, vision`
+
+The headline drifts between "for agents" (README) and "for engineers /
+agents / QA" (product.md). Tighten so the headline reads
+"persistent browser sessions with human-in-the-loop," agents are the
+primary user, engineers / QA the secondary. Consolidate overlapping
+prose so README → product.md → vision.md narrow in scope rather than
+repeat each other.
+
+**Files:**
+- Edit `README.md` headline and one-paragraph pitch.
+- Edit `docs/product.md` "Who It's For" section.
+- Edit `docs/vision.md` to cut the product-narrative paragraphs that
+  duplicate product.md and keep only the philosophy + roadmap.
+
+**Acceptance:** The same one-line wedge appears verbatim in README,
+product.md, and vision.md. Each doc has a distinct job: README =
+quickstart, product.md = narrative, vision.md = philosophy + roadmap.
+
+**Risk:** None. Patrick reviews tone before merge.
+
+### PR 11 · `docs: status badges on plan files`
+
+Add a one-line status header to every file in `docs/plans/` so a new
+contributor can tell historical from in-flight at a glance.
+
+**Files:** `docs/plans/v0.10-flows.md`, `v0.11-replayable.md`,
+`v0.12-solid.md`, `v0.13-lean.md`, `v0.14-polish.md`,
+`v0.15-lock.md`.
+
+**Acceptance:** Each plan has a `**Status:** SHIPPED YYYY-MM-DD` or
+`**Status:** IN-PROGRESS` line directly under the H1.
+
+**Risk:** None.
+
+### PR 12 · `docs: contributor onboarding cross-links`
+
+`CONTRIBUTING.md` does not currently link to
+`docs/reference/api-stability.md` or `docs/architecture/decisions/`.
+Add a "Before You Code" section that points contributors at the zone
+contract and ADR log.
+
+**Files:** `CONTRIBUTING.md`.
+
+**Acceptance:** A contributor can land in the repo, read
+CONTRIBUTING.md top to bottom, and reach the public-surface contract
+without grepping.
+
+**Risk:** None.
+
+### PR 13 · `docs: surface v0.13/v0.15 breaking changes in docs index`
+
+`docs/README.md` does not currently flag breaking changes. Add a
+one-liner pointing at the breaking-changes section of
+`docs/reference/api-stability.md` for v0.12 → v0.13 (session removal)
+and v0.14 → v0.15 (data verb consolidation).
+
+**Files:** `docs/README.md`.
+
+**Acceptance:** A user upgrading from v0.13 → v0.15 finds the
+deprecation in two clicks.
+
+**Risk:** None.
+
+---
+
+## WS-7 · Code hygiene rideshare
+
+**Outcome:** The codebase has no `Struct.new` where `Data.define`
+would do, no missing `frozen_string_literal` pragmas, and
+`workflow.rb` is split along its three concerns.
+
+These are nits in isolation but cheap to land alongside the bigger
+WS-1..WS-5 work.
+
+### PR 14 · `refactor: Data.define for value types`
+
+Replace `Struct.new` with `Data.define` for value types where
+mutability is not used. Confirmed targets:
+- `lib/browserctl/workflow.rb:72` (`StepResult`).
+- `lib/browserctl/migrations.rb` (`Migration`).
+- Audit remaining `Struct.new` call sites; convert if no caller
+  mutates.
+
+**Files:** the affected library files and their specs.
+
+**Acceptance:** `grep -rn "Struct.new" lib/` returns only call sites
+where mutability is intentional (document each with a `# mutable:` comment).
+
+**Risk:** Low. Behavioural change is "assignment to a field now
+raises" which is caught at test time.
+
+### PR 15 · `chore: frozen_string_literal pragma on remaining lib files`
+
+Approximately ten files in `lib/browserctl/` are missing the
+`# frozen_string_literal: true` pragma. Add it; fix any test failures
+caused by frozen-string assumptions.
+
+**Files:** the affected library files.
+
+**Acceptance:** `grep -L "frozen_string_literal: true" lib/**/*.rb`
+returns nothing.
+
+**Risk:** Low. Caught at spec time.
+
+### PR 16 · `refactor: extract PageProxy from workflow.rb`
+
+`lib/browserctl/workflow.rb` is 386 lines holding three concerns:
+`WorkflowContext`, `PageProxy`, `WorkflowDefinition`. Extract
+`PageProxy` to `lib/browserctl/workflow/page_proxy.rb`. Stable zone
+(the DSL surface) is unchanged.
+
+**Files:**
+- New `lib/browserctl/workflow/page_proxy.rb`.
+- Edit `lib/browserctl/workflow.rb` to require the new file.
+
+**Acceptance:** Public surface diff against `main` is empty. All
+existing workflow specs pass without change.
+
+**Risk:** Low.
+
+---
+
+## Execution order
+
+WS-6 PR 9 (stale session docs) should land first — it's a 15-minute
+fix that closes the most visible user-facing bug and de-risks the
+README. After that:
+
+1. **Parallelisable** (any order): WS-2 PR 4, WS-3 PR 6, WS-6 PRs
+   10-13, WS-7 PRs 14-16.
+2. **Sequential**: WS-1 PR 1 (ADR) → WS-1 PR 2 (data verb) →
+   nothing else until PR 2 has soaked for at least one minor release.
+3. **Parallel with WS-1 PR 2**: WS-2 PR 5 (plugin isolation), WS-4
+   PR 7 (tracing seam), WS-5 PR 8 (PageDriver).
+
+The hard gate before declaring v0.15 done is WS-1 PR 2 plus all of
+WS-2 plus WS-3 PR 6. Without those three, v1.0 is not lockable.
+Everything else is desirable but skippable if the soak window starts
+slipping.
+
+## After v0.15
+
+The v0.15 release cuts. The two-month soak resumes from that date.
+At the end of soak, `docs/plans/v1.0-cut.md` opens with one job:
+delete the deprecated `cookie *` and `storage *` aliases (WS-1 PR 3)
+and bump the version to 1.0.0. No new code lands in the soak window
+except `fix:` PRs that touch nothing the lock-file covers.


### PR DESCRIPTION
## Summary

- Adds a `**Status:**` header directly under the H1 of every `docs/plans/v0.1*.md` file so contributors can tell historical milestones from in-flight at a glance.
- SHIPPED dates use the corresponding release tag date; v0.13 uses v0.13.1 (2026-05-11). v0.15 is IN-PROGRESS.

| File | Status |
| --- | --- |
| v0.10-flows.md | SHIPPED 2026-05-09 |
| v0.11-replayable.md | SHIPPED 2026-05-10 |
| v0.12-solid.md | SHIPPED 2026-05-10 |
| v0.13-lean.md | SHIPPED 2026-05-11 |
| v0.14-polish.md | SHIPPED 2026-05-12 |
| v0.15-lock.md | IN-PROGRESS |

## Test plan

- [x] `grep -E "^\*\*Status:\*\*" docs/plans/v0.1*.md | wc -l` returns 6