### PR TITLE
chore: drop --store local|session wire short-forms (v0.16 WS-2 PR 3)

### DIFF
--- a/docs/architecture/decisions/0021-data-verb-consolidation.md
+++ b/docs/architecture/decisions/0021-data-verb-consolidation.md
@@ -36,6 +36,8 @@ Every `data` operation requires `--scope {cookies|localStorage|sessionStorage}`.
 
 The scope names match the browser-platform names (`localStorage`, `sessionStorage`) rather than the current short forms (`local`, `session`) because the long forms are unambiguous to first-touch users and to AI agents that have read MDN. The short forms are accepted as aliases on the wire for v0.15 only, deprecated alongside the old verbs.
 
+> **Update (v0.16):** the short-form scope aliases (`local`, `session`) were v0.15-only as stated above and have been removed in v0.16. The long-form `localStorage` / `sessionStorage` are the only accepted scope values; passing `local` or `session` now returns `INVALID_ARGUMENT` with a hint pointing at the long form.
+
 ### Deprecation path
 
 `cookie *` and `storage *` ship in v0.15 as alias dispatchers that:

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -187,7 +187,7 @@ for the design.
 | Client: `Client#cookies`, `#set_cookie`, `#delete_cookies`, `#import_cookies`, `#export_cookies` | `Client#data_get`, `#data_set`, `#data_delete`, `#data_list` | Removed in v0.16. |
 | Client: `Client#storage_get`, `#storage_set`, `#storage_export`, `#storage_import`, `#storage_delete` | same as above | |
 | CLI: `cookie <op>` | `data <op> --scope cookies` | `cookie` CLI verb removed in v0.16. |
-| CLI: `storage <op>` | `data <op> --scope localStorage\|sessionStorage` | `storage` CLI verb removed in v0.16; `--store local\|session` short forms accepted on the wire as v0.15-only aliases. |
+| CLI: `storage <op>` | `data <op> --scope localStorage\|sessionStorage` | `storage` CLI verb removed in v0.16. The `--store local\|session` short forms were v0.15-only wire aliases and were removed in v0.16. |
 
 Removal timeline:
 

--- a/lib/browserctl/server/handlers/data.rb
+++ b/lib/browserctl/server/handlers/data.rb
@@ -15,6 +15,11 @@ module Browserctl
       module Data
         VALID_SCOPES = %w[cookies localStorage sessionStorage].freeze
 
+        # Short-form scope aliases. Were accepted as v0.15-only wire aliases
+        # per ADR-0021; removed in v0.16. Kept here only to produce a helpful
+        # hint in the INVALID_ARGUMENT envelope.
+        SHORT_FORM_HINTS = { "local" => "localStorage", "session" => "sessionStorage" }.freeze
+
         private
 
         # @return [Hash] unified response with `ok`, `scope`, plus per-op fields
@@ -115,17 +120,17 @@ module Browserctl
           return invalid_scope_error(raw) if raw.nil?
 
           scope = raw.to_s
-          # Accept short forms as v0.15-only wire aliases (per ADR-0021).
-          scope = "localStorage"   if scope == "local"
-          scope = "sessionStorage" if scope == "session"
           return invalid_scope_error(raw) unless VALID_SCOPES.include?(scope)
 
           scope
         end
 
         def invalid_scope_error(raw)
+          hint = SHORT_FORM_HINTS[raw.to_s]
+          message = "invalid --scope '#{raw}' — expected one of: #{VALID_SCOPES.join(', ')}"
+          message += " (short form '#{raw}' was removed in v0.16 — use '#{hint}')" if hint
           {
-            error: "invalid --scope '#{raw}' — expected one of: #{VALID_SCOPES.join(', ')}",
+            error: message,
             code: Browserctl::Error::Codes::INVALID_ARGUMENT
           }
         end

--- a/spec/unit/handlers/data_spec.rb
+++ b/spec/unit/handlers/data_spec.rb
@@ -26,17 +26,16 @@ RSpec.describe Browserctl::CommandDispatcher::Handlers::Data do
       expect(res[:code]).to eq("INVALID_ARGUMENT")
     end
 
-    it "accepts 'local' as a wire alias for 'localStorage'" do
-      fake_driver.stub_evaluate("localStorage.getItem(\"k\")", "v")
+    it "rejects the v0.15 short form 'local' with a hint pointing at 'localStorage'" do
       res = dispatcher.dispatch(cmd: "data_get", name: "main", key: "k", scope: "local")
-      expect(res[:ok]).to be true
-      expect(res[:scope]).to eq("localStorage")
+      expect(res[:code]).to eq("INVALID_ARGUMENT")
+      expect(res[:error]).to match(/localStorage/)
     end
 
-    it "accepts 'session' as a wire alias for 'sessionStorage'" do
-      fake_driver.stub_evaluate("sessionStorage.getItem(\"k\")", "v")
+    it "rejects the v0.15 short form 'session' with a hint pointing at 'sessionStorage'" do
       res = dispatcher.dispatch(cmd: "data_get", name: "main", key: "k", scope: "session")
-      expect(res[:scope]).to eq("sessionStorage")
+      expect(res[:code]).to eq("INVALID_ARGUMENT")
+      expect(res[:error]).to match(/sessionStorage/)
     end
   end
 


### PR DESCRIPTION
## Summary

Removes the v0.15-only `local` / `session` short-form scope aliases from the `data` wire verb. The long-form `localStorage` / `sessionStorage` are now the only accepted scope values.

ADR-0021 explicitly described these short forms as "accepted as aliases on the wire for v0.15 only, deprecated alongside the old verbs." This PR is just executing on that.

## Changes

- `lib/browserctl/server/handlers/data.rb` — `validate_scope` no longer expands `local`/`session`. Invalid values now return `INVALID_ARGUMENT`; if the caller passed a known v0.15 short form, the error message includes a hint pointing at the canonical long form.
- `spec/unit/handlers/data_spec.rb` — the two "accepts short form" specs become negative tests asserting `INVALID_ARGUMENT` with a hint mentioning the long form.
- `docs/architecture/decisions/0021-data-verb-consolidation.md` — one-line v0.16 update note under the scope-naming paragraph. History preserved.
- `docs/reference/api-stability.md` — migration table footnote updated: the short forms were v0.15-only and were removed in v0.16.

## Test plan

- [x] `bundle exec rspec` — 1074 examples, 0 failures, 77 pending (browser-required, expected on this machine).
- [x] `bundle exec rubocop` — clean, 252 files inspected, no offenses.
- [x] Wire request with `scope: "local"` returns `INVALID_ARGUMENT` with hint mentioning `localStorage` (covered by new unit test).
- [x] All long-form scope tests still pass.