### PR TITLE
refactor: drop session.page back-compat shim (v0.16 WS-2 PR 2)

### DIFF
--- a/lib/browserctl/driver/ferrum_page_driver.rb
+++ b/lib/browserctl/driver/ferrum_page_driver.rb
@@ -12,11 +12,6 @@ module Browserctl
     class FerrumPageDriver
       include PageDriver
 
-      # @return [Object] the underlying Ferrum/CDP page. Exposed for callers
-      #   that still bridge through Ferrum-typed APIs (currently only the CDP
-      #   driver's `devtools_info`). New handler code must not use this.
-      attr_reader :raw_page
-
       def initialize(page)
         @raw_page = page
       end

--- a/lib/browserctl/server/page_session.rb
+++ b/lib/browserctl/server/page_session.rb
@@ -1,22 +1,18 @@
 # frozen_string_literal: true
 
-require_relative "../driver/ferrum_page_driver"
+require_relative "../driver/page_driver"
 
 module Browserctl
   class PageSession
     attr_reader :driver, :mutex, :pause_cv
     attr_accessor :ref_registry, :prev_snapshot, :fingerprint_index, :snapshot_id
 
-    # @param page_or_driver [Browserctl::Driver::PageDriver, Object] either a
-    #   PageDriver (preferred) or a raw Ferrum/CDP page (auto-wrapped in
-    #   {Browserctl::Driver::FerrumPageDriver} for back-compat with callers
-    #   that still construct sessions from a raw page).
-    def initialize(page_or_driver)
-      @driver = if page_or_driver.is_a?(Browserctl::Driver::PageDriver)
-                  page_or_driver
-                else
-                  Browserctl::Driver::FerrumPageDriver.new(page_or_driver)
-                end
+    # @param driver [Browserctl::Driver::PageDriver] a PageDriver
+    #   implementation (or any duck-typed equivalent in tests). Raw Ferrum
+    #   pages are no longer accepted — wrap with
+    #   {Browserctl::Driver::FerrumPageDriver} at the call site.
+    def initialize(driver)
+      @driver            = driver
       @mutex             = Mutex.new
       @pause_cv          = ConditionVariable.new
       @ref_registry      = {}
@@ -24,14 +20,6 @@ module Browserctl
       @snapshot_id       = nil
       @prev_snapshot     = nil
       @paused            = false
-    end
-
-    # Back-compat accessor. New handler code calls {#driver} directly; this
-    # returns the underlying Ferrum/CDP page for legacy callers (the CDP
-    # driver's `devtools_info`, the page-lifecycle close path, and a unit
-    # spec).
-    def page
-      @driver.respond_to?(:raw_page) ? @driver.raw_page : @driver
     end
 
     def paused? = @paused

--- a/spec/public_surface_spec.rb
+++ b/spec/public_surface_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe "public surface lock-file" do
       end,
       "devtools" => lambda do |ctx|
         page = instance_double("Ferrum::Page")
-        ctx.pages["main"] = Browserctl::PageSession.new(page)
+        ctx.pages["main"] = Browserctl::PageSession.new(Browserctl::Driver::FerrumPageDriver.new(page))
         allow(ctx.driver).to receive(:supports?).with(:devtools).and_return(true)
         info = { port: 9222, target_id: "ABC" }
         allow(ctx.driver).to receive(:devtools_info)
@@ -222,7 +222,7 @@ RSpec.describe "public surface lock-file" do
       "press" => lambda do |ctx|
         keyboard = double("keyboard", down: nil, up: nil)
         page = instance_double("Ferrum::Page", keyboard: keyboard)
-        ctx.pages["main"] = Browserctl::PageSession.new(page)
+        ctx.pages["main"] = Browserctl::PageSession.new(Browserctl::Driver::FerrumPageDriver.new(page))
         { cmd: "press", name: "main", key: "Enter" }
       end,
       "hover" => lambda do |ctx|
@@ -230,7 +230,7 @@ RSpec.describe "public surface lock-file" do
         page  = instance_double("Ferrum::Page",
                                 evaluate: { "x" => 1.0, "y" => 1.0 },
                                 mouse: mouse)
-        ctx.pages["main"] = Browserctl::PageSession.new(page)
+        ctx.pages["main"] = Browserctl::PageSession.new(Browserctl::Driver::FerrumPageDriver.new(page))
         { cmd: "hover", name: "main", selector: "button" }
       end,
       "upload" => lambda do |ctx|

--- a/spec/unit/command_dispatcher_spec.rb
+++ b/spec/unit/command_dispatcher_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "browserctl/server/command_dispatcher"
 require "browserctl/server/snapshot_builder"
 require "browserctl/server/page_session"
+require "browserctl/driver/ferrum_page_driver"
 
 RSpec.describe Browserctl::CommandDispatcher do
   let(:driver)     { double("driver") }
@@ -38,7 +39,7 @@ RSpec.describe Browserctl::CommandDispatcher do
       result = dispatcher.dispatch({ cmd: "page_open", name: "home" })
       expect(result).to eq({ ok: true, name: "home" })
       expect(pages["home"]).to be_a(Browserctl::PageSession)
