### PR TITLE
docs: surface breaking changes in docs index (v0.15 WS-6 PR 13)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Look things up without reading linearly.
 |---|---|
 | [Commands](reference/commands.md) | Every CLI command, flag, snapshot format, and PageProxy method |
 | [API Stability](reference/api-stability.md) | Fixed / Stable / Extension zones, wire protocol contract |
+| [Breaking Changes](reference/api-stability.md#breaking-changes-log) | Upgrading? v0.12 → v0.13 removed `session` (use `state`); v0.14 → v0.15 consolidates cookie/storage under `data` |
 | [Style Guide](reference/style-guide.md) | Naming conventions per layer — wire, CLI, SDK |
 
 ---


### PR DESCRIPTION
## Summary

- Adds a one-line pointer in `docs/README.md` to the breaking-changes section of `docs/reference/api-stability.md`.
- Calls out the two upgrade-relevant breaks: v0.12 → v0.13 (`session` removed, use `state`) and v0.14 → v0.15 (cookie/storage consolidated under `data`).

Per v0.15-lock plan PR 13 (WS-6). Acceptance: a user upgrading from v0.13 → v0.15 finds the deprecation in two clicks.

## Test plan

- [x] Link target `#breaking-changes-log` resolves to the existing heading in `api-stability.md`.
- [x] No other files touched.