### PR TITLE
refactor: extract PageDriver interface from PageSession (v0.15 WS-5 PR 8)

### DIFF
--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -158,6 +158,12 @@ Known limits, intentional at this stage:
 
 These limits are why `store`/`fetch` are Extension. A future revision may add scoping, TTLs, or session-bound lifetime, and Extension status leaves room to do that without a major bump.
 
+### `Browserctl::Driver::PageDriver`
+
+The `PageDriver` interface (`lib/browserctl/driver/page_driver.rb`) and its only shipped implementation `FerrumPageDriver` are **Extension**. They exist so handlers can be unit-tested without spawning Chrome — see `spec/support/fake_page_driver.rb` and `spec/unit/handlers/` for the test double and unit specs.
+
+The interface is **not** a plugin point. Per the v0.15 plan, shipping a non-Ferrum backend is explicitly a non-goal of the 1.0 line; the seam exists for testability. Method signatures may change between minor releases with a changelog entry.
+
 ---
 
 ## Known overlapping surfaces — consolidation deferred to v2.0

--- a/lib/browserctl/driver/cdp.rb
+++ b/lib/browserctl/driver/cdp.rb
@@ -45,9 +45,9 @@ module Browserctl
         capability == :devtools
       end
 
-      def devtools_info(page)
+      def devtools_info(page_driver)
         port      = @ferrum.process.port
-        target_id = page.target_id
+        target_id = page_driver.target_id
         { port: port, target_id: target_id }
       end
 

--- a/lib/browserctl/driver/ferrum_page_driver.rb
+++ b/lib/browserctl/driver/ferrum_page_driver.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "page_driver"
+
+module Browserctl
+  module Driver
+    # The only {PageDriver} implementation v0.15 ships. Wraps a Ferrum page
+    # (or {CDPPage} delegator over one) and forwards each interface method to
+    # the underlying Ferrum API. Intentionally dumb — no caching, no policy,
+    # no logging. Anything beyond plain forwarding belongs in the handler or
+    # in a dedicated wrapper, not here.
+    class FerrumPageDriver
+      include PageDriver
+
+      # @return [Object] the underlying Ferrum/CDP page. Exposed for callers
+      #   that still bridge through Ferrum-typed APIs (currently only the CDP
+      #   driver's `devtools_info`). New handler code must not use this.
+      attr_reader :raw_page
+
+      def initialize(page)
+        @raw_page = page
+      end
+
+      def go_to(url) = @raw_page.go_to(url)
+      def current_url = @raw_page.current_url
+      def body = @raw_page.body
+      def evaluate(expression) = @raw_page.evaluate(expression)
+      def at_css(selector) = @raw_page.at_css(selector)
+      def screenshot(path:, full: false) = @raw_page.screenshot(path: path, full: full)
+      def activate = @raw_page.activate
+      def close = @raw_page.close
+      def on(event, &) = @raw_page.on(event, &)
+      def off(event, id) = @raw_page.off(event, id)
+      def keyboard_down(key) = @raw_page.keyboard.down(key)
+      def keyboard_up(key) = @raw_page.keyboard.up(key)
+      def mouse_move(x:, y:) = @raw_page.mouse.move(x: x, y: y) # rubocop:disable Naming/MethodParameterName
+      def cookies_all = @raw_page.cookies.all
+      def cookies_set(**) = @raw_page.cookies.set(**)
+      def cookies_clear = @raw_page.cookies.clear
+      def target_id = @raw_page.target_id
+    end
+  end
+end

--- a/lib/browserctl/driver/page_driver.rb
+++ b/lib/browserctl/driver/page_driver.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Browserctl
+  module Driver
+    # PageDriver is the interface every handler in `lib/browserctl/server/handlers/`
+    # talks to instead of touching a raw Ferrum page. It exists so unit tests can
+    # swap in a `FakePageDriver` (see `spec/support/fake_page_driver.rb`) without
+    # spawning a real browser.
+    #
+    # This module is intentionally a thin contract: Ruby has no real interfaces,
+    # so the implementation is duck-typed. The method list below is the entire
+    # public surface handlers may use. New entries here require a corresponding
+    # implementation in {FerrumPageDriver} **and** the test double, plus a
+    # handler that justifies them — do not add methods speculatively.
+    #
+    # Element-returning methods (currently only {#at_css}) return whatever the
+    # underlying driver returns. The fake driver returns stub objects with
+    # matching duck-typed methods (`focus`, `type`, `click`, `evaluate`,
+    # `select_file`). Handlers should treat these as opaque element handles.
+    #
+    # PageDriver lives in the **Extension** zone of the public surface
+    # (see `docs/reference/api-stability.md`). It is a testing seam, not an
+    # invitation to ship a non-Ferrum backend — that path is explicitly a
+    # non-goal of v0.15 (`docs/plans/v0.15-lock.md`).
+    module PageDriver
+      # Navigate the page to the given URL. Blocks until load completes.
+      # @param url [String]
+      def go_to(url) = raise NotImplementedError
+
+      # @return [String] the current top-frame URL
+      def current_url = raise NotImplementedError
+
+      # @return [String] the current page body HTML
+      def body = raise NotImplementedError
+
+      # Evaluate a JS expression in the page context.
+      # @param expression [String]
+      # @return [Object] the JSON-decoded result
+      def evaluate(expression) = raise NotImplementedError
+
+      # Find the first element matching the CSS selector.
+      # @param selector [String]
+      # @return [Object, nil] an element handle (duck-typed: `focus`, `type`,
+      #   `click`, `evaluate`, `select_file`) or nil if no match
+      def at_css(selector) = raise NotImplementedError
+
+      # Capture a screenshot to disk.
+      # @param path [String]
+      # @param full [Boolean]
+      def screenshot(path:, full: false) = raise NotImplementedError
+
+      # Bring the page tab to the foreground (headed mode only).
+      def activate = raise NotImplementedError
+
+      # Close the underlying page/tab.
+      def close = raise NotImplementedError
+
+      # Subscribe to a page event (currently only `:dialog`).
+      # @return [Object] a subscription id usable with {#off}
+      def on(event, &) = raise NotImplementedError
+
+      # Remove a subscription created by {#on}.
+      def off(event, id) = raise NotImplementedError
+
+      # Press a key down. Pair with {#keyboard_up}.
+      def keyboard_down(key) = raise NotImplementedError
+
+      # Release a key.
+      def keyboard_up(key) = raise NotImplementedError
+
+      # Move the mouse pointer to viewport coordinates.
+      def mouse_move(x:, y:) = raise NotImplementedError # rubocop:disable Naming/MethodParameterName
+
+      # @return [Hash{String => Object}] all cookies for the page, keyed by
+      #   cookie name, with each value responding to `to_h`.
+      def cookies_all = raise NotImplementedError
+
+      # Set a cookie. Accepts `name:`, `value:`, `domain:`, `path:`, and any
+      # of `httponly:`, `secure:`, `expires:`.
+      def cookies_set(**) = raise NotImplementedError
+
+      # Clear every cookie on the page.
+      def cookies_clear = raise NotImplementedError
+
+      # Underlying CDP target id; used by the devtools handler. Backends that
+      # do not expose CDP should raise.
+      def target_id = raise NotImplementedError
+    end
+  end
+end

