### PR TITLE
chore: resolve or rename TODOs in recording/trace (v0.16 WS-3 PR 4)

### DIFF
--- a/lib/browserctl/recording.rb
+++ b/lib/browserctl/recording.rb
@@ -80,7 +80,7 @@ module Browserctl
       return unless ref_count.positive?
 
       warn "Warning: #{ref_count} ref-based interaction(s) were captured but cannot be replayed by ref."
-      warn "Search the generated workflow for 'TODO: ref-based' and replace with stable CSS selectors."
+      warn "Search the generated workflow for 'REVIEW: ref-based' and replace with stable CSS selectors."
     end
 
     class << self

--- a/lib/browserctl/recording/workflow_renderer.rb
+++ b/lib/browserctl/recording/workflow_renderer.rb
@@ -151,7 +151,7 @@ module Browserctl
       def secret_header(secrets)
         return "" if secrets.empty?
 
-        lines = ["# TODO: review the following secret-shaped fields detected during recording.",
+        lines = ["# REVIEW: the following secret-shaped fields were detected during recording.",
                  "# Configure a secret_ref: source for each before running:"]
         secrets.each { |f| lines << "#   - secret_#{f}" }
         "\n#{lines.join("\n")}\n"
@@ -163,7 +163,7 @@ module Browserctl
         if body.nil?
           page_sym = cmd[:name].to_s.gsub(/[^a-zA-Z0-9_]/, "_")
           action   = cmd[:action].to_s.gsub(/[^a-z_]/, "")
-          return "# TODO: ref-based #{action} on #{cmd[:name].inspect} (ref: #{cmd[:ref].inspect}) — " \
+          return "# REVIEW: ref-based #{action} on #{cmd[:name].inspect} (ref: #{cmd[:ref].inspect}) — " \
                  "replace with a stable CSS selector\n" \
                  "# step #{label.inspect} do\n" \
                  "#   page(:#{page_sym}).#{action}(\"YOUR_SELECTOR_HERE\")\n" \
@@ -194,7 +194,7 @@ module Browserctl
       end
 
       def ref_interaction_parts(cmd)
-        ["TODO: ref-based #{cmd[:action]} on #{cmd[:name]} (ref: #{cmd[:ref]})", nil]
+        ["REVIEW: ref-based #{cmd[:action]} on #{cmd[:name]} (ref: #{cmd[:ref]})", nil]
       end
 
       def selector_parts(cmd)

--- a/lib/browserctl/trace/event_stream.rb
+++ b/lib/browserctl/trace/event_stream.rb
@@ -58,7 +58,9 @@ module Browserctl
       # Session resolution. When session_id is stamped on records (future PR),
       # filter/select by it. Otherwise, treat the entire merged stream as one
       # session — caller can scope by tailing/rotating logs.
-      # TODO: stamp session_id on every log line so this scopes correctly.
+      # See: https://github.com/patrick204nqh/browserctl/issues/212 — until
+      # session_id is stamped on every log line by the writer, this is the
+      # best-effort heuristic.
       def filter_session(rows)
         if @session_filter
           rows.select { |r| r["session_id"].to_s == @session_filter }

--- a/spec/unit/recording/workflow_renderer_spec.rb
+++ b/spec/unit/recording/workflow_renderer_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Browserctl::Recording::WorkflowRenderer do
       expect(ruby).to include("page(:login).fill(\"input[name=password]\", params[:secret_password])")
     end
 
-    it "emits a TODO when a ref-interaction is present (no replayable selector)" do
+    it "emits a REVIEW marker when a ref-interaction is present (no replayable selector)" do
       cmds = [{ cmd: "_ref_interaction", name: "p", action: "click", ref: "abc123" }]
       ruby = described_class.render("ex", cmds)
-      expect(ruby).to include("TODO: ref-based click")
+      expect(ruby).to include("REVIEW: ref-based click")
     end
   end
 

--- a/spec/unit/recording_spec.rb
+++ b/spec/unit/recording_spec.rb
@@ -161,11 +161,11 @@ RSpec.describe Browserctl::Recording do
       expect(entry).not_to have_key("secret_hint")
     end
 
-    it "emits secret_ref params and TODO header in the generated workflow" do
+    it "emits secret_ref params and REVIEW header in the generated workflow" do
       described_class.append("fill", name: "login", selector: 'input[name="api_key"]', value: "k")
       described_class.append("fill", name: "login", selector: 'input[type="password"]', value: "p")
       ruby = described_class.generate_workflow("gen", keep_log: true)
-      expect(ruby).to include("# TODO: review the following secret-shaped fields")
+      expect(ruby).to include("# REVIEW: the following secret-shaped fields")
       expect(ruby).to include("#   - secret_api_key")
       expect(ruby).to include("#   - secret_password")
       expect(ruby).to include("param :secret_api_key, secret: true")


### PR DESCRIPTION
Part of v0.16 WS-3. Audits the five `# TODO` markers in `lib/` and either renames them (when they were user-facing instructions emitted into generated files, not engineering TODOs) or files an issue (when implementation is out of scope for a cleanup PR).

## TODOs touched

| Location | Decision | Notes |
| --- | --- | --- |
| `lib/browserctl/recording.rb:83` | Renamed | Warning text now points users at `'REVIEW: ref-based'` instead of `'TODO: ref-based'`. |
| `lib/browserctl/recording/workflow_renderer.rb:154` | Renamed | Secret-shaped field header in generated workflows now uses `# REVIEW:` marker. |
| `lib/browserctl/recording/workflow_renderer.rb:166` | Renamed | Ref-based step fallback comment in generated workflows now uses `# REVIEW: ref-based` marker. |
| `lib/browserctl/recording/workflow_renderer.rb:197` | Renamed | Ref-interaction step label now uses `REVIEW: ref-based` marker. |
| `lib/browserctl/trace/event_stream.rb:61` | Issue filed (#212) | Implementing requires plumbing session_id through the daemon logger boundary, out of scope for a v0.16 cleanup PR. Comment now links the issue. |

## Spec updates

- `spec/unit/recording_spec.rb` — assertion on secret-field header marker updated.
- `spec/unit/recording/workflow_renderer_spec.rb` — assertion on ref-interaction label updated.

## Verification

- `grep -rn "TODO\|FIXME\|XXX\|HACK" lib/` returns zero lines.
- `bundle exec rspec` — 1074 examples, 0 failures, 77 pending (chrome-gated integration specs only).
- `bundle exec rubocop` on touched files — no offenses.

## Rationale for the rename

The three `TODO: ref-based ...` strings in `workflow_renderer.rb` aren't engineering TODOs — they are user-facing instructions that get written into generated workflow files when a recorded interaction was ref-based and therefore can't be replayed without a stable selector. Keeping the `TODO:` prefix polluted `grep TODO lib/` with strings whose target audience was the recorder's user, not the maintainer. The `REVIEW:` prefix preserves the instruction without overloading the standard TODO marker.