### PR TITLE
refactor: Data.define for value types (v0.15 WS-7 PR 14)

### DIFF
--- a/lib/browserctl/callable_definition.rb
+++ b/lib/browserctl/callable_definition.rb
@@ -20,8 +20,8 @@ module Browserctl
   # deliberately absent from `FlowContext` — flows return state, workflows
   # share state.
   class CallableDefinition
-    ParamDef = Struct.new(:name, :required, :secret, :default, :secret_ref, keyword_init: true)
-    StepDef  = Struct.new(:label, :block, :retry_count, :timeout, keyword_init: true)
+    ParamDef = Data.define(:name, :required, :secret, :default, :secret_ref)
+    StepDef  = Data.define(:label, :block, :retry_count, :timeout)
 
     attr_reader :name, :description, :param_defs, :steps
 

--- a/lib/browserctl/detectors/auth_required.rb
+++ b/lib/browserctl/detectors/auth_required.rb
@@ -21,7 +21,7 @@ module Browserctl
     # runs server-side (handlers/observation.rb) and client-side (workflow
     # `load_state` hook).
     module AuthRequired
-      Result = Struct.new(:triggered, :code, :reason, :suggested_flow, keyword_init: true) do
+      Result = Data.define(:triggered, :code, :reason, :suggested_flow) do
         def to_h
           { triggered: triggered, code: code, reason: reason, suggested_flow: suggested_flow }.compact
         end

--- a/lib/browserctl/flow.rb
+++ b/lib/browserctl/flow.rb
@@ -4,7 +4,7 @@ require_relative "callable_definition"
 require_relative "errors"
 
 module Browserctl
-  FlowConditionDef = Struct.new(:kind, :label, :block, keyword_init: true)
+  FlowConditionDef = Data.define(:kind, :label, :block)
 
   # Back-compat aliases — flow_wrapper specs reference these directly.
   FlowParamDef = CallableDefinition::ParamDef

--- a/lib/browserctl/flows/stdlib/cloudflare_solve.rb
+++ b/lib/browserctl/flows/stdlib/cloudflare_solve.rb
@@ -13,7 +13,7 @@ require_relative "../../flow"
 # the duck-typed (current_url, body) interface the detector expects.
 module Browserctl
   module Flows
-    PageDetectorAdapter = Struct.new(:current_url, :body)
+    PageDetectorAdapter = Data.define(:current_url, :body)
 
     module CloudflareSolve
       module_function

--- a/lib/browserctl/migrations.rb
+++ b/lib/browserctl/migrations.rb
@@ -22,11 +22,11 @@ module Browserctl
     # absolute path of the file being migrated; it is responsible for
     # rewriting that file in place, advancing it from `from_version` to
     # `to_version`.
-    Migration = Struct.new(:format, :from_version, :to_version, :upgrade, keyword_init: true)
+    Migration = Data.define(:format, :from_version, :to_version, :upgrade)
 
     # Result of {.run}. `applied` is the ordered list of {Migration} steps
     # that ran. When the artifact was already at target, `applied` is empty.
-    Result = Struct.new(:format, :from, :to, :applied, keyword_init: true)
+    Result = Data.define(:format, :from, :to, :applied)
 
     FORMAT_EXTENSIONS = {
       ".bctl" => :bundle,

--- a/lib/browserctl/replay/context.rb
+++ b/lib/browserctl/replay/context.rb
@@ -16,7 +16,7 @@ module Browserctl
     # context so the surrounding workflow runner can render them into a
     # drift report at end-of-run.
     class Context
-      DriftEvent = Struct.new(:command, :selector, :matched_ref, :score, :reason, keyword_init: true)
+      DriftEvent = Data.define(:command, :selector, :matched_ref, :score, :reason)
 
       attr_reader :drift_events
 

--- a/lib/browserctl/replay/fingerprint_matcher.rb
+++ b/lib/browserctl/replay/fingerprint_matcher.rb
@@ -21,7 +21,7 @@ module Browserctl
       DEFAULT_THRESHOLD = 0.6
       WEIGHTS = { text: 0.40, role: 0.20, neighbors: 0.25, position: 0.15 }.freeze
 
-      Match = Struct.new(:candidate, :score, keyword_init: true)
+      Match = Data.define(:candidate, :score)
 
       def initialize(threshold: DEFAULT_THRESHOLD, weights: WEIGHTS)
         @threshold = threshold

--- a/lib/browserctl/state/mutator.rb
+++ b/lib/browserctl/state/mutator.rb
@@ -16,7 +16,7 @@ module Browserctl
     # caller (CLI or Workflow) can decide how to render them. The CLI maps
     # to a non-zero exit; a Workflow caller may catch and continue.
     class Mutator
-      Result = Struct.new(:save_result, :flow_name, :flow_version, keyword_init: true) do
+      Result = Data.define(:save_result, :flow_name, :flow_version) do
         def to_h
           (save_result || {}).merge(rotated_flow: flow_name)
         end

--- a/lib/browserctl/workflow.rb
+++ b/lib/browserctl/workflow.rb
@@ -69,7 +69,7 @@ module Browserctl
   # workflow specs reference these directly).
   ParamDef = CallableDefinition::ParamDef
   StepDef  = CallableDefinition::StepDef
-  StepResult = Struct.new(:name, :ok, :error, keyword_init: true)
+  StepResult = Data.define(:name, :ok, :error)
 
   class WorkflowContext
     include ContextualPersistence
@@ -359,7 +359,7 @@ module Browserctl
       last_error = nil
       (defn.retry_count + 1).times do
         execute_step_block(ctx, defn)
-        return StepResult.new(name: defn.label, ok: true)
+        return StepResult.new(name: defn.label, ok: true, error: nil)
       rescue StandardError => e
         last_error = e
       end


### PR DESCRIPTION
## Summary

Replaces every `Struct.new(...)` value-type declaration in `lib/` with `Data.define(...)`. Per the v0.15 plan (PR 14), value types in this codebase do not mutate fields after construction, so `Data` gives stronger guarantees (frozen, equality-by-value) for the same surface.

## Sites converted

| File | Type |
| --- | --- |
| `lib/browserctl/workflow.rb` | `StepResult` |
| `lib/browserctl/migrations.rb` | `Migration`, `Result` |
| `lib/browserctl/callable_definition.rb` | `ParamDef`, `StepDef` |
| `lib/browserctl/flow.rb` | `FlowConditionDef` |
| `lib/browserctl/state/mutator.rb` | `Result` (with method block) |
| `lib/browserctl/replay/fingerprint_matcher.rb` | `Match` |
| `lib/browserctl/replay/context.rb` | `DriftEvent` |
| `lib/browserctl/detectors/auth_required.rb` | `Result` (with method block) |
| `lib/browserctl/flows/stdlib/cloudflare_solve.rb` | `PageDetectorAdapter` |

One caller fix: `Workflow#run_step` now passes `error: nil` explicitly on the success branch (Data.define keyword constructors require all fields).

## Acceptance

- `grep -rn "Struct.new" lib/` returns nothing.
- No `# mutable:` annotations needed — no site mutates.

## Test plan

- [x] `bundle exec rspec` — 1012 examples, 0 failures, 57 pending (browser-required).
- [x] `bundle exec rubocop` — clean.