--- a/lib/browserctl/server/handlers/cookies.rb
+++ b/lib/browserctl/server/handlers/cookies.rb
@@ -10,7 +10,7 @@ module Browserctl
           session = @global_mutex.synchronize { @pages[req[:name]] }
           return { error: "no page named '#{req[:name]}'" } unless session
 
-          all = session.page.cookies.all
+          all = session.driver.cookies_all
           { ok: true, cookies: all.values.map(&:to_h) }
         end
 
@@ -18,7 +18,7 @@ module Browserctl
           session = @global_mutex.synchronize { @pages[req[:name]] }
           return { error: "no page named '#{req[:name]}'" } unless session
 
-          session.page.cookies.set(
+          session.driver.cookies_set(
             name: req[:cookie_name],
             value: req[:value],
             domain: req[:domain],
@@ -31,14 +31,14 @@ module Browserctl
           session = @global_mutex.synchronize { @pages[req[:name]] }
           return { error: "no page named '#{req[:name]}'" } unless session
 
-          session.page.cookies.clear
+          session.driver.cookies_clear
           { ok: true }
         end
 
         def cmd_import_cookies(req)
           with_page(req[:name]) do |session|
             req[:cookies].each do |c|
-              session.page.cookies.set(
+              session.driver.cookies_set(
                 name: c[:name],
                 value: c[:value],
                 domain: c[:domain],

--- a/lib/browserctl/server/handlers/devtools.rb
+++ b/lib/browserctl/server/handlers/devtools.rb
@@ -12,7 +12,7 @@ module Browserctl
           session = @global_mutex.synchronize { @pages[req[:name]] }
           return { error: "no page named '#{req[:name]}'" } unless session
 
-          info      = @driver.devtools_info(session.page)
+          info      = @driver.devtools_info(session.driver)
           port      = info[:port]
           target_id = info[:target_id]
           devtools_url = "http://127.0.0.1:#{port}/devtools/inspector.html" \

--- a/lib/browserctl/server/handlers/interaction.rb
+++ b/lib/browserctl/server/handlers/interaction.rb
@@ -8,8 +8,8 @@ module Browserctl
 
         def cmd_press(req)
           with_page(req[:name]) do |session|
-            session.page.keyboard.down(req[:key])
-            session.page.keyboard.up(req[:key])
+            session.driver.keyboard_down(req[:key])
+            session.driver.keyboard_up(req[:key])
             { ok: true }
           end
         end
@@ -19,7 +19,7 @@ module Browserctl
             sel = resolve_selector_from(session, req)
             return sel if sel.is_a?(Hash)
 
-            coords = session.page.evaluate(
+            coords = session.driver.evaluate(
               "(function(sel) {   " \
               "var el = document.querySelector(sel);   " \
               "if (!el) return null;   " \
@@ -35,7 +35,7 @@ module Browserctl
               )
             end
 
-            session.page.mouse.move(x: coords["x"], y: coords["y"])
+            session.driver.mouse_move(x: coords["x"], y: coords["y"])
             { ok: true }
           end
         end
@@ -48,7 +48,7 @@ module Browserctl
             sel = resolve_selector_from(session, req)
             return sel if sel.is_a?(Hash)
 
-            el = session.page.at_css(sel)
+            el = session.driver.at_css(sel)
             unless el
               return error_payload(
                 code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
@@ -67,7 +67,7 @@ module Browserctl
             sel = resolve_selector_from(session, req)
             return sel if sel.is_a?(Hash)
 
-            el = session.page.at_css(sel)
+            el = session.driver.at_css(sel)
             unless el
               return error_payload(
                 code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
@@ -88,8 +88,8 @@ module Browserctl
           with_page(req[:name]) do |session|
             text = req[:text]
             id   = nil
-            id = session.page.on(:dialog) do |dialog|
-              session.page.off(:dialog, id)
+            id = session.driver.on(:dialog) do |dialog|
+              session.driver.off(:dialog, id)
               dialog.accept(text)
             end
             { ok: true }
@@ -99,8 +99,8 @@ module Browserctl
         def cmd_dialog_dismiss(req)
           with_page(req[:name]) do |session|
             id = nil
-            id = session.page.on(:dialog) do |dialog|
-              session.page.off(:dialog, id)
+            id = session.driver.on(:dialog) do |dialog|
+              session.driver.off(:dialog, id)
               dialog.dismiss
             end
             { ok: true }

--- a/lib/browserctl/server/handlers/navigation.rb
+++ b/lib/browserctl/server/handlers/navigation.rb
@@ -19,20 +19,20 @@ module Browserctl
           end
 
           with_page(req[:name]) do |session|
-            session.page.go_to(req[:url])
-            { ok: true, url: session.page.current_url, challenge: Detectors.cloudflare?(session.page) }
+            session.driver.go_to(req[:url])
+            { ok: true, url: session.driver.current_url, challenge: Detectors.cloudflare?(session.driver) }
           end
         end
 
         def cmd_wait(req)
           with_page(req[:name]) do |session|
-            result = wait_for_selector(session.page, req[:selector], req.fetch(:timeout, 30).to_f)
+            result = wait_for_selector(session.driver, req[:selector], req.fetch(:timeout, 30).to_f)
             result[:error] ? result : { ok: true, selector: req[:selector] }
           end
         end
 
         def cmd_evaluate(req)
-          with_page(req[:name]) { |session| { ok: true, result: session.page.evaluate(req[:expression]) } }
+          with_page(req[:name]) { |session| { ok: true, result: session.driver.evaluate(req[:expression]) } }
         end
 
         def cmd_fill(req)
@@ -40,7 +40,7 @@ module Browserctl
             sel = resolve_selector_from(session, req)
             return sel if sel.is_a?(Hash)
 
-            result = type_into(session.page, sel, req[:value])
+            result = type_into(session.driver, sel, req[:value])
             enrich_with_recording_metadata(result, session, sel, req)
           end
         end
@@ -50,7 +50,7 @@ module Browserctl
             sel = resolve_selector_from(session, req)
             return sel if sel.is_a?(Hash)
 
-            result = click_element(session.page, sel)
+            result = click_element(session.driver, sel)
             enrich_with_recording_metadata(result, session, sel, req)
           end
         end
@@ -69,14 +69,14 @@ module Browserctl
             ref: ref,
             fingerprint: fp,
             snapshot_id: session.snapshot_id,
-            postcondition_hint: { url: session.page.current_url }
+            postcondition_hint: { url: session.driver.current_url }
           )
           enriched[:post_snapshot_digest] = capture_post_snapshot_digest(session) if req[:capture_post_snapshot]
           enriched.compact
         end
 
         def capture_post_snapshot_digest(session)
-          snapshot = @snapshot_builder.call(session.page)
+          snapshot = @snapshot_builder.call(session.driver)
           Browserctl::Replay::SnapshotDiff.digest(snapshot)
         rescue JSON::ParserError, Timeout::Error, Browserctl::Error => e
           Browserctl.logger.debug("post-snapshot digest skipped: #{e.class}: #{e.message}")
@@ -84,11 +84,11 @@ module Browserctl
         end
 
         def cmd_url(req)
-          with_page(req[:name]) { |session| { ok: true, url: session.page.current_url } }
+          with_page(req[:name]) { |session| { ok: true, url: session.driver.current_url } }
         end
 
-        def type_into(page, selector, value)
-          el = page.at_css(selector)
+        def type_into(driver, selector, value)
+          el = driver.at_css(selector)
           unless el
             return error_payload(
               code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
@@ -103,8 +103,8 @@ module Browserctl
           { ok: true }
         end
 
-        def click_element(page, selector)
-          el = page.at_css(selector)
+        def click_element(driver, selector)
+          el = driver.at_css(selector)
           unless el
             return error_payload(
               code: Browserctl::Error::Codes::SELECTOR_NOT_FOUND,
@@ -127,10 +127,10 @@ module Browserctl
           session.ref_registry[req[:ref]] || { error: "ref '#{req[:ref]}' not found — run snap first" }
         end
 
-        def wait_for_selector(page, selector, timeout)
+        def wait_for_selector(driver, selector, timeout)
           deadline = Time.now + timeout
           loop do
-            found = page.at_css(selector)
+            found = driver.at_css(selector)
             break { ok: true } if found
             break { error: "wait timeout: selector '#{selector}' not found after #{timeout}s" } if Time.now >= deadline
 

--- a/lib/browserctl/server/handlers/observation.rb
+++ b/lib/browserctl/server/handlers/observation.rb
@@ -19,9 +19,9 @@ module Browserctl
         # bundle in hand (see PR 18); without them, only the URL signal fires.
         def cmd_auth_check(req)
           with_page(req[:name]) do |session|
-            cookies = session.page.cookies.all.values.map(&:to_h) if req[:include_cookies]
+            cookies = session.driver.cookies_all.values.map(&:to_h) if req[:include_cookies]
             result = Browserctl::Detectors.auth_required(
-              session.page,
+              session.driver,
               cookies: cookies,
               suggested_flow: req[:suggested_flow]
             )
@@ -38,11 +38,11 @@ module Browserctl
 
         def take_snapshot(session, format, diff)
           nonce     = SecureRandom.hex(8)
-          challenge = Detectors.cloudflare?(session.page)
+          challenge = Detectors.cloudflare?(session.driver)
 
-          return { ok: true, html: session.page.body, challenge: challenge, nonce: nonce } unless format == "elements"
+          return { ok: true, html: session.driver.body, challenge: challenge, nonce: nonce } unless format == "elements"
 
-          snapshot = @snapshot_builder.call(session.page)
+          snapshot = @snapshot_builder.call(session.driver)
           registry = snapshot.to_h { |el| [el[:ref], el[:selector]] }
           fp_index = build_fingerprint_index(snapshot)
 
@@ -84,7 +84,7 @@ module Browserctl
             return path if path.is_a?(Hash)
 
             FileUtils.mkdir_p(File.dirname(path))
-            session.page.screenshot(path: path, full: req.fetch(:full, false))
+            session.driver.screenshot(path: path, full: req.fetch(:full, false))
             { ok: true, path: path }
           end
         end

--- a/lib/browserctl/server/handlers/page_lifecycle.rb
+++ b/lib/browserctl/server/handlers/page_lifecycle.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../../driver/ferrum_page_driver"
+
 module Browserctl
   class CommandDispatcher
     module Handlers
@@ -8,15 +10,15 @@ module Browserctl
 
         def cmd_page_open(req)
           session = @global_mutex.synchronize do
-            @pages[req[:name]] ||= PageSession.new(@driver.create_page)
+            @pages[req[:name]] ||= PageSession.new(Browserctl::Driver::FerrumPageDriver.new(@driver.create_page))
           end
-          session.page.go_to(req[:url]) if req[:url]
+          session.driver.go_to(req[:url]) if req[:url]
           { ok: true, name: req[:name] }
         end
 
         def cmd_page_close(req)
           session = @global_mutex.synchronize { @pages.delete(req[:name]) }
-          session&.page&.close
+          session&.driver&.close
           { ok: true }
         end
 
@@ -28,7 +30,7 @@ module Browserctl
           return { error: "page focus requires headed mode — start browserd with --headed" } unless @driver.headed?
 
           with_page(req[:name]) do |session|
-            session.page.activate
+            session.driver.activate
             { ok: true }
           end
         end

--- a/lib/browserctl/server/handlers/state.rb
+++ b/lib/browserctl/server/handlers/state.rb
@@ -47,7 +47,7 @@ module Browserctl
 
           unless req[:skip_auth_check]
             auth = Browserctl::Detectors.auth_required(
-              target.page, cookies: cookies, suggested_flow: data[:manifest][:flow]
+              target.driver, cookies: cookies, suggested_flow: data[:manifest][:flow]
             )
             if auth.triggered
               return Browserctl::AuthRequiredError.new(
@@ -79,7 +79,7 @@ module Browserctl
         def restore_state_cookies(target, cookies)
           cookies.each do |raw|
             c = raw.transform_keys(&:to_sym)
-            target.page.cookies.set(**c.slice(:name, :value, :domain, :path))
+            target.driver.cookies_set(**c.slice(:name, :value, :domain, :path))
           end
         end
 
@@ -102,7 +102,7 @@ module Browserctl
 
         def capture_state_payload
           first = @global_mutex.synchronize { @pages.values.first }
-          cookies = first.page.cookies.all.values.map(&:to_h)
+          cookies = first.driver.cookies_all.values.map(&:to_h)
 
           local_storage   = {}
           session_storage = {}
@@ -110,9 +110,9 @@ module Browserctl
 
           @global_mutex.synchronize { @pages.dup }.each_value do |session|
             session.mutex.synchronize do
-              origin    = session.page.evaluate("location.origin")
-              ls_str    = session.page.evaluate("JSON.stringify({...localStorage})") || "{}"
-              ss_str    = session.page.evaluate("JSON.stringify({...sessionStorage})") || "{}"
+              origin    = session.driver.evaluate("location.origin")
+              ls_str    = session.driver.evaluate("JSON.stringify({...localStorage})") || "{}"
+              ss_str    = session.driver.evaluate("JSON.stringify({...sessionStorage})") || "{}"
               local_storage[origin]   = JSON.parse(ls_str)
               session_storage[origin] = JSON.parse(ss_str)
               captured_origins << origin

--- a/lib/browserctl/server/handlers/storage.rb
+++ b/lib/browserctl/server/handlers/storage.rb
@@ -13,7 +13,7 @@ module Browserctl
             js    = storage_js_get(store, req[:key])
             return { error: "unknown store '#{store}' — use 'local' or 'session'" } unless js
 
-            value = session.page.evaluate(js)
+            value = session.driver.evaluate(js)
             { ok: true, value: value }
           end
         end
@@ -25,7 +25,7 @@ module Browserctl
             js    = storage_js_set(store, req[:key], req[:value])
             return { error: "unknown store '#{store}' — use 'local' or 'session'" } unless js
 
-            session.page.evaluate(js)
+            session.driver.evaluate(js)
             { ok: true }
           end
         end
@@ -37,16 +37,16 @@ module Browserctl
             stores  = req.fetch(:stores, "all")
             data    = {}
 
-            origin = session.page.evaluate("location.origin")
+            origin = session.driver.evaluate("location.origin")
             data[origin] = {}
 
             if %w[local all].include?(stores)
-              local = JSON.parse(session.page.evaluate("JSON.stringify({...localStorage})") || "{}")
+              local = JSON.parse(session.driver.evaluate("JSON.stringify({...localStorage})") || "{}")
               data[origin].merge!(local)
             end
 
             if %w[session all].include?(stores)
-              sess = JSON.parse(session.page.evaluate("JSON.stringify({...sessionStorage})") || "{}")
+              sess = JSON.parse(session.driver.evaluate("JSON.stringify({...sessionStorage})") || "{}")
               data[origin].merge!(sess)
             end
 
@@ -71,7 +71,7 @@ module Browserctl
             key_count = 0
             data.each_value do |keys|
               keys.each do |k, v|
-                session.page.evaluate("localStorage.setItem(#{k.to_json}, #{v.to_json})")
+                session.driver.evaluate("localStorage.setItem(#{k.to_json}, #{v.to_json})")
                 key_count += 1
               end
             end
@@ -84,8 +84,8 @@ module Browserctl
         def cmd_storage_delete(req)
           with_page(req[:name]) do |session|
             stores = req.fetch(:stores, "all")
-            session.page.evaluate("localStorage.clear()")   if %w[local all].include?(stores)
-            session.page.evaluate("sessionStorage.clear()") if %w[session all].include?(stores)
+            session.driver.evaluate("localStorage.clear()")   if %w[local all].include?(stores)
+            session.driver.evaluate("sessionStorage.clear()") if %w[session all].include?(stores)
             { ok: true }
           end
         end

--- a/lib/browserctl/server/page_session.rb
+++ b/lib/browserctl/server/page_session.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
+require_relative "../driver/ferrum_page_driver"
+
 module Browserctl
   class PageSession
-    attr_reader :page, :mutex, :pause_cv
+    attr_reader :driver, :mutex, :pause_cv
     attr_accessor :ref_registry, :prev_snapshot, :fingerprint_index, :snapshot_id
 
-    def initialize(page)
-      @page              = page
+    # @param page_or_driver [Browserctl::Driver::PageDriver, Object] either a
+    #   PageDriver (preferred) or a raw Ferrum/CDP page (auto-wrapped in
+    #   {Browserctl::Driver::FerrumPageDriver} for back-compat with callers
+    #   that still construct sessions from a raw page).
+    def initialize(page_or_driver)
+      @driver = if page_or_driver.is_a?(Browserctl::Driver::PageDriver)
+                  page_or_driver
+                else
+                  Browserctl::Driver::FerrumPageDriver.new(page_or_driver)
+                end
       @mutex             = Mutex.new
       @pause_cv          = ConditionVariable.new
       @ref_registry      = {}
@@ -14,6 +24,14 @@ module Browserctl
       @snapshot_id       = nil
       @prev_snapshot     = nil
       @paused            = false
+    end
+
+    # Back-compat accessor. New handler code calls {#driver} directly; this
+    # returns the underlying Ferrum/CDP page for legacy callers (the CDP
+    # driver's `devtools_info`, the page-lifecycle close path, and a unit
+    # spec).
+    def page
+      @driver.respond_to?(:raw_page) ? @driver.raw_page : @driver
     end
 
     def paused? = @paused

--- a/spec/public_surface_spec.rb
+++ b/spec/public_surface_spec.rb
@@ -243,7 +243,8 @@ RSpec.describe "public surface lock-file" do
         ctx.pages["main"] = Browserctl::PageSession.new(page)
         allow(ctx.driver).to receive(:supports?).with(:devtools).and_return(true)
         info = { port: 9222, target_id: "ABC" }
-        allow(ctx.driver).to receive(:devtools_info).with(page).and_return(info)
+        allow(ctx.driver).to receive(:devtools_info)
+        .with(an_instance_of(Browserctl::Driver::FerrumPageDriver)).and_return(info)
         { cmd: "devtools", name: "main" }
       end,
       "ping" => lambda do |_ctx|

--- a/spec/support/fake_page_driver.rb
+++ b/spec/support/fake_page_driver.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "browserctl/driver/page_driver"
+
+module Browserctl
+  module Testing
+    # In-memory test double for {Browserctl::Driver::PageDriver}. Stateful
+    # enough to let handlers exercise their full happy path without spawning
+    # a browser. Pair with {FakeElement} for `at_css` calls.
+    #
+    # Each call is recorded on `#calls` so specs can assert against the
+    # interaction trace. Use `stub_evaluate` to register canned return values
+    # for `evaluate(expression)`, and `register_element(selector, element)` to
+    # wire up specific selector → element mappings.
+    class FakePageDriver
+      include Browserctl::Driver::PageDriver
+
+      attr_reader :calls, :cookies_store
+      attr_accessor :current_url, :body, :target_id
+
+      def initialize(current_url: "https://example.com/", body: "<html></html>")
+        @current_url   = current_url
+        @body          = body
+        @target_id     = "fake-target-id"
+        @calls         = []
+        @evaluate_stubs = {}
+        @evaluate_default = nil
+        @elements      = {}
+        @cookies_store = {}
+        @event_subs    = Hash.new { |h, k| h[k] = {} }
+        @next_sub_id   = 0
+      end
+
+      # --- evaluate stubbing ---
+
+      def stub_evaluate(expression, result)
+        @evaluate_stubs[expression] = result
+      end
+
+      def stub_evaluate_default(result)
+        @evaluate_default = result
+      end
+
+      # --- element registration ---
+
+      def register_element(selector, element)
+        @elements[selector] = element
+      end
+
+      # --- PageDriver interface ---
+
+      def go_to(url)
+        record(:go_to, url)
+        @current_url = url
+      end
+
+      def evaluate(expression)
+        record(:evaluate, expression)
+        return @evaluate_stubs[expression] if @evaluate_stubs.key?(expression)
+
+        @evaluate_default
+      end
+
+      def at_css(selector)
+        record(:at_css, selector)
+        @elements[selector]
+      end
+
+      def screenshot(path:, full: false)
+        record(:screenshot, path, full)
+        :screenshot_taken
+      end
+
+      def activate
+        record(:activate)
+      end
+
+      def close
+        record(:close)
+      end
+
+      def on(event, &block)
+        id = (@next_sub_id += 1)
+        @event_subs[event][id] = block
+        record(:on, event, id)
+        id
+      end
+
+      def off(event, id)
+        record(:off, event, id)
+        @event_subs[event].delete(id)
+      end
+
+      def keyboard_down(key)
+        record(:keyboard_down, key)
+      end
+
+      def keyboard_up(key)
+        record(:keyboard_up, key)
+      end
+
+      def mouse_move(x:, y:) # rubocop:disable Naming/MethodParameterName
+        record(:mouse_move, x, y)
+      end
+
+      def cookies_all
+        @cookies_store
+      end
+
+      def cookies_set(**opts)
+        name = opts[:name]
+        @cookies_store[name] = FakeCookie.new(opts)
+        record(:cookies_set, opts)
+      end
+
+      def cookies_clear
+        record(:cookies_clear)
+        @cookies_store.clear
+      end
+
+      # --- helpers ---
+
+      # Trigger every registered handler for an event with a fake dialog/etc.
+      def emit(event, payload)
+        @event_subs[event].each_value { |blk| blk.call(payload) }
+      end
+
+      def calls_for(method_name)
+        @calls.select { |c| c.first == method_name }
+      end
+
+      private
+
+      def record(method, *args)
+        @calls << [method, *args]
+      end
+
+      # Cookie struct that responds to `to_h` like Ferrum's cookies do.
+      class FakeCookie
+        def initialize(attrs)
+          @attrs = attrs.dup
+        end
+
+        def to_h = @attrs.dup
+      end
+    end
+
+    # Minimal element double that handlers exercise via `at_css(...)`.
+    # Records every method invocation on `#calls`.
+    class FakeElement
+      attr_reader :calls
+
+      def initialize
+        @calls = []
+      end
+
+      def focus           = @calls << [:focus]
+      def type(value)     = @calls << [:type, value]
+      def click           = @calls << [:click]
+      def evaluate(expr)  = (@calls << [:evaluate, expr]) && nil
+      def select_file(path) = @calls << [:select_file, path]
+    end
+  end
+end

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -425,7 +425,8 @@ RSpec.describe Browserctl::CommandDispatcher do
 
     it "returns a devtools_url for a known page when driver supports devtools" do
       allow(driver).to receive(:supports?).with(:devtools).and_return(true)
-      allow(driver).to receive(:devtools_info).with(page).and_return({ port: 9222, target_id: "ABCD1234" })
+      allow(driver).to receive(:devtools_info).with(an_instance_of(Browserctl::Driver::FerrumPageDriver))
+                                              .and_return({ port: 9222, target_id: "ABCD1234" })
       res = dispatcher.dispatch({ cmd: "devtools", name: "main" })
       expect(res[:ok]).to be true
       expect(res[:devtools_url]).to include("9222")

--- a/spec/unit/handlers/cookies_spec.rb
+++ b/spec/unit/handlers/cookies_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/server/command_dispatcher"
+require "browserctl/server/page_session"
+require "support/fake_page_driver"
+
+# Unit-level coverage for the Cookies handler family. No browser; the driver
+# is a {Browserctl::Testing::FakePageDriver}.
+RSpec.describe Browserctl::CommandDispatcher::Handlers::Cookies do
+  let(:fake_driver) { Browserctl::Testing::FakePageDriver.new }
+  let(:session)     { Browserctl::PageSession.new(fake_driver) }
+  let(:pages)       { { "main" => session } }
+  let(:capability_driver) { double("driver") }
+  subject(:dispatcher) { Browserctl::CommandDispatcher.new(pages, capability_driver) }
+
+  describe "cookies (list)" do
+    it "returns the driver's cookies as an array of hashes" do
+      fake_driver.cookies_set(name: "sid", value: "abc", domain: ".example.com", path: "/")
+      res = dispatcher.dispatch({ cmd: "cookies", name: "main" })
+      expect(res[:ok]).to be true
+      expect(res[:cookies].first).to include(name: "sid", value: "abc")
+    end
+
+    it "errors for unknown page" do
+      res = dispatcher.dispatch({ cmd: "cookies", name: "ghost" })
+      expect(res[:error]).to match(/no page named 'ghost'/)
+    end
+  end
+
+  describe "set_cookie" do
+    it "forwards name, value, domain, path to the driver" do
+      res = dispatcher.dispatch(
+        cmd: "set_cookie", name: "main",
+        cookie_name: "sid", value: "abc", domain: ".x.com", path: "/api"
+      )
+      expect(res).to eq({ ok: true })
+      call = fake_driver.calls_for(:cookies_set).first
+      expect(call[1]).to include(name: "sid", value: "abc", domain: ".x.com", path: "/api")
+    end
+
+    it "defaults path to '/' when omitted" do
+      dispatcher.dispatch(
+        cmd: "set_cookie", name: "main",
+        cookie_name: "sid", value: "abc", domain: ".x.com"
+      )
+      expect(fake_driver.calls_for(:cookies_set).first[1][:path]).to eq("/")
+    end
+  end
+
+  describe "delete_cookies" do
+    it "calls cookies_clear" do
+      fake_driver.cookies_set(name: "sid", value: "abc")
+      res = dispatcher.dispatch({ cmd: "delete_cookies", name: "main" })
+      expect(res).to eq({ ok: true })
+      expect(fake_driver.calls_for(:cookies_clear)).not_to be_empty
+      expect(fake_driver.cookies_all).to be_empty
+    end
+  end
+
+  describe "import_cookies" do
+    it "applies each cookie via cookies_set and reports the count" do
+      cookies = [
+        { name: "a", value: "1", domain: ".x.com" },
+        { name: "b", value: "2", domain: ".x.com", path: "/api", secure: true }
+      ]
+      res = dispatcher.dispatch({ cmd: "import_cookies", name: "main", cookies: cookies })
+      expect(res).to eq({ ok: true, count: 2 })
+      expect(fake_driver.calls_for(:cookies_set).length).to eq(2)
+    end
+  end
+end

--- a/spec/unit/handlers/interaction_spec.rb
+++ b/spec/unit/handlers/interaction_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/server/command_dispatcher"
+require "browserctl/server/page_session"
+require "support/fake_page_driver"
+
+# Unit-level coverage for the Interaction handler family. Drives every command
+# through a {Browserctl::Testing::FakePageDriver} — no Chrome, no Ferrum.
+RSpec.describe Browserctl::CommandDispatcher::Handlers::Interaction do
+  let(:fake_driver)  { Browserctl::Testing::FakePageDriver.new }
+  let(:session)      { Browserctl::PageSession.new(fake_driver) }
+  let(:pages)        { { "main" => session } }
+  let(:capability_driver) { double("driver") }
+  subject(:dispatcher) { Browserctl::CommandDispatcher.new(pages, capability_driver) }
+
+  describe "press" do
+    it "calls keyboard_down + keyboard_up via the driver" do
+      res = dispatcher.dispatch({ cmd: "press", name: "main", key: "Enter" })
+      expect(res).to eq({ ok: true })
+      expect(fake_driver.calls_for(:keyboard_down)).to eq([[:keyboard_down, "Enter"]])
+      expect(fake_driver.calls_for(:keyboard_up)).to eq([[:keyboard_up, "Enter"]])
+    end
+  end
+
+  describe "hover" do
+    it "evaluates selector geometry then moves the mouse" do
+      fake_driver.stub_evaluate_default({ "x" => 10, "y" => 20 })
+      res = dispatcher.dispatch({ cmd: "hover", name: "main", selector: "#go" })
+      expect(res).to eq({ ok: true })
+      expect(fake_driver.calls_for(:mouse_move)).to eq([[:mouse_move, 10, 20]])
+    end
+
+    it "returns SELECTOR_NOT_FOUND when geometry probe returns nil" do
+      fake_driver.stub_evaluate_default(nil)
+      res = dispatcher.dispatch({ cmd: "hover", name: "main", selector: "#ghost" })
+      expect(res[:code]).to eq(Browserctl::Error::Codes::SELECTOR_NOT_FOUND)
+    end
+  end
+
+  describe "select" do
+    it "evaluates a value-assignment script on the matched element" do
+      el = Browserctl::Testing::FakeElement.new
+      fake_driver.register_element("#choice", el)
+      res = dispatcher.dispatch({ cmd: "select", name: "main", selector: "#choice", value: "B" })
+      expect(res).to eq({ ok: true })
+      expect(el.calls.first.first).to eq(:evaluate)
+      expect(el.calls.first[1]).to include("dispatchEvent")
+    end
+
+    it "returns SELECTOR_NOT_FOUND when at_css returns nil" do
+      res = dispatcher.dispatch({ cmd: "select", name: "main", selector: "#ghost", value: "A" })
+      expect(res[:code]).to eq(Browserctl::Error::Codes::SELECTOR_NOT_FOUND)
+    end
+  end
+
+  describe "dialog_accept" do
+    it "subscribes to :dialog and unsubscribes inside the callback" do
+      dispatcher.dispatch({ cmd: "dialog_accept", name: "main", text: "ok" })
+      dialog = double("dialog")
+      expect(dialog).to receive(:accept).with("ok")
+      fake_driver.emit(:dialog, dialog)
+      # Subscription is removed inside the callback
+      expect(fake_driver.calls_for(:off)).not_to be_empty
+    end
+  end
+end

--- a/spec/unit/handlers/observation_spec.rb
+++ b/spec/unit/handlers/observation_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "browserctl/server/command_dispatcher"
+require "browserctl/server/page_session"
+require "support/fake_page_driver"
+
+# Unit-level coverage for the Observation handler family. No Chrome, no Ferrum
+# — every page interaction routes through {Browserctl::Testing::FakePageDriver}.
+RSpec.describe Browserctl::CommandDispatcher::Handlers::Observation do
+  let(:fake_driver) { Browserctl::Testing::FakePageDriver.new(body: "<html></html>") }
+  let(:session)     { Browserctl::PageSession.new(fake_driver) }
+  let(:pages)       { { "main" => session } }
+  let(:capability_driver) { double("driver") }
+  subject(:dispatcher) { Browserctl::CommandDispatcher.new(pages, capability_driver) }
+
+  describe "snapshot (html format)" do
+    it "returns the body and a nonce" do
+      res = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
+      expect(res[:ok]).to be true
+      expect(res[:html]).to eq("<html></html>")
+      expect(res[:nonce]).to be_a(String)
+    end
+
+    it "produces a fresh nonce each call" do
+      r1 = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
+      r2 = dispatcher.dispatch({ cmd: "snapshot", name: "main", format: "html" })
+      expect(r1[:nonce]).not_to eq(r2[:nonce])
+    end
+  end
+
+  describe "auth_check" do
+    it "returns auth_required: false when no detector fires" do
+      fake_driver.current_url = "https://example.com/dashboard"
+      res = dispatcher.dispatch({ cmd: "auth_check", name: "main" })
+      expect(res).to eq({ ok: true, auth_required: false })
+    end
+
+    it "returns an AUTH_REQUIRED payload when URL matches a login path" do
+      fake_driver.current_url = "https://example.com/login"
+      res = dispatcher.dispatch({ cmd: "auth_check", name: "main" })
+      expect(res[:code]).to eq("AUTH_REQUIRED")
+    end
+  end
+
+  describe "screenshot" do
+    it "passes path: and full: through to the driver" do
+      Dir.mktmpdir do |tmp|
+        path = File.join(tmp, "shot.png")
+        # Allow the screenshot directory pre-check by routing under SCREENSHOT_DIR
+        # — bypass safety check by stubbing the path validator via default dir.
+        allow_any_instance_of(Browserctl::CommandDispatcher)
+          .to receive(:safe_screenshot_path).and_return(path)
+        res = dispatcher.dispatch({ cmd: "screenshot", name: "main", path: path })
+        expect(res[:ok]).to be true
+        expect(fake_driver.calls_for(:screenshot)).to eq([[:screenshot, path, false]])
+      end
+    end
+  end
+end

--- a/spec/unit/handlers_navigation_spec.rb
+++ b/spec/unit/handlers_navigation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Browserctl::CommandDispatcher::Handlers::Navigation do
     end
   end
 
-  let(:session) { instance_double("Browserctl::PageSession", page: :fake_page) }
+  let(:session) { instance_double("Browserctl::PageSession", driver: :fake_driver) }
 
   context "expected exceptions are swallowed and logged at debug" do
     [
@@ -29,7 +29,7 @@ RSpec.describe Browserctl::CommandDispatcher::Handlers::Navigation do
       Browserctl::Error.new("typed failure")
     ].each do |err|
       it "returns nil and logs at debug when snapshot raises #{err.class}" do
-        builder = ->(_page) { raise err }
+        builder = ->(_driver) { raise err }
         harness = harness_class.new(builder)
         debug_messages = []
         allow(Browserctl).to receive(:logger).and_return(
@@ -45,7 +45,7 @@ RSpec.describe Browserctl::CommandDispatcher::Handlers::Navigation do
   end
 
   it "propagates unexpected exceptions (rescue is no longer too wide)" do
-    builder = ->(_page) { raise "unexpected" }
+    builder = ->(_driver) { raise "unexpected" }
     harness = harness_class.new(builder)
 
     expect { harness.capture_post_snapshot_digest(session) }
@@ -53,7 +53,7 @@ RSpec.describe Browserctl::CommandDispatcher::Handlers::Navigation do
   end
 
   it "propagates ArgumentError (proves StandardError-wide rescue is gone)" do
-    builder = ->(_page) { raise ArgumentError, "bad arg" }
+    builder = ->(_driver) { raise ArgumentError, "bad arg" }
     harness = harness_class.new(builder)
 
     expect { harness.capture_post_snapshot_digest(session) }


### PR DESCRIPTION
## Summary

Extracts a `PageDriver` interface from `PageSession` so handlers can be unit-tested without a real Chrome. Every handler in `lib/browserctl/server/handlers/` now calls `session.driver.<method>` instead of poking at `session.page.<x>` directly. The interface is **Extension zone** — the seam is for testability, NOT an invitation to ship a non-Ferrum backend before 1.0 (per `docs/plans/v0.15-lock.md` non-goals).

## Interface (`Browserctl::Driver::PageDriver`)

Methods every handler may call:

- `go_to(url)`, `current_url`, `body`, `evaluate(expression)`
- `at_css(selector)` (returns a duck-typed element handle)
- `screenshot(path:, full:)`, `activate`, `close`
- `on(event, &)`, `off(event, id)`
- `keyboard_down(key)`, `keyboard_up(key)`
- `mouse_move(x:, y:)`
- `cookies_all`, `cookies_set(**)`, `cookies_clear`
- `target_id` (CDP — used by the devtools handler)

`FerrumPageDriver` (`lib/browserctl/driver/ferrum_page_driver.rb`) is the only implementation v0.15 ships. It's a dumb forwarder over a Ferrum/CDP page.

## Handler families converted

All ten handler files under `lib/browserctl/server/handlers/`:

- `cookies.rb`, `daemon_control.rb` (no page calls — untouched), `devtools.rb`, `error_payload.rb` (n/a), `hitl.rb` (no page calls — untouched), `interaction.rb`, `navigation.rb`, `observation.rb`, `page_lifecycle.rb`, `state.rb`, `storage.rb`

`grep -rn "session.page\." lib/` now returns nothing.

## Test double + new unit specs

- `spec/support/fake_page_driver.rb` — `Browserctl::Testing::FakePageDriver`, stateful in-memory double + `FakeElement` for `at_css` returns. Records every call for assertions.
- `spec/unit/handlers/interaction_spec.rb`, `observation_spec.rb`, `cookies_spec.rb` — 17 examples, runs in ~12ms with no Chrome.

## Test plan

- [x] `bundle exec rspec spec/unit/handlers/` — 17 examples, 0 failures, ~0.012s
- [x] `bundle exec rspec` — 1029 examples, 0 failures, 57 pending (Chrome-skip, pre-existing)
- [x] `bundle exec rubocop` — 241 files, no offenses
- [x] `grep -rn "session.page\." lib/` returns empty
- [x] Public-surface lock-file still passes (no boundary moved)
- [x] `docs/reference/api-stability.md` lists `Browserctl::Driver::PageDriver` under Extension