### PR TITLE
docs: align positioning across README/product/vision (v0.15 WS-6 PR 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 <h1 align="center">browserctl</h1>
 
 <p align="center">
-  The browser you delegate to your agents — with a pause button for the parts that still need you.
+  persistent browser sessions with human-in-the-loop.
+</p>
+
+<p align="center">
+  <sub>Built for AI agents. Useful to the engineers and QA folks who work with them.</sub>
 </p>
 
 <p align="center">

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,6 +1,6 @@
 # browserctl — Product Story
 
-> Navigate the web. Stay in session. Never start over.
+> persistent browser sessions with human-in-the-loop.
 
 ---
 
@@ -97,13 +97,9 @@ Workflows are plain Ruby. They compose, retry, timeout, and share steps. Params 
 
 ## Who It's For
 
-**Engineers debugging issues** — Record the reproduction steps. Capture screenshots at each stage. Share the workflow script instead of a 10-step Confluence doc.
+**AI agents — the primary user.** Give your agent a browser it can actually use on the real web — Cloudflare walls, consent modals, 2FA prompts and all. The agent handles the mechanical work; HITL handles the judgment calls. The session stays alive between commands, so the agent picks up where it left off without re-authenticating on every step.
 
-**AI/agent teams** — Give your agent a browser it can actually use on the real web — Cloudflare walls, consent modals, 2FA prompts and all. The agent handles the mechanical work; HITL handles the judgment calls.
-
-**QA and release teams** — Smoke test every environment with the same script. Record the passing run as evidence. Replay it before the next release.
-
-**Anyone with browser toil** — If you click through the same 12 pages every week, write the workflow once and delegate it.
+**Engineers and QA — secondary, by extension.** The same primitives that let an agent debug a flaky checkout let an engineer reproduce a bug once, then iterate on the fix without restarting from the home page. The same recordings an agent generates become smoke tests a QA team can replay every release. If you click through the same 12 pages every week, write the workflow once and delegate it.
 
 ---
 
@@ -121,4 +117,4 @@ browserctl occupies a specific space: **interactive, stateful, composable browse
 
 ## The One-Line Pitch
 
-> The browser you delegate to your agents — with a pause button for the parts that still need you.
+> persistent browser sessions with human-in-the-loop.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,14 +1,8 @@
 # browserctl — Vision & Roadmap
 
-> _Navigate the web. Stay in session._
+> persistent browser sessions with human-in-the-loop.
 
----
-
-## What browserctl Is
-
-browserctl is a **persistent browser automation daemon and CLI**, purpose-built for AI agents and developer workflows. Unlike Selenium or Playwright, which restart the browser on every script run, browserctl keeps a named browser session alive — preserving cookies, localStorage, open tabs, and page state across discrete commands.
-
-It is the difference between a browser **you restart** and a browser **you steer**.
+This document is the philosophy and the release roadmap. For the product narrative — what browserctl is, who it's for, and the use cases it serves — see [product.md](product.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Aligns the headline positioning across the three top-level docs so they reinforce one wedge instead of drifting. Part of v0.15 WS-6.

**Wedge (verbatim in all three files):** persistent browser sessions with human-in-the-loop.

**Audience hierarchy:** agents primary, engineers and QA secondary.

## Per-file changes

- **README.md** — replaced the "browser you delegate to your agents" tagline with the wedge; added a one-line sub-note placing agents primary, engineers/QA secondary. Quickstart untouched.
- **docs/product.md** — wedge in the opening blockquote; rewrote "Who It's For" to a two-bucket structure (agents primary, engineers/QA secondary) instead of four parallel audiences; updated "The One-Line Pitch" to the wedge.
- **docs/vision.md** — wedge in the opening blockquote; cut the "What browserctl Is" prose paragraph (duplicated product.md) and replaced it with a one-line pointer to product.md. Philosophy and roadmap untouched.

## Tone review

This PR is a taste call — please review tone before merging. Recommend leaving open for review rather than auto-merging.

## Test plan

- [ ] `grep -F "persistent browser sessions with human-in-the-loop" README.md docs/product.md docs/vision.md` returns one match per file.
- [ ] README quickstart commands still copy-pasteable end-to-end.
- [ ] No emojis introduced.
- [ ] Voice still reads as the existing project voice.