-      expect(pages["home"].page).to eq(page)
+      expect(pages["home"].driver).to be_a(Browserctl::Driver::FerrumPageDriver)
     end
 
     it "page_open navigates to url when given" do
@@ -420,7 +421,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   describe "#cmd_devtools" do
     let(:driver) { double("driver") }
     let(:page)   { instance_double("Ferrum::Page") }
-    let(:pages)  { { "main" => Browserctl::PageSession.new(page) } }
+    let(:pages)  { { "main" => Browserctl::PageSession.new(Browserctl::Driver::FerrumPageDriver.new(page)) } }
     subject(:dispatcher) { described_class.new(pages, driver) }
 
     it "returns a devtools_url for a known page when driver supports devtools" do
@@ -449,7 +450,7 @@ RSpec.describe Browserctl::CommandDispatcher do
   describe "store / fetch commands" do
     let(:driver)  { double("driver") }
     let(:page)    { instance_double("Ferrum::Page") }
-    let(:pages)   { { "main" => Browserctl::PageSession.new(page) } }
+    let(:pages)   { { "main" => Browserctl::PageSession.new(Browserctl::Driver::FerrumPageDriver.new(page)) } }
     subject(:dispatcher) { described_class.new(pages, driver) }
 
     describe "behaviour" do

--- a/spec/unit/interaction_spec.rb
+++ b/spec/unit/interaction_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "browserctl/server/command_dispatcher"
 require "browserctl/server/snapshot_builder"
 require "browserctl/server/page_session"
+require "browserctl/driver/ferrum_page_driver"
 
 RSpec.describe "interaction handlers" do
   let(:browser)    { double("browser") }
@@ -11,7 +12,7 @@ RSpec.describe "interaction handlers" do
   subject(:dispatcher) { Browserctl::CommandDispatcher.new(pages, browser, Browserctl::SnapshotBuilder.new) }
 
   def make_page(page_double)
-    pages["p"] = Browserctl::PageSession.new(page_double)
+    pages["p"] = Browserctl::PageSession.new(Browserctl::Driver::FerrumPageDriver.new(page_double))
   end
 
   describe "press" do

--- a/spec/unit/page_session_spec.rb
+++ b/spec/unit/page_session_spec.rb
@@ -2,13 +2,14 @@
 
 require "spec_helper"
 require "browserctl/server/page_session"
+require "support/fake_page_driver"
 
 RSpec.describe Browserctl::PageSession do
-  let(:page) { double("Ferrum::Page") }
-  subject(:session) { described_class.new(page) }
+  let(:driver) { Browserctl::Testing::FakePageDriver.new }
+  subject(:session) { described_class.new(driver) }
 
-  it "holds the page" do
-    expect(session.page).to eq(page)
+  it "holds the driver" do
+    expect(session.driver).to eq(driver)
   end
 
   it "starts with an empty ref_registry" do
@@ -35,7 +36,7 @@ RSpec.describe Browserctl::PageSession do
   end
 
   it "has a separate mutex per instance" do
-    other = described_class.new(double("page2"))
+    other = described_class.new(Browserctl::Testing::FakePageDriver.new)
     expect(session.mutex).not_to equal(other.mutex)
   end
 
@@ -60,7 +61,7 @@ RSpec.describe Browserctl::PageSession do
     end
 
     it "has a separate pause_cv per instance" do
-      other = described_class.new(double("page2"))
+      other = described_class.new(Browserctl::Testing::FakePageDriver.new)
       expect(session.pause_cv).not_to equal(other.pause_cv)
     end
   end


### PR DESCRIPTION
## Summary

Drops the `PageSession#page` accessor and the dual-mode constructor introduced in v0.15 WS-3 PR 8.

### Shim lifecycle

- **v0.15 WS-3 PR 8** extracted a `PageDriver` interface. To avoid rewriting `spec/unit/page_session_spec.rb` in the same PR, the agent kept `session.page` as a back-compat shim returning `driver.raw_page`, and let `PageSession.new` accept either a raw Ferrum page or a `PageDriver`.
- **v0.16 WS-2 PR 2** (this PR) retires the shim now that the spec is rewritten against `session.driver`.

### Changes

- `PageSession#initialize` accepts a `PageDriver` (or duck-typed equivalent) only — the `is_a?(PageDriver)` auto-wrap branch is gone.
- `PageSession#page` accessor deleted.
- `FerrumPageDriver#raw_page` reader deleted — grep confirmed no caller depended on it beyond the shim. The CDP driver's `devtools_info` uses `page_driver.target_id`, not the raw Ferrum page.
- `spec/unit/page_session_spec.rb` rewritten against `session.driver` using the `FakePageDriver` from `spec/support/fake_page_driver.rb`.
- Sibling unit specs (`command_dispatcher_spec`, `interaction_spec`, `public_surface_spec`) that previously relied on the auto-wrap now wrap their raw Ferrum doubles in `FerrumPageDriver` at the call site.

## Test plan

- [x] `bundle exec rspec` — 1074 examples, 0 failures, 77 pending (chrome-required integration specs, unchanged)
- [x] `bundle exec rubocop` — 252 files, no offenses
- [x] `grep -rn "session\.page\b\|\.raw_page\b" lib/ spec/` returns no